### PR TITLE
Add support for EZMESURE_ES_PWD to the API

### DIFF
--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -7,7 +7,9 @@
   },
   "elasticsearch": {
     "port": "EZMESURE_ELASTIC_PORT",
-    "host": "EZMESURE_ELASTIC_HOST"
+    "host": "EZMESURE_ELASTIC_HOST",
+    "user": "EZMESURE_ELASTIC_USER",
+    "password": "EZMESURE_ES_PWD"
   },
   "auth": {
     "secret": "EZMESURE_AUTH_SECRET",

--- a/api/config/default.json
+++ b/api/config/default.json
@@ -8,7 +8,9 @@
   "elasticsearch": {
     "port": 9200,
     "host": "localhost",
-    "indicePrefix": "ez_"
+    "indicePrefix": "ez_",
+    "user": "elastic",
+    "password": "changeme"
   },
   "logs": {
     "app": { "Console": { "timestamp": true, "colorize": true } },

--- a/api/src/lib/services/elastic.js
+++ b/api/src/lib/services/elastic.js
@@ -4,7 +4,7 @@ import template from '../utils/index-template';
 
 const elastic = new elasticsearch.Client({
   host: `${config.get('elasticsearch.host')}:${config.get('elasticsearch.port')}`,
-  httpAuth: 'elastic:changeme'
+  httpAuth: `${config.get('elasticsearch.user')}:${config.get('elasticsearch.password')}`
 });
 
 elastic.indices.putTemplate({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - https_proxy
       - EZMESURE_ELASTIC_HOST=elastic
       - EZMESURE_MONGO_HOST=mongodb
+      - EZMESURE_ES_PWD
       - EZMESURE_AUTH_SECRET
       - NODE_ENV
     links:


### PR DESCRIPTION
This PR adds the elastic user/pass to the config and forward the associated environment vars in the docker-compose file.