### PR TITLE
feature: renamed "sub institutions" into "components"

### DIFF
--- a/front/components/SubInstitutionsManager.vue
+++ b/front/components/SubInstitutionsManager.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card :loading="loading" v-bind="$attrs">
     <v-card-title class="headline">
-      {{ $t('subinstitutions.subinstitutions') }}
+      {{ $t('components.components') }}
 
       <v-spacer />
 
@@ -173,7 +173,7 @@
         width="2"
       />
       <div v-else class="text-grey">
-        {{ $t('subinstitutions.noSubInstitutions') }}
+        {{ $t('components.noSubInstitutions') }}
       </div>
     </v-card-text>
 

--- a/front/components/institutions/InstitutionsFiltersDrawer.vue
+++ b/front/components/institutions/InstitutionsFiltersDrawer.vue
@@ -131,7 +131,7 @@
       <v-row class="px-0">
         <v-col style="position: relative;">
           <v-label class="slider-label slider-label-withicon">
-            {{ $t('subinstitutions.subinstitutions') }}
+            {{ $t('components.components') }}
           </v-label>
 
           <v-range-slider

--- a/front/locales/en.json
+++ b/front/locales/en.json
@@ -380,10 +380,10 @@
     "notAttachedToAnyInstitution": "You are not attached to any institution, where you have not declared any information about your institution.",
     "reportInstitutionInformation": "Report institution information."
   },
-  "subinstitutions": {
-    "subinstitutions": "Sub-institutions",
-    "count": "{count} sub-inst.",
-    "noSubInstitutions": "No sub-institution"
+  "components": {
+    "components": "Components",
+    "count": "{count} components",
+    "noComponent": "No components"
   },
   "tasks": {
     "failedToFetchTasks": "Failed to fetch tasks list",

--- a/front/locales/fr.json
+++ b/front/locales/fr.json
@@ -381,10 +381,10 @@
     "notAttachedToAnyInstitution": "Vous n'êtes rattachés à aucun établissement, où vous n'avez déclaré aucunes informations sur votre établissement.",
     "reportInstitutionInformation": "Déclarer des informations d'établissement."
   },
-  "subinstitutions": {
-    "subinstitutions": "Sous-établissements",
-    "count": "{count} sous-étab.",
-    "noSubInstitutions": "Aucun sous-établissement"
+  "components": {
+    "components": "Composantes",
+    "count": "{count} composante|{count} composantes",
+    "noComponent": "Aucune composante"
   },
   "tasks": {
     "failedToFetchTasks": "Impossible de récupérer la liste des tâches",

--- a/front/pages/admin/institutions.vue
+++ b/front/pages/admin/institutions.vue
@@ -103,7 +103,7 @@
           class="elevation-1"
           @click="$refs.subInstitutionsDialog?.display?.(item)"
         >
-          {{ $tc('subinstitutions.count', item.childInstitutions.length) }}
+          {{ $tc('components.count', item.childInstitutions.length) }}
 
           <v-icon right small>
             mdi-family-tree
@@ -352,7 +352,7 @@ export default {
           filter: (_value, _search, item) => this.columnArrayFilter('memberships', item),
         },
         {
-          text: this.$t('subinstitutions.subinstitutions'),
+          text: this.$t('components.components'),
           width: '170px',
           value: 'childInstitutions',
           filter: (_value, _search, item) => this.columnArrayFilter('childInstitutions', item),


### PR DESCRIPTION
![image](https://github.com/ezpaarse-project/ezmesure/assets/34627360/69fdfd43-0268-4bee-b676-d91b83d562e2)
