### PR TITLE
better SEO

### DIFF
--- a/front/components/AppBar.vue
+++ b/front/components/AppBar.vue
@@ -1,7 +1,7 @@
 <template>
   <v-toolbar app fixed dark>
     <v-toolbar-title>
-      ezMESURE
+      ezMESURE - Plateforme des tableaux de bord ezPAARSE de l’ESR
     </v-toolbar-title>
     <v-spacer/>
     <v-toolbar-items class="hidden-xs-only">

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -3,11 +3,11 @@ module.exports = {
   ** Headers of the page
   */
   head: {
-    title: 'ezmesure-front',
+    title: 'ezMESURE - Plateforme des tableaux de bord ezPAARSE de l’ESR',
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { hid: 'description', name: 'description', content: 'ezmesure front' }
+      { hid: 'description', name: 'description', content: 'ezMESURE est un entrepôt centralisant au niveau national les statistiques d’usage de la documentation scientifique numérique des établissements de l’enseignement supérieur et de la recherche (ESR). ezMESURE aggrege les données produites par les installations ezPAARSE des établissements de l’ESR.' }
     ],
     link: [
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },


### PR DESCRIPTION
because our google page rank is so bad:
ezmesure.couperin.org is not the first result when searching "ezmesure" in google
and our title and the small text (description) is bad, see:
![image](https://user-images.githubusercontent.com/328244/39064372-95ef7a8a-44ce-11e8-8714-025350c8fa32.png)
