### PR TITLE
feat: partners from db instead of elastic

### DIFF
--- a/api/lib/controllers/openapi.json
+++ b/api/lib/controllers/openapi.json
@@ -246,22 +246,44 @@
           },
           "social": {
             "description": "Social links of the institution",
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "properties": {
-              "twitterUrl": { "type": "string" },
-              "linkedinUrl": { "type": "string" },
-              "youtubeUrl": { "type": "string" },
-              "facebookUrl": { "type": "string" }
+              "twitterUrl": {
+                "type": "string"
+              },
+              "linkedinUrl": {
+                "type": "string"
+              },
+              "youtubeUrl": {
+                "type": "string"
+              },
+              "facebookUrl": {
+                "type": "string"
+              }
             }
           },
           "auto": {
             "description": "Automated services of the institution",
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "properties": {
-              "ezpaarse": { "type": "boolean" },
-              "ezmesure": { "type": "boolean" },
-              "report": { "type": "boolean" },
-              "sushi": { "type": "boolean" }
+              "ezpaarse": {
+                "type": "boolean"
+              },
+              "ezmesure": {
+                "type": "boolean"
+              },
+              "report": {
+                "type": "boolean"
+              },
+              "sushi": {
+                "type": "boolean"
+              }
             }
           },
           "sushiReadySince": {
@@ -434,15 +456,23 @@
           "institution": {
             "description": "The institution associated to this space",
             "allOf": [
-              { "$ref": "#/components/schemas/Institution" },
-              { "readOnly": true }
+              {
+                "$ref": "#/components/schemas/Institution"
+              },
+              {
+                "readOnly": true
+              }
             ]
           },
           "institutionId": {
             "description": "ID of the institution associated to this space",
             "allOf": [
-              { "$ref": "#/components/schemas/ItemID" },
-              { "readOnly": false }
+              {
+                "$ref": "#/components/schemas/ItemID"
+              },
+              {
+                "readOnly": false
+              }
             ]
           },
           "type": {
@@ -485,15 +515,23 @@
           "user": {
             "description": "The user associated to this permission",
             "allOf": [
-              { "$ref": "#/components/schemas/User" },
-              { "readOnly": true }
+              {
+                "$ref": "#/components/schemas/User"
+              },
+              {
+                "readOnly": true
+              }
             ]
           },
           "space": {
             "description": "The space associated to this permission",
             "allOf": [
-              { "$ref": "#/components/schemas/Space" },
-              { "readOnly": true }
+              {
+                "$ref": "#/components/schemas/Space"
+              },
+              {
+                "readOnly": true
+              }
             ]
           },
           "readonly": {
@@ -787,7 +825,7 @@
             "type": "array",
             "readOnly": true,
             "items": {
-              "type" : "object",
+              "type": "object",
               "properties": {
                 "code": {
                   "description": "The exception code",
@@ -4144,7 +4182,102 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/Institution"
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "acronym": {
+                        "type": "string"
+                      },
+                      "social": {
+                        "type": "object",
+                        "properties": {
+                          "twitterUrl": {
+                            "type": "string"
+                          },
+                          "youtubeUrl": {
+                            "type": "string"
+                          },
+                          "facebookUrl": {
+                            "type": "string"
+                          },
+                          "linkedinUrl": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "servicesEnabled": {
+                        "type": "object",
+                        "properties": {
+                          "ezpaarse": {
+                            "type": "boolean"
+                          },
+                          "ezcounter": {
+                            "type": "boolean"
+                          },
+                          "ezreeport": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "contacts": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "fullName": {
+                              "type": "string"
+                            },
+                            "roles": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "x-examples": {
+                    "Example 1": [
+                      {
+                        "name": "Centre national de la recherche scientifique",
+                        "acronym": "CNRS",
+                        "social": {
+                          "twitterUrl": "",
+                          "youtubeUrl": "",
+                          "facebookUrl": "",
+                          "linkedinUrl": ""
+                        },
+                        "servicesEnabled": {
+                          "ezpaarse": true,
+                          "ezcounter": true,
+                          "ezreeport": true
+                        },
+                        "contacts": [
+                          {
+                            "fullName": "Tom SUBLET",
+                            "roles": [
+                              "contact:tech"
+                            ]
+                          },
+                          {
+                            "fullName": "ezMESURE Administrator",
+                            "roles": [
+                              "contact:doc"
+                            ]
+                          },
+                          {
+                            "fullName": "Yannick SCHURTER",
+                            "roles": [
+                              "contact:tech"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   }
                 }
               }
@@ -4553,10 +4686,14 @@
             "application/json": {
               "schema": {
                 "allOf": [
-                  { "$ref": "#/components/schemas/Repository" },
+                  {
+                    "$ref": "#/components/schemas/Repository"
+                  },
                   {
                     "properties": {
-                      "institutionId": { "readOnly": false }
+                      "institutionId": {
+                        "readOnly": false
+                      }
                     }
                   }
                 ]
@@ -5721,7 +5858,7 @@
       }
     },
     "/sushi/batch_delete": {
-    "post": {
+      "post": {
         "summary": "Delete multiple Sushi items",
         "operationId": "post-sushi-batch_delete",
         "responses": {
@@ -6358,7 +6495,10 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "asc"
             }
           }
@@ -7273,7 +7413,9 @@
                 "type": "array",
                 "items": {
                   "allOf": [
-                    { "$ref": "#/components/schemas/User" },
+                    {
+                      "$ref": "#/components/schemas/User"
+                    },
                     {
                       "type": "object",
                       "properties": {
@@ -7287,7 +7429,6 @@
                         }
                       }
                     }
-
                   ]
                 }
               }

--- a/api/lib/controllers/partners/actions.js
+++ b/api/lib/controllers/partners/actions.js
@@ -1,6 +1,96 @@
-const Institution = require('../../models/Institution');
+const institutionService = require('../../entities/institutions.service');
+
+const ezrAxios = require('../../services/ezreeport/axios');
+const { appLogger } = require('../../services/logger');
+
+/**
+ * Checks if institution is using ezREEPORT
+ *
+ * @param {string} institution Institution id
+ *
+ * @returns Is the institution have an enabled report in ezREEPORT
+ */
+const isInstitutionHaveReport = async (institution) => {
+  let found = false;
+
+  try {
+    const { data } = await ezrAxios.get(`/admin/namespaces/${institution}`);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const task of (data.content?.tasks ?? [])) {
+      if (task.enabled) {
+        found = true;
+        break;
+      }
+    }
+  } catch (error) {
+    appLogger.warn(`Couldn't get reports of [${institution}]: ${error}`);
+  }
+
+  return found;
+};
 
 exports.list = async (ctx) => {
+  const partners = await institutionService.findMany({
+    where: {
+      validated: true,
+      hidePartner: false,
+    },
+    include: {
+      memberships: {
+        // search for doc/tech contacts
+        where: {
+          roles: {
+            hasSome: ['contact:doc', 'contact:tech'],
+          },
+        },
+        include: {
+          user: true,
+        },
+      },
+      spaces: true,
+    },
+  });
+
   ctx.type = 'json';
-  ctx.body = await Institution.findAllValidated();
+  ctx.body = await Promise.all(
+    partners.map(
+      async (i) => {
+        const servicesEnabled = {
+          ezpaarse: false,
+          ezcounter: false,
+          ezreeport: false,
+        };
+
+        // search for ezpaarse & counter5 spaces
+        // eslint-disable-next-line no-restricted-syntax
+        for (const { type } of i.spaces) {
+          if (servicesEnabled.ezcounter && servicesEnabled.ezpaarse) {
+            break;
+          }
+
+          servicesEnabled.ezpaarse = servicesEnabled.ezpaarse || type === 'ezpaarse';
+          servicesEnabled.ezcounter = servicesEnabled.ezcounter || type === 'counter5';
+        }
+
+        // search for enabled ezreeport
+        servicesEnabled.ezreeport = await isInstitutionHaveReport(i.id);
+
+        // mapping contacts
+        const contacts = i.memberships.map(
+          (m) => ({
+            fullName: m.user.fullName,
+            roles: m.roles,
+          }),
+        );
+
+        return {
+          name: i.name,
+          acronym: i.acronym,
+          social: i.social,
+          servicesEnabled,
+          contacts,
+        };
+      },
+    ),
+  );
 };

--- a/api/lib/controllers/partners/index.js
+++ b/api/lib/controllers/partners/index.js
@@ -1,7 +1,6 @@
 const router = require('koa-joi-router')();
 const { list } = require('./actions');
 
-
 router.get('/', list);
 
 module.exports = router;

--- a/front/components/PartnerCard.vue
+++ b/front/components/PartnerCard.vue
@@ -21,14 +21,14 @@
       </div>
     </v-card-text>
 
-    <v-divider />
+    <template v-if="hasContacts">
+      <v-divider />
 
-    <v-card-text class="text-center">
-      <div class="subtitle-1">
-        {{ $t('partners.correspondents') }}
-      </div>
+      <v-card-text class="text-center">
+        <div class="subtitle-1">
+          {{ $t('partners.correspondents') }}
+        </div>
 
-      <template v-if="hasContacts">
         <div v-for="contact in contacts" :key="contact.name">
           <v-tooltip right>
             <template #activator="{ on }">
@@ -43,23 +43,15 @@
             <span>{{ contact.label }}</span>
           </v-tooltip>
         </div>
-      </template>
+      </v-card-text>
+    </template>
 
-      <div v-else class="font-italic">
-        {{ $t('partners.noContacts') }}
-      </div>
-    </v-card-text>
+    <template v-if="hasServices">
+      <v-divider />
 
-    <v-divider />
-
-    <v-card-text class="text-center">
-      <div class="subtitle-1">
-        {{ $t('partners.automated') }}
-      </div>
-
-      <template v-if="hasAutomation">
+      <v-card-text class="text-center">
         <v-chip
-          v-for="auto in automations"
+          v-for="auto in servicesEnabled"
           :key="auto.label"
           :color="auto.color"
           small
@@ -69,21 +61,13 @@
         >
           {{ $t(`partners.auto.${auto.label}`) }}
         </v-chip>
-      </template>
+      </v-card-text>
+    </template>
 
-      <div v-else class="font-italic">
-        {{ $t('partners.noAutomations') }}
-      </div>
-    </v-card-text>
+    <template v-if="hasLinks">
+      <v-divider />
 
-    <v-divider />
-
-    <v-card-text class="text-center">
-      <div class="subtitle-1">
-        {{ $t('partners.links') }}
-      </div>
-
-      <template v-if="hasLinks">
+      <v-card-text class="text-center">
         <v-btn
           v-for="link in links"
           :key="link.icon"
@@ -93,12 +77,8 @@
         >
           <v-icon>{{ link.icon }}</v-icon>
         </v-btn>
-      </template>
-
-      <div v-else class="font-italic">
-        {{ $t('partners.noLinks') }}
-      </div>
-    </v-card-text>
+      </v-card-text>
+    </template>
   </v-card>
 </template>
 
@@ -121,62 +101,88 @@ export default {
       return this.contacts.length > 0;
     },
     contacts() {
-      const doc = this.partner?.docContactName;
-      const tech = this.partner?.techContactName;
-      const contacts = [];
-
-      if (doc) {
-        contacts.push({
-          name: doc,
-          type: 'doc',
-          icon: 'mdi-book',
-          color: 'green',
-          label: this.$t('partners.documentary'),
-        });
-      }
-      if (tech) {
-        contacts.push({
-          name: tech,
-          type: 'tech',
-          icon: 'mdi-wrench',
-          color: 'blue',
-          label: this.$t('partners.technical'),
-        });
+      if (!this.partnerName) {
+        return [];
       }
 
-      return contacts;
+      return this.partner.contacts
+        .map(
+          (user) => {
+            const roles = new Set(user.roles);
+
+            if (roles.has('contact:doc')) {
+              return {
+                name: user.fullName,
+                type: 'doc',
+                icon: 'mdi-book',
+                color: 'green',
+                label: this.$t('partners.documentary'),
+              };
+            }
+
+            if (roles.has('contact:tech')) {
+              return {
+                name: user.fullName,
+                type: 'tech',
+                icon: 'mdi-wrench',
+                color: 'blue',
+                label: this.$t('partners.technical'),
+              };
+            }
+
+            return {
+              name: user.fullName,
+              type: 'unknown',
+              icon: 'mdi-mdi',
+              color: 'grey',
+              label: '????',
+            };
+          },
+        )
+        .sort(
+          ({ type }) => (type === 'doc' ? -1 : 1),
+        );
     },
-    automations() {
+    servicesEnabled() {
+      const servicesEnabled = this.partner?.servicesEnabled;
+      if (!servicesEnabled) {
+        return [];
+      }
+
       return [
-        { label: 'ezpaarse', color: 'teal', automated: this.partner?.auto?.ezpaarse },
-        { label: 'ezmesure', color: 'purple', automated: this.partner?.auto?.ezmesure },
-        { label: 'report', color: 'blue', automated: this.partner?.auto?.report },
-        { label: 'sushi', color: 'red', automated: this.partner?.auto?.sushi },
+        { label: 'ezpaarse', color: 'teal', automated: servicesEnabled.ezpaarse },
+        { label: 'ezreeport', color: 'blue', automated: servicesEnabled.ezreeport },
+        { label: 'ezcounter', color: 'red', automated: servicesEnabled.ezcounter },
       ].filter((auto) => auto.automated);
     },
-    hasAutomation() {
-      return this.automations.length > 0;
+    hasServices() {
+      return this.servicesEnabled.length > 0;
     },
     hasLinks() {
       return this.links.length > 0;
     },
     links() {
+      const social = this.partner?.social;
+      if (!social) {
+        return [];
+      }
+
       const links = [];
 
-      if (this.partner?.website) {
-        links.push({ icon: 'mdi-web', color: '#616161', url: this.partner?.website });
+      if (social.website) {
+        links.push({ icon: 'mdi-web', color: '#616161', url: social.website });
       }
-      if (this.partner?.twitterUrl) {
-        links.push({ icon: 'mdi-twitter', color: '#1da1f2', url: this.partner?.twitterUrl });
+      if (social.twitterUrl) {
+        links.push({ icon: 'mdi-twitter', color: '#1da1f2', url: social.twitterUrl });
       }
-      if (this.partner?.linkedinUrl) {
-        links.push({ icon: 'mdi-linkedin', color: '#0077b5', url: this.partner?.linkedinUrl });
+      if (social.linkedinUrl) {
+        links.push({ icon: 'mdi-linkedin', color: '#0077b5', url: social.linkedinUrl });
       }
-      if (this.partner?.youtubeUrl) {
-        links.push({ icon: 'mdi-youtube', color: '#ff0000', url: this.partner?.youtubeUrl });
+      if (social.youtubeUrl) {
+        links.push({ icon: 'mdi-youtube', color: '#ff0000', url: social.youtubeUrl });
       }
-      if (this.partner?.facebookUrl) {
-        links.push({ icon: 'mdi-facebook', color: '#1877f2', url: this.partner?.facebookUrl });
+      if (social.facebookUrl) {
+        links.push({ icon: 'mdi-facebook', color: '#1877f2', url: social.facebookUrl });
       }
 
       return links;

--- a/front/locales/en.json
+++ b/front/locales/en.json
@@ -104,6 +104,8 @@
     "auto": {
       "ezpaarse": "ezPAARSE",
       "ezmesure": "ezMESURE",
+      "ezcounter": "ezCOUNTER",
+      "ezreeport": "ezREEPORT",
       "report": "Reporting",
       "sushi": "SUSHI"
     }

--- a/front/locales/fr.json
+++ b/front/locales/fr.json
@@ -104,6 +104,8 @@
     "auto": {
       "ezpaarse": "ezPAARSE",
       "ezmesure": "ezMESURE",
+      "ezcounter": "ezCOUNTER",
+      "ezreeport": "ezREEPORT",
       "report": "Reporting",
       "sushi": "SUSHI"
     }

--- a/front/pages/partners.vue
+++ b/front/pages/partners.vue
@@ -31,31 +31,6 @@
           hide-details
         />
       </v-col>
-      <v-col cols="12" sm="6" md="5" lg="4">
-        <v-select
-          v-model="selectedAutomations"
-          :items="automations"
-          :item-text="item => $t(`partners.auto.${item.label}`)"
-          item-value="label"
-          :label="$t('partners.automated')"
-          solo
-          multiple
-          hide-details
-          max-width="200"
-        >
-          <template #selection="{ item }">
-            <v-chip
-              :color="item.color"
-              label
-              dark
-              close
-              @click:close="deselectAutomation(item.label)"
-            >
-              {{ $t(`partners.auto.${item.label}`) }}
-            </v-chip>
-          </template>
-        </v-select>
-      </v-col>
     </v-row>
 
     <v-layout row wrap justify-center>


### PR DESCRIPTION
![image](https://github.com/ezpaarse-project/ezmesure/assets/34627360/8f2a8c49-a34c-4bb5-80f9-b99ccb0704f4)

## Features
- Redone tags
  - `sushi` -> `ezCOUNTER`
    - if there's is a space of type `counter5` 
  - `ezPAARSE`
    - if there's is a space of type `ezpaarse`
  - `reporting` -> `ezREEPORT`
    - if there's an active report 
- Supporting multiple contacts
- Removing empty blocs
- Removed automation filter