### PR TITLE
fix(front): Fixed warnings about deprecated options

### DIFF
--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -68,7 +68,7 @@ module.exports = {
       fallbackLocale: 'en',
     },
   },
-  devModules: [
+  buildModules: [
     '@nuxtjs/auth',
     ['@nuxtjs/vuetify', { optionsPath: './vuetify.options.js' }],
   ],

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18816,9 +18816,9 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
     "node_modules/vuetify": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.14.tgz",
-      "integrity": "sha512-nr6wU3uTzhhEPssH23cW0Ee/hCrayp7cjl3nNjM2OmNwiJlV91tZiL1VO3597SqZyjh1xIa+m9J2rpKTSdIlrA==",
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.15.tgz",
+      "integrity": "sha512-2a6sBSHzivXgi9pZMyHuzTgMyInCkj/BrVwTnoCa1Y/Dnfwj7lkWzgKQDScbGVK0q4vJ+YHoBBrLOmnhz1R0YA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/johnleider"
@@ -34250,9 +34250,9 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw=="
     },
     "vuetify": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.14.tgz",
-      "integrity": "sha512-nr6wU3uTzhhEPssH23cW0Ee/hCrayp7cjl3nNjM2OmNwiJlV91tZiL1VO3597SqZyjh1xIa+m9J2rpKTSdIlrA==",
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.6.15.tgz",
+      "integrity": "sha512-2a6sBSHzivXgi9pZMyHuzTgMyInCkj/BrVwTnoCa1Y/Dnfwj7lkWzgKQDScbGVK0q4vJ+YHoBBrLOmnhz1R0YA==",
       "requires": {}
     },
     "vuetify-loader": {


### PR DESCRIPTION
- Upgraded [Vuetify to 2.6.15 (from 2.6.14)](https://github.com/vuetifyjs/vuetify/releases/tag/v2.6.15)
- Renamed `devModules` to `buildModules` in nuxt config