### PR TITLE
feat(api): added support for transaction

### DIFF
--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -16,7 +16,7 @@
     "SharedArrayBuffer": "readonly"
   },
   "parserOptions": {
-    "ecmaVersion": 2020
+    "ecmaVersion": 2022
   },
   "rules": {
     "consistent-return": 0

--- a/api/lib/controllers/auth/auth.js
+++ b/api/lib/controllers/auth/auth.js
@@ -5,8 +5,8 @@ const elastic = require('../../services/elastic');
 
 const usersElastic = require('../../services/elastic/users');
 const ezrUsers = require('../../services/ezreeport/users');
-const usersService = require('../../entities/users.service');
-const membershipsService = require('../../entities/memberships.service');
+const UsersService = require('../../entities/users.service');
+const MembershipsService = require('../../entities/memberships.service');
 const { appLogger } = require('../../services/logger');
 const { sendPasswordRecovery, sendWelcomeMail, sendNewUserToContacts } = require('./mail');
 
@@ -65,6 +65,8 @@ exports.renaterLogin = async (ctx) => {
   };
 
   const { username } = userProps;
+
+  const usersService = new UsersService();
 
   let user = await usersService.findUnique({ where: { username } });
 
@@ -138,6 +140,8 @@ exports.elasticLogin = async (ctx) => {
     return;
   }
 
+  const usersService = new UsersService();
+
   user = await usersService.findUnique({ where: { username } });
 
   if (!user) {
@@ -161,6 +165,8 @@ exports.activate = async (ctx) => {
     ctx.throw(409, ctx.$t('errors.user.alreadyActivated'));
     return;
   }
+
+  const usersService = new UsersService();
 
   try {
     await usersService.acceptTerms(user.username);
@@ -246,6 +252,7 @@ exports.resetPassword = async (ctx) => {
   const { username } = ctx.state.user;
   const { createdAt } = ctx.state.jwtdata;
 
+  const usersService = new UsersService();
   const user = await usersService.findUnique({ where: { username } });
 
   user.metadata = user.metadata || {};
@@ -295,6 +302,7 @@ exports.changePassword = async (ctx) => {
 };
 
 exports.getUser = async (ctx) => {
+  const usersService = new UsersService();
   const user = await usersService.findUnique({
     where: { username: ctx.state.user.username },
     include: {
@@ -332,6 +340,7 @@ exports.getToken = async (ctx) => {
 exports.getMemberships = async (ctx) => {
   const { username } = ctx.state.user;
   ctx.status = 200;
+  const membershipsService = new MembershipsService();
   ctx.body = await membershipsService.findMany({
     where: { username },
     include: { institution: true },

--- a/api/lib/controllers/auth/mail.js
+++ b/api/lib/controllers/auth/mail.js
@@ -16,7 +16,7 @@ const { sendMail, generateMail } = require('../../services/mail');
  * @param {string} data.resetLink - Reset recovery password link.
  * @param {string} data.validity - Duration of Recovery link.
  *
- * @returns {void}
+ * @returns {Promise<void>}
  */
 exports.sendActivateUserMail = function sendActivateUserMail(user, activateLink) {
   return sendMail({
@@ -34,7 +34,7 @@ exports.sendActivateUserMail = function sendActivateUserMail(user, activateLink)
  * @param {string} user.username - Username of user.
  * @param {string} user.email - User email.
  *
- * @returns {void}
+ * @returns {Promise<void>}
  */
 exports.sendWelcomeMail = function sendWelcomeMail(user) {
   return sendMail({
@@ -55,7 +55,7 @@ exports.sendWelcomeMail = function sendWelcomeMail(user) {
  * @param {string} data.resetLink - Reset recovery password link.
  * @param {string} data.validity - Duration of Recovery link.
  *
- * @returns {void}
+ * @returns {Promise<void>}
  */
 exports.sendPasswordRecovery = function sendPasswordRecovery(user, data) {
   return sendMail({
@@ -74,7 +74,7 @@ exports.sendPasswordRecovery = function sendPasswordRecovery(user, data) {
  * @param {Object} data - Mail config.
  * @param {string} data.newUser - Username of user who activated his account.
  *
- * @returns {void}
+ * @returns {Promise<void>}
  */
 exports.sendNewUserToContacts = function sendNewUserToContacts(receivers, data) {
   return sendMail({

--- a/api/lib/controllers/harvests/actions.js
+++ b/api/lib/controllers/harvests/actions.js
@@ -1,4 +1,4 @@
-const harvestsService = require('../../entities/harvest.service');
+const HarvestsService = require('../../entities/harvest.service');
 
 /**
   * @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs
@@ -29,9 +29,9 @@ exports.getHarvests = async (ctx) => {
     options.where.period = { gte: from, lte: to };
   }
 
-  const harvests = await harvestsService.findMany(options);
+  const harvestsService = new HarvestsService();
 
   ctx.type = 'json';
   ctx.status = 200;
-  ctx.body = harvests;
+  ctx.body = await harvestsService.findMany(options);
 };

--- a/api/lib/controllers/institutions/actions.js
+++ b/api/lib/controllers/institutions/actions.js
@@ -1,7 +1,14 @@
 const config = require('config');
-const { propsToPrismaInclude } = require('../utils');
-const institutionsService = require('../../entities/institutions.service');
-const usersService = require('../../entities/users.service');
+
+const { sendMail, generateMail } = require('../../services/mail');
+const { appLogger } = require('../../services/logger');
+const InstitutionsService = require('../../entities/institutions.service');
+const UsersService = require('../../entities/users.service');
+const ImagesService = require('../../services/images');
+const SushiCredentialsService = require('../../entities/sushi-credentials.service');
+const MembershipsService = require('../../entities/memberships.service');
+const RepositoriesService = require('../../entities/repositories.service');
+const SpacesService = require('../../entities/spaces.service');
 
 /* eslint-disable max-len */
 /**
@@ -34,13 +41,7 @@ const {
   includableFields: spaceIncludableFields,
 } = require('../../entities/repositories.dto');
 
-const imagesService = require('../../services/images');
-const { sendMail, generateMail } = require('../../services/mail');
-const { appLogger } = require('../../services/logger');
-const sushiCredentialsService = require('../../entities/sushi-credentials.service');
-const membershipsService = require('../../entities/memberships.service');
-const repositoriesService = require('../../entities/repositories.service');
-const spacesService = require('../../entities/spaces.service');
+const { propsToPrismaInclude } = require('../utils');
 
 const {
   PERMISSIONS,
@@ -120,10 +121,10 @@ exports.getInstitutions = async (ctx) => {
     };
   }
 
-  const institution = await institutionsService.findMany(options);
+  const institutionsService = new InstitutionsService();
 
   ctx.type = 'json';
-  ctx.body = institution;
+  ctx.body = await institutionsService.findMany(options);
 };
 
 exports.getInstitution = async (ctx) => {
@@ -136,6 +137,8 @@ exports.getInstitution = async (ctx) => {
   if (ctx.state?.user?.isAdmin) {
     include = propsToPrismaInclude(propsToInclude, includableFields);
   }
+
+  const institutionsService = new InstitutionsService();
 
   ctx.type = 'json';
   ctx.status = 200;
@@ -173,8 +176,10 @@ exports.createInstitution = async (ctx) => {
     };
   }
 
+  const institutionsService = new InstitutionsService();
+
   if (body?.logo) {
-    institutionData.logoId = await imagesService.storeLogo(body.logo);
+    institutionData.logoId = await ImagesService.storeLogo(body.logo);
   }
 
   const institution = await institutionsService.create({
@@ -213,8 +218,11 @@ exports.updateInstitution = async (ctx) => {
   const oldLogoId = institution.logoId;
   const wasSushiReady = institution.sushiReadySince;
 
+  const institutionsService = new InstitutionsService();
+  const membershipsService = new MembershipsService();
+
   if (institutionData.logo) {
-    institutionData.logoId = await imagesService.storeLogo(institutionData.logo);
+    institutionData.logoId = await ImagesService.storeLogo(institutionData.logo);
   }
 
   // FIXME: handle admin restricted fields
@@ -228,7 +236,7 @@ exports.updateInstitution = async (ctx) => {
   appLogger.verbose(`Institution [${institution.id}] is updated`);
 
   if (institutionData.logo && oldLogoId) {
-    await imagesService.remove(oldLogoId);
+    await ImagesService.remove(oldLogoId);
   }
 
   if (!wasValidated && institutionData.validated === true) {
@@ -303,7 +311,12 @@ exports.importInstitutions = async (ctx) => {
     });
   };
 
-  const importItem = async (itemData = {}) => {
+  /**
+   * @param {InstitutionsService} institutionsService
+   * @param {*} itemData
+   * @returns
+   */
+  const importItem = async (institutionsService, itemData = {}) => {
     const { value: item, error } = adminImportSchema.validate(itemData);
 
     if (error) {
@@ -326,7 +339,7 @@ exports.importInstitutions = async (ctx) => {
     const institutionData = {
       ...item,
       logo: undefined,
-      logoId: item.logo ? await imagesService.storeLogo(item.logo) : item.logoId,
+      logoId: item.logo ? await ImagesService.storeLogo(item.logo) : item.logoId,
 
       spaces: {
         connectOrCreate: item.spaces?.map?.((spaceData) => ({
@@ -420,15 +433,18 @@ exports.importInstitutions = async (ctx) => {
     addResponseItem(institution, 'created');
   };
 
-  for (let i = 0; i < body.length; i += 1) {
-    const institutionData = body[i] || {};
+  await InstitutionsService.$transaction(async (institutionsService) => {
+    for (let i = 0; i < body.length; i += 1) {
+      const institutionData = body[i] || {};
 
-    try {
-      await importItem(institutionData); // eslint-disable-line no-await-in-loop
-    } catch (e) {
-      addResponseItem(institutionData, 'error', e.message);
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await importItem(institutionsService, institutionData);
+      } catch (e) {
+        addResponseItem(institutionData, 'error', e.message);
+      }
     }
-  }
+  });
 
   ctx.type = 'json';
   ctx.body = response;
@@ -445,6 +461,8 @@ exports.deleteInstitution = async (ctx) => {
     institutionName: institution.name,
   };
 
+  const institutionsService = new InstitutionsService();
+
   const data = await institutionsService.delete({ where: { id: institutionId } });
   appLogger.verbose(`Institution [${institution?.id}] is deleted`);
 
@@ -454,6 +472,8 @@ exports.deleteInstitution = async (ctx) => {
 
 exports.getInstitutionRepositories = async (ctx) => {
   const { include: propsToInclude } = ctx.query;
+
+  const repositoriesService = new RepositoriesService();
 
   const repositories = await repositoriesService.findMany({
     where: { institutions: { some: { id: ctx.state.institution.id } } },
@@ -469,6 +489,8 @@ exports.getInstitutionRepositories = async (ctx) => {
 exports.getInstitutionSpaces = async (ctx) => {
   const { include: propsToInclude } = ctx.query;
 
+  const spacesService = new SpacesService();
+
   const spaces = await spacesService.findMany({
     where: { institutionId: ctx.state.institution.id },
     include: propsToPrismaInclude(propsToInclude, spaceIncludableFields),
@@ -483,6 +505,8 @@ exports.getInstitutionSpaces = async (ctx) => {
 exports.getInstitutionMember = async (ctx) => {
   const { institutionId, username } = ctx.params;
   const { include: propsToInclude } = ctx.query;
+
+  const membershipsService = new MembershipsService();
 
   const membership = await membershipsService.findUnique({
     where: {
@@ -503,6 +527,8 @@ exports.getInstitutionMember = async (ctx) => {
 
 exports.getInstitutionMembers = async (ctx) => {
   const { include: propsToInclude } = ctx.query;
+
+  const membershipsService = new MembershipsService();
 
   const memberships = await membershipsService.findMany({
     where: { institutionId: ctx.state.institution.id },
@@ -549,6 +575,9 @@ exports.addInstitutionMember = async (ctx) => {
     institutionName,
     username,
   };
+
+  const usersService = new UsersService();
+  const membershipsService = new MembershipsService();
 
   const user = await usersService.findUnique({
     where: { username },
@@ -617,6 +646,9 @@ exports.removeInstitutionMember = async (ctx) => {
     username,
   };
 
+  const usersService = new UsersService();
+  const membershipsService = new MembershipsService();
+
   const user = await usersService.findUnique({
     where: { username },
     select: {
@@ -657,7 +689,11 @@ exports.removeInstitutionMember = async (ctx) => {
 };
 
 exports.getSushiData = async (ctx) => {
-  const sushiItems = await sushiCredentialsService.findMany({
+  const sushiCredentialsService = new SushiCredentialsService();
+
+  ctx.type = 'json';
+  ctx.status = 200;
+  ctx.body = await sushiCredentialsService.findMany({
     where: {
       institutionId: ctx.state.institution.id,
     },
@@ -665,13 +701,13 @@ exports.getSushiData = async (ctx) => {
       endpoint: true,
     },
   });
-
-  ctx.type = 'json';
-  ctx.status = 200;
-  ctx.body = sushiItems;
 };
 
 exports.requestMembership = async (ctx) => {
+  ctx.action = 'institutions/requestMembership';
+
+  const institutionsService = new InstitutionsService();
+
   const members = await institutionsService.getContacts(ctx.state.institution.id);
   const emails = members.map((member) => member.user.email);
   const link = `${ctx.request.header.origin}/institutions/${ctx.state.institution.id}/members`;

--- a/api/lib/controllers/institutions/admin.js
+++ b/api/lib/controllers/institutions/admin.js
@@ -50,13 +50,16 @@ exports.validateInstitution = async (ctx) => {
 
   const wasValidated = institution.validated;
 
-  const updatedInstitution = await InstitutionsService.update({
+  const usersService = new UsersService();
+  const institutionsService = new InstitutionsService();
+
+  const updatedInstitution = await institutionsService.update({
     where: { id: institution.id },
     data: { validated },
   });
 
   if (!wasValidated && validated === true) {
-    let contacts = await UsersService.findMany({
+    let contacts = await usersService.findMany({
       where: {
         memberships: {
           some: {

--- a/api/lib/controllers/institutions/repositories.js
+++ b/api/lib/controllers/institutions/repositories.js
@@ -1,5 +1,5 @@
-const repositoriesService = require('../../entities/repositories.service');
-const repoPermissionsService = require('../../entities/repository-permissions.service');
+const RepositoriesService = require('../../entities/repositories.service');
+const RepoPermissionsService = require('../../entities/repository-permissions.service');
 const {
   upsertSchema: permissionUpsertSchema,
 } = require('../../entities/repository-permissions.dto');
@@ -39,7 +39,10 @@ exports.upsertRepositoryPermission = async (ctx) => {
     },
   };
 
-  const updatedPermissions = await repoPermissionsService.upsert({
+  const repoPermissionsService = new RepoPermissionsService();
+
+  ctx.status = 200;
+  ctx.body = await repoPermissionsService.upsert({
     where: {
       username_institutionId_repositoryPattern: {
         username,
@@ -50,16 +53,16 @@ exports.upsertRepositoryPermission = async (ctx) => {
     create: permissionData,
     update: permissionData,
   });
-
-  ctx.status = 200;
-  ctx.body = updatedPermissions;
 };
 
 exports.deleteRepositoryPermission = async (ctx) => {
   const { repository, institution } = ctx.state;
   const { username } = ctx.params;
 
-  const updatedPermissions = await repoPermissionsService.delete({
+  const repoPermissionsService = new RepoPermissionsService();
+
+  ctx.status = 200;
+  ctx.body = await repoPermissionsService.delete({
     where: {
       username_institutionId_repositoryPattern: {
         username,
@@ -68,14 +71,13 @@ exports.deleteRepositoryPermission = async (ctx) => {
       },
     },
   });
-
-  ctx.status = 200;
-  ctx.body = updatedPermissions;
 };
 
 exports.removeRepository = async (ctx) => {
   const { repository } = ctx.state;
   const { pattern, institutionId } = ctx.params;
+
+  const repositoriesService = new RepositoriesService();
 
   if (repository.institutions.length >= 2) {
     await repositoriesService.disconnectInstitution(pattern, institutionId);
@@ -95,6 +97,9 @@ exports.addRepository = async (ctx) => {
     ctx.throw(409, ctx.$t('errors.repository.typeMismatch', repository.pattern));
   }
 
+  const repositoriesService = new RepositoriesService();
+
+  ctx.status = repository ? 200 : 201;
   ctx.body = await repositoriesService.upsert({
     where: { pattern },
     create: {
@@ -114,6 +119,4 @@ exports.addRepository = async (ctx) => {
       },
     },
   });
-
-  ctx.status = repository ? 200 : 201;
 };

--- a/api/lib/controllers/institutions/subinstitutions.js
+++ b/api/lib/controllers/institutions/subinstitutions.js
@@ -1,9 +1,11 @@
-const institutionsService = require('../../entities/institutions.service');
+const InstitutionsService = require('../../entities/institutions.service');
 const { includableFields } = require('../../entities/institutions.dto');
 const { propsToPrismaInclude } = require('../utils');
 
 exports.getSubInstitutions = async (ctx) => {
   const { include: propsToInclude } = ctx.query;
+
+  const institutionsService = new InstitutionsService();
 
   const subInstitutions = await institutionsService.findMany({
     where: { parentInstitutionId: ctx.state.institution.id },
@@ -19,7 +21,11 @@ exports.addSubInstitution = async (ctx) => {
   const { institution } = ctx.state;
   const { subInstitutionId } = ctx.params;
 
-  const newInstitution = await institutionsService.update({
+  const institutionsService = new InstitutionsService();
+
+  ctx.type = 'json';
+  ctx.status = 200;
+  ctx.body = await institutionsService.update({
     where: { id: institution.id },
     include: { childInstitutions: true },
     data: {
@@ -29,17 +35,17 @@ exports.addSubInstitution = async (ctx) => {
     },
 
   });
-
-  ctx.type = 'json';
-  ctx.status = 200;
-  ctx.body = newInstitution;
 };
 
 exports.removeSubInstitution = async (ctx) => {
   const { institution } = ctx.state;
   const { subInstitutionId } = ctx.params;
 
-  const newInstitution = await institutionsService.update({
+  const institutionsService = new InstitutionsService();
+
+  ctx.type = 'json';
+  ctx.status = 200;
+  ctx.body = await institutionsService.update({
     where: { id: institution.id },
     include: { childInstitutions: true },
     data: {
@@ -47,10 +53,5 @@ exports.removeSubInstitution = async (ctx) => {
         disconnect: { id: subInstitutionId },
       },
     },
-
   });
-
-  ctx.type = 'json';
-  ctx.status = 200;
-  ctx.body = newInstitution;
 };

--- a/api/lib/controllers/kibana-spaces/actions.js
+++ b/api/lib/controllers/kibana-spaces/actions.js
@@ -1,5 +1,5 @@
-const spacesService = require('../../entities/spaces.service');
-const spacePermissionsService = require('../../entities/space-permissions.service');
+const SpacesService = require('../../entities/spaces.service');
+const SpacePermissionsService = require('../../entities/space-permissions.service');
 const {
   upsertSchema: permissionUpsertSchema,
 } = require('../../entities/space-permissions.dto');
@@ -28,6 +28,8 @@ exports.getMany = async (ctx) => {
     };
   }
 
+  const spacesService = new SpacesService();
+
   ctx.type = 'json';
   ctx.body = await spacesService.findMany({ where });
 };
@@ -40,6 +42,8 @@ exports.getOne = async (ctx) => {
 
 exports.upsertOne = async (ctx) => {
   const { body } = ctx.request;
+
+  const spacesService = new SpacesService();
 
   let space;
 
@@ -70,6 +74,8 @@ exports.upsertOne = async (ctx) => {
 
 exports.createOne = async (ctx) => {
   const { body } = ctx.request;
+
+  const spacesService = new SpacesService();
 
   let space;
 
@@ -104,6 +110,8 @@ exports.updateOne = async (ctx) => {
   const { space } = ctx.state;
   const { body } = ctx.request;
 
+  const spacesService = new SpacesService();
+
   let updatedSushiCredentials;
 
   try {
@@ -129,6 +137,7 @@ exports.updateOne = async (ctx) => {
 exports.deleteOne = async (ctx) => {
   const { spaceId } = ctx.params;
 
+  const spacesService = new SpacesService();
   await spacesService.delete({ where: { id: spaceId } });
 
   ctx.status = 204;
@@ -158,7 +167,10 @@ exports.upsertPermission = async (ctx) => {
     },
   };
 
-  const updatedPermissions = await spacePermissionsService.upsert({
+  const spacePermissionsService = new SpacePermissionsService();
+
+  ctx.status = 200;
+  ctx.body = await spacePermissionsService.upsert({
     where: {
       username_spaceId: {
         username,
@@ -168,16 +180,16 @@ exports.upsertPermission = async (ctx) => {
     create: permissionData,
     update: permissionData,
   });
-
-  ctx.status = 200;
-  ctx.body = updatedPermissions;
 };
 
 exports.deletePermission = async (ctx) => {
   const { space } = ctx.state;
   const { username } = ctx.params;
 
-  const updatedPermissions = await spacePermissionsService.delete({
+  const spacePermissionsService = new SpacePermissionsService();
+
+  ctx.status = 200;
+  ctx.body = await spacePermissionsService.delete({
     where: {
       username_spaceId: {
         username,
@@ -185,7 +197,4 @@ exports.deletePermission = async (ctx) => {
       },
     },
   });
-
-  ctx.status = 200;
-  ctx.body = updatedPermissions;
 };

--- a/api/lib/controllers/partners/actions.js
+++ b/api/lib/controllers/partners/actions.js
@@ -1,5 +1,5 @@
 const { addDays, isAfter } = require('date-fns');
-const institutionService = require('../../entities/institutions.service');
+const InstitutionService = require('../../entities/institutions.service');
 
 const ezrAxios = require('../../services/ezreeport/axios');
 const { appLogger } = require('../../services/logger');
@@ -44,6 +44,7 @@ const institutionHasReport = async (institutionId) => {
 };
 
 exports.list = async (ctx) => {
+  const institutionService = new InstitutionService(ctx);
   const partners = await institutionService.findMany({
     where: {
       validated: true,

--- a/api/lib/controllers/partners/actions.js
+++ b/api/lib/controllers/partners/actions.js
@@ -44,7 +44,7 @@ const institutionHasReport = async (institutionId) => {
 };
 
 exports.list = async (ctx) => {
-  const institutionService = new InstitutionService(ctx);
+  const institutionService = new InstitutionService();
   const partners = await institutionService.findMany({
     where: {
       validated: true,

--- a/api/lib/controllers/repositories/actions.js
+++ b/api/lib/controllers/repositories/actions.js
@@ -1,4 +1,4 @@
-const repositoriesService = require('../../entities/repositories.service');
+const RepositoriesService = require('../../entities/repositories.service');
 const { includableFields } = require('../../entities/repositories.dto');
 
 const {
@@ -43,6 +43,8 @@ exports.getMany = async (ctx) => {
     };
   }
 
+  const repositoriesService = new RepositoriesService();
+
   ctx.type = 'json';
   ctx.body = await repositoriesService.findMany({
     take: Number.isInteger(size) && size >= 0 ? size : undefined,
@@ -78,6 +80,8 @@ exports.createOne = async (ctx) => {
     configUpsert.update.institutions = { connect: { id: body?.institutionId } };
   }
 
+  const repositoriesService = new RepositoriesService();
+
   try {
     repository = await repositoriesService.upsert({
       where: { pattern: body.pattern },
@@ -108,6 +112,8 @@ exports.updateOne = async (ctx) => {
 
   let updatedRepository;
 
+  const repositoriesService = new RepositoriesService();
+
   try {
     updatedRepository = await repositoriesService.update({
       where: {
@@ -134,6 +140,8 @@ exports.updateOne = async (ctx) => {
 
 exports.deleteOne = async (ctx) => {
   const { pattern } = ctx.params;
+
+  const repositoriesService = new RepositoriesService();
 
   await repositoriesService.delete({
     where: { pattern },

--- a/api/lib/controllers/tasks/actions.js
+++ b/api/lib/controllers/tasks/actions.js
@@ -1,4 +1,4 @@
-const harvestJobService = require('../../entities/harvest-job.service');
+const HarvestJobService = require('../../entities/harvest-job.service');
 const { harvestQueue } = require('../../services/jobs');
 
 /** @typedef {import('@prisma/client').Prisma.HarvestJobWhereInput} HarvestJobWhereInput */
@@ -51,6 +51,8 @@ exports.getAll = async (ctx) => {
     distinct = Array.isArray(distinctFields) ? distinctFields : distinctFields.split(',').map((s) => s.trim());
   }
 
+  const harvestJobService = new HarvestJobService();
+
   ctx.body = await harvestJobService.findMany({
     include: {
       credentials: {
@@ -67,6 +69,8 @@ exports.getAll = async (ctx) => {
 
 exports.getOne = async (ctx) => {
   const { taskId } = ctx.params;
+
+  const harvestJobService = new HarvestJobService();
 
   const task = await harvestJobService.findUnique({
     where: { id: taskId },
@@ -90,6 +94,8 @@ exports.getOne = async (ctx) => {
 
 exports.cancelOne = async (ctx) => {
   const { taskId } = ctx.params;
+
+  const harvestJobService = new HarvestJobService();
 
   let task = await harvestJobService.findUnique({ where: { id: taskId } });
   const job = await harvestQueue.getJob(taskId);
@@ -131,6 +137,7 @@ exports.deleteOne = async (ctx) => {
     await job.remove();
   }
 
+  const harvestJobService = new HarvestJobService();
   await harvestJobService.delete({ where: { id: taskId } });
 
   ctx.status = 204;

--- a/api/lib/controllers/utils.js
+++ b/api/lib/controllers/utils.js
@@ -4,7 +4,7 @@ const { merge } = require('lodash');
  * Transform props to include into a valid prisma `include` field
  *
  * @param {string[]} props
- * @param {(string[] | Set<string>)?} includableFields
+ * @param {(string[] | Set<string>)?} [includableFields]
  * @returns
  */
 const propsToPrismaInclude = (props, includableFields) => {
@@ -39,7 +39,7 @@ const propsToPrismaInclude = (props, includableFields) => {
  *
  * @param {string} prop
  * @param {'asc'|'desc'} order
- * @param {(string[] | Set<string>)?} sortableFields
+ * @param {(string[] | Set<string>)?} [sortableFields]
  * @returns
  */
 const propsToPrismaSort = (prop, order, sortableFields) => {

--- a/api/lib/entities/actions.service.js
+++ b/api/lib/entities/actions.service.js
@@ -1,4 +1,5 @@
 // @ts-check
+const BasePrismaService = require('./base-prisma.service');
 const actionsPrisma = require('../services/prisma/actions');
 
 /* eslint-disable max-len */
@@ -10,44 +11,47 @@ const actionsPrisma = require('../services/prisma/actions');
 /** @typedef {import('@prisma/client').Prisma.ActionCreateArgs} ActionCreateArgs */
 /* eslint-enable max-len */
 
-module.exports = class ActionsService {
+module.exports = class ActionsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<ActionsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {ActionCreateArgs} params
    * @returns {Promise<Action>}
    */
-  static create(params) {
-    return actionsPrisma.create(params);
+  create(params) {
+    return actionsPrisma.create(params, this.prisma);
   }
 
   /**
    * @param {ActionFindManyArgs} params
    * @returns {Promise<Action[]>}
    */
-  static findMany(params) {
-    return actionsPrisma.findMany(params);
+  findMany(params) {
+    return actionsPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {ActionFindUniqueArgs} params
    * @returns {Promise<Action | null>}
    */
-  static findUnique(params) {
-    return actionsPrisma.findUnique(params);
+  findUnique(params) {
+    return actionsPrisma.findUnique(params, this.prisma);
   }
 
   /**
    * @param {ActionUpdateArgs} params
    * @returns {Promise<Action>}
    */
-  static update(params) {
-    return actionsPrisma.update(params);
+  update(params) {
+    return actionsPrisma.update(params, this.prisma);
   }
 
   /**
    * @param {ActionUpsertArgs} params
    * @returns {Promise<Action>}
    */
-  static upsert(params) {
-    return actionsPrisma.upsert(params);
+  upsert(params) {
+    return actionsPrisma.upsert(params, this.prisma);
   }
 };

--- a/api/lib/entities/base-prisma.service.js
+++ b/api/lib/entities/base-prisma.service.js
@@ -23,7 +23,11 @@ class BasePrismaService {
   currentTransaction = undefined;
 
   /**
-   * @param {TransactionClient | BasePrismaService} prismaOrService
+   * Create a new service with a prisma client
+   *
+   * @param {TransactionClient | BasePrismaService} prismaOrService Prisma instance or service.
+   * Default to global prisma instance, if a service is provided it'll reuse the prisma instance
+   * and transaction
    */
   constructor(prismaOrService = client) {
     if (prismaOrService instanceof BasePrismaService) {
@@ -36,8 +40,11 @@ class BasePrismaService {
   }
 
   /**
-   * @param {Function} executor
-   * @returns
+   * Start a new interactive transaction
+   *
+   * @param {Function} executor The executor of the transaction, take a service as parameter
+   *
+   * @returns {Promise<any>} The result of the transaction
    */
   static $transaction(executor) {
     const currentTransaction = client.$transaction(
@@ -61,8 +68,8 @@ class BasePrismaService {
    * @param {string} action The event name
    * @param {any[]} payload The payload of the event
    *
-   * @returns Returns `true` if the event had listeners, `false` otherwise.
-   * If in transaction returns a Promise resolved when the hook is triggered
+   * @returns {boolean | Promise<boolean>} Returns `true` if the event had listeners
+   * `false` otherwise. If in transaction returns a Promise resolved when the hook is triggered
    */
   triggerHooks(action, ...payload) {
     if (!this.currentTransaction) {

--- a/api/lib/entities/base-prisma.service.js
+++ b/api/lib/entities/base-prisma.service.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+const { triggerHooks } = require('../hooks/hookEmitter');
+const { client } = require('../services/prisma');
+
+/* eslint-disable max-len */
+/** @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient */
+/* eslint-enable max-len */
+
+/**
+ * @template {BasePrismaService} S
+ * @typedef {(service: S) => Promise<any>} Executor
+ */
+
+/**
+ * @template {BasePrismaService} S
+ * @typedef {(executor: Executor<S>) => ReturnType<Executor<S>>} TransactionFnc
+ */
+
+/** @abstract @class */
+class BasePrismaService {
+  /** @type {Promise<any> | undefined} */
+  currentTransaction = undefined;
+
+  /**
+   * @param {TransactionClient | BasePrismaService} prismaOrService
+   */
+  constructor(prismaOrService = client) {
+    if (prismaOrService instanceof BasePrismaService) {
+      this.prisma = prismaOrService.prisma;
+      this.currentTransaction = prismaOrService.currentTransaction;
+      return;
+    }
+
+    this.prisma = prismaOrService;
+  }
+
+  /**
+   * @param {Function} executor
+   * @returns
+   */
+  static $transaction(executor) {
+    const currentTransaction = client.$transaction(
+      (tx) => {
+        const service = new this(tx);
+        service.currentTransaction = currentTransaction;
+
+        return executor(service);
+      },
+    );
+
+    return currentTransaction;
+  }
+
+  /**
+   * Trigger a hook
+   *
+   * In transaction mode, the hook is triggered when the transaction commits.
+   * Hooks aren't triggered if transaction rolls back.
+   *
+   * @param {string} action The event name
+   * @param {any[]} payload The payload of the event
+   *
+   * @returns Returns `true` if the event had listeners, `false` otherwise.
+   * If in transaction returns a Promise resolved when the hook is triggered
+   */
+  triggerHooks(action, ...payload) {
+    if (!this.currentTransaction) {
+      return triggerHooks(action, ...payload);
+    }
+
+    return this.currentTransaction.then(
+      () => triggerHooks(action, ...payload),
+    );
+  }
+}
+
+module.exports = BasePrismaService;

--- a/api/lib/entities/harvest.service.js
+++ b/api/lib/entities/harvest.service.js
@@ -1,5 +1,6 @@
 // @ts-check
 const harvestPrisma = require('../services/prisma/harvest');
+const BasePrismaService = require('./base-prisma.service');
 
 /* eslint-disable max-len */
 /** @typedef {import('@prisma/client').Harvest} Harvest */
@@ -10,44 +11,47 @@ const harvestPrisma = require('../services/prisma/harvest');
 /** @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs */
 /* eslint-enable max-len */
 
-module.exports = class HarvestsService {
+module.exports = class HarvestsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<HarvestsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {HarvestCreateArgs} params
    * @returns {Promise<Harvest>}
    */
-  static create(params) {
-    return harvestPrisma.create(params);
+  create(params) {
+    return harvestPrisma.create(params, this.prisma);
   }
 
   /**
    * @param {HarvestFindManyArgs} params
    * @returns {Promise<Harvest[]>}
    */
-  static findMany(params) {
-    return harvestPrisma.findMany(params);
+  findMany(params) {
+    return harvestPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {HarvestFindUniqueArgs} params
    * @returns {Promise<Harvest | null>}
    */
-  static findUnique(params) {
-    return harvestPrisma.findUnique(params);
+  findUnique(params) {
+    return harvestPrisma.findUnique(params, this.prisma);
   }
 
   /**
    * @param {HarvestUpdateArgs} params
    * @returns {Promise<Harvest>}
    */
-  static update(params) {
-    return harvestPrisma.update(params);
+  update(params) {
+    return harvestPrisma.update(params, this.prisma);
   }
 
   /**
    * @param {HarvestUpsertArgs} params
    * @returns {Promise<Harvest>}
    */
-  static upsert(params) {
-    return harvestPrisma.upsert(params);
+  upsert(params) {
+    return harvestPrisma.upsert(params, this.prisma);
   }
 };

--- a/api/lib/entities/institutions.dto.js
+++ b/api/lib/entities/institutions.dto.js
@@ -9,7 +9,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   id: Joi.string().trim(),

--- a/api/lib/entities/institutions.service.js
+++ b/api/lib/entities/institutions.service.js
@@ -1,7 +1,6 @@
 // @ts-check
+const BasePrismaService = require('./base-prisma.service');
 const institutionsPrisma = require('../services/prisma/institutions');
-
-const { triggerHooks } = require('../hooks/hookEmitter');
 
 /* eslint-disable max-len */
 /**
@@ -15,14 +14,17 @@ const { triggerHooks } = require('../hooks/hookEmitter');
  */
 /* eslint-enable max-len */
 
-module.exports = class InstitutionsService {
+module.exports = class InstitutionsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<InstitutionsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {InstitutionCreateArgs} params
    * @returns {Promise<Institution>}
    */
-  static async create(params) {
-    const institution = await institutionsPrisma.create(params);
-    triggerHooks('institution:create', institution);
+  async create(params) {
+    const institution = await institutionsPrisma.create(params, this.prisma);
+    this.triggerHooks('institution:create', institution);
     return institution;
   }
 
@@ -30,9 +32,9 @@ module.exports = class InstitutionsService {
    * @param {InstitutionCreateArgs} params
    * @returns {Promise<Institution>}
    */
-  static async createAsUser(params) {
-    const institution = await institutionsPrisma.create(params);
-    triggerHooks('institution:create', institution);
+  async createAsUser(params) {
+    const institution = await institutionsPrisma.create(params, this.prisma);
+    this.triggerHooks('institution:create', institution);
     return institution;
   }
 
@@ -40,16 +42,16 @@ module.exports = class InstitutionsService {
    * @param {InstitutionFindManyArgs} params
    * @returns {Promise<Institution[]>}
    */
-  static findMany(params) {
-    return institutionsPrisma.findMany(params);
+  findMany(params) {
+    return institutionsPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {InstitutionFindUniqueArgs} params
    * @returns {Promise<Institution | null>}
    */
-  static findUnique(params) {
-    return institutionsPrisma.findUnique(params);
+  findUnique(params) {
+    return institutionsPrisma.findUnique(params, this.prisma);
   }
 
   /**
@@ -57,17 +59,17 @@ module.exports = class InstitutionsService {
    * @param {Object | null} includes
    * @returns {Promise<Institution | null>}
    */
-  static findByID(id, includes = null) {
-    return institutionsPrisma.findByID(id, includes);
+  findByID(id, includes = null) {
+    return institutionsPrisma.findByID(id, includes, this.prisma);
   }
 
   /**
    * @param {InstitutionUpdateArgs} params
    * @returns {Promise<Institution>}
    */
-  static async update(params) {
-    const institution = await institutionsPrisma.update(params);
-    triggerHooks('institution:update', institution);
+  async update(params) {
+    const institution = await institutionsPrisma.update(params, this.prisma);
+    this.triggerHooks('institution:update', institution);
     return institution;
   }
 
@@ -76,9 +78,13 @@ module.exports = class InstitutionsService {
    * @param {string} subInstitutionId
    * @returns {Promise<Institution>}
    */
-  static async addSubInstitution(institutionId, subInstitutionId) {
-    const institution = await institutionsPrisma.addSubInstitution(institutionId, subInstitutionId);
-    triggerHooks('institution:update', institution);
+  async addSubInstitution(institutionId, subInstitutionId) {
+    const institution = await institutionsPrisma.addSubInstitution(
+      institutionId,
+      subInstitutionId,
+      this.prisma,
+    );
+    this.triggerHooks('institution:update', institution);
     return institution;
   }
 
@@ -86,9 +92,9 @@ module.exports = class InstitutionsService {
    * @param {string} id
    * @returns {Promise<Institution>}
    */
-  static async validate(id) {
-    const institution = await institutionsPrisma.validate(id);
-    triggerHooks('institution:update', institution);
+  async validate(id) {
+    const institution = await institutionsPrisma.validate(id, this.prisma);
+    this.triggerHooks('institution:update', institution);
     return institution;
   }
 
@@ -96,9 +102,9 @@ module.exports = class InstitutionsService {
    * @param {InstitutionUpsertArgs} params
    * @returns {Promise<Institution>}
    */
-  static async upsert(params) {
-    const institution = await institutionsPrisma.upsert(params);
-    triggerHooks('institution:upsert', institution);
+  async upsert(params) {
+    const institution = await institutionsPrisma.upsert(params, this.prisma);
+    this.triggerHooks('institution:upsert', institution);
     return institution;
   }
 
@@ -106,8 +112,8 @@ module.exports = class InstitutionsService {
    * @param {InstitutionDeleteArgs} params
    * @returns {Promise<Institution | null>}
    */
-  static async delete(params) {
-    const data = await institutionsPrisma.remove(params);
+  async delete(params) {
+    const data = await institutionsPrisma.remove(params, this.prisma);
 
     if (!data) return null;
 
@@ -117,17 +123,17 @@ module.exports = class InstitutionsService {
       institution,
     } = data;
 
-    triggerHooks('institution:delete', institution);
+    this.triggerHooks('institution:delete', institution);
 
     institution.memberships?.forEach((element) => {
-      triggerHooks('memberships:delete', element);
+      this.triggerHooks('memberships:delete', element);
 
-      element.repositoryPermissions.forEach((repoPerm) => { triggerHooks('repository_permission:delete', repoPerm); });
-      element.spacePermissions.forEach((spacePerm) => { triggerHooks('space_permission:delete', spacePerm); });
+      element.repositoryPermissions.forEach((repoPerm) => { this.triggerHooks('repository_permission:delete', repoPerm); });
+      element.spacePermissions.forEach((spacePerm) => { this.triggerHooks('space_permission:delete', spacePerm); });
     });
-    institution.spaces?.forEach((element) => { triggerHooks('space:delete', element); });
-    deletedRepos.forEach((element) => { triggerHooks('repository:delete', element); });
-    institution.sushiCredentials?.forEach((element) => { triggerHooks('sushi_credentials:delete', element); });
+    institution.spaces?.forEach((element) => { this.triggerHooks('space:delete', element); });
+    deletedRepos.forEach((element) => { this.triggerHooks('repository:delete', element); });
+    institution.sushiCredentials?.forEach((element) => { this.triggerHooks('sushi_credentials:delete', element); });
 
     return deletedInstitution;
   }
@@ -135,25 +141,39 @@ module.exports = class InstitutionsService {
   /**
    * @returns {Promise<Object | null>}
    */
-  static async removeAll() {
+  async removeAll() {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
-    const institutions = await this.findMany({});
+    /** @param {InstitutionsService} service */
+    const processor = async (service) => {
+      const institutions = await service.findMany({});
 
-    if (institutions.length === 0) { return null; }
+      if (institutions.length === 0) { return null; }
 
-    await Promise.all(institutions.map(async (institution) => {
-      await this.delete({
-        where: {
-          id: institution.id,
-        },
-      });
-    }));
+      await Promise.all(
+        institutions.map(
+          (institution) => service.delete({
+            where: {
+              id: institution.id,
+            },
+          }),
+        ),
+      );
 
-    return institutions;
+      return institutions;
+    };
+
+    if (this.currentTransaction) {
+      return processor(this);
+    }
+    return InstitutionsService.$transaction(processor);
   }
 
-  static async getContacts(institutionId) {
-    return institutionsPrisma.getContacts(institutionId);
+  /**
+   * @param {string} institutionId
+   * @returns
+   */
+  getContacts(institutionId) {
+    return institutionsPrisma.getContacts(institutionId, this.prisma);
   }
 };

--- a/api/lib/entities/institutions.service.js
+++ b/api/lib/entities/institutions.service.js
@@ -145,7 +145,7 @@ module.exports = class InstitutionsService extends BasePrismaService {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     /** @param {InstitutionsService} service */
-    const processor = async (service) => {
+    const transaction = async (service) => {
       const institutions = await service.findMany({});
 
       if (institutions.length === 0) { return null; }
@@ -164,9 +164,9 @@ module.exports = class InstitutionsService extends BasePrismaService {
     };
 
     if (this.currentTransaction) {
-      return processor(this);
+      return transaction(this);
     }
-    return InstitutionsService.$transaction(processor);
+    return InstitutionsService.$transaction(transaction);
   }
 
   /**

--- a/api/lib/entities/log.service.js
+++ b/api/lib/entities/log.service.js
@@ -1,4 +1,5 @@
 // @ts-check
+const BasePrismaService = require('./base-prisma.service');
 const logPrisma = require('../services/prisma/log');
 
 /* eslint-disable max-len */
@@ -10,45 +11,48 @@ const logPrisma = require('../services/prisma/log');
 /** @typedef {import('@prisma/client').Prisma.LogCreateArgs} LogCreateArgs */
 /* eslint-enable max-len */
 
-module.exports = class LogsService {
+module.exports = class LogsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<LogsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {LogCreateArgs} params
    * @returns {Promise<Log>}
    */
-  static create(params) {
-    return logPrisma.create(params);
+  create(params) {
+    return logPrisma.create(params, this.prisma);
   }
 
   /**
    * @param {LogFindManyArgs} params
    * @returns {Promise<Log[]>}
    */
-  static findMany(params) {
-    return logPrisma.findMany(params);
+  findMany(params) {
+    return logPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {LogFindUniqueArgs} params
    * @returns {Promise<Log | null>}
    */
-  static findUnique(params) {
-    return logPrisma.findUnique(params);
+  findUnique(params) {
+    return logPrisma.findUnique(params, this.prisma);
   }
 
   /**
    * @param {LogUpdateArgs} params
    * @returns {Promise<Log>}
    */
-  static update(params) {
-    return logPrisma.update(params);
+  update(params) {
+    return logPrisma.update(params, this.prisma);
   }
 
   /**
    * @param {LogUpsertArgs} params
    * @returns {Promise<Log>}
    */
-  static upsert(params) {
-    return logPrisma.upsert(params);
+  upsert(params) {
+    return logPrisma.upsert(params, this.prisma);
   }
 
   /**
@@ -57,7 +61,7 @@ module.exports = class LogsService {
    * @param {string} message - log message
    * @returns {Promise<Log>}
    */
-  static log(jobId, level, message) {
-    return logPrisma.log(jobId, level, message);
+  log(jobId, level, message) {
+    return logPrisma.log(jobId, level, message, this.prisma);
   }
 };

--- a/api/lib/entities/memberships.dto.js
+++ b/api/lib/entities/memberships.dto.js
@@ -35,7 +35,7 @@ const PERMISSIONS = Object.values(FEATURES).flatMap((feature) => Object.values(f
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   username: Joi.string().trim(),

--- a/api/lib/entities/memberships.service.js
+++ b/api/lib/entities/memberships.service.js
@@ -103,7 +103,7 @@ module.exports = class MembershipsService extends BasePrismaService {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     /** @param {MembershipsService} service */
-    const processor = async (service) => {
+    const transaction = async (service) => {
       const memberships = await service.findMany({});
 
       if (memberships.length === 0) { return null; }
@@ -125,8 +125,8 @@ module.exports = class MembershipsService extends BasePrismaService {
     };
 
     if (this.currentTransaction) {
-      return processor(this);
+      return transaction(this);
     }
-    return MembershipsService.$transaction(processor);
+    return MembershipsService.$transaction(transaction);
   }
 };

--- a/api/lib/entities/memberships.service.js
+++ b/api/lib/entities/memberships.service.js
@@ -1,6 +1,6 @@
 // @ts-check
+const BasePrismaService = require('./base-prisma.service');
 const membershipsPrisma = require('../services/prisma/memberships');
-const { triggerHooks } = require('../hooks/hookEmitter');
 
 /* eslint-disable max-len */
 /**
@@ -16,14 +16,17 @@ const { triggerHooks } = require('../hooks/hookEmitter');
  */
 /* eslint-enable max-len */
 
-module.exports = class MembershipsService {
+module.exports = class MembershipsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<MembershipsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {MembershipCreateArgs} params
    * @returns {Promise<Membership>}
    */
-  static async create(params) {
-    const membership = await membershipsPrisma.create(params);
-    triggerHooks('membership:upsert', membership);
+  async create(params) {
+    const membership = await membershipsPrisma.create(params, this.prisma);
+    this.triggerHooks('membership:upsert', membership);
     return membership;
   }
 
@@ -31,16 +34,16 @@ module.exports = class MembershipsService {
    * @param {MembershipFindManyArgs} params
    * @returns {Promise<Membership[]>}
    */
-  static findMany(params) {
-    return membershipsPrisma.findMany(params);
+  findMany(params) {
+    return membershipsPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {MembershipFindUniqueArgs} params
    * @returns {Promise<Membership | null>}
    */
-  static findUnique(params) {
-    return membershipsPrisma.findUnique(params);
+  findUnique(params) {
+    return membershipsPrisma.findUnique(params, this.prisma);
   }
 
   /**
@@ -49,17 +52,17 @@ module.exports = class MembershipsService {
    * @param {Object | null} includes
    * @returns {Promise<Membership | null>}
    */
-  static findByID(institutionId, username, includes = null) {
-    return membershipsPrisma.findByID(institutionId, username, includes);
+  findByID(institutionId, username, includes = null) {
+    return membershipsPrisma.findByID(institutionId, username, includes, this.prisma);
   }
 
   /**
    * @param {MembershipUpdateArgs} params
    * @returns {Promise<Membership>}
    */
-  static async update(params) {
-    const membership = await membershipsPrisma.update(params);
-    triggerHooks('membership:upsert', membership);
+  async update(params) {
+    const membership = await membershipsPrisma.update(params, this.prisma);
+    this.triggerHooks('membership:upsert', membership);
     return membership;
   }
 
@@ -67,9 +70,9 @@ module.exports = class MembershipsService {
    * @param {MembershipUpsertArgs} params
    * @returns {Promise<Membership>}
    */
-  static async upsert(params) {
-    const membership = await membershipsPrisma.upsert(params);
-    triggerHooks('membership:upsert', membership);
+  async upsert(params) {
+    const membership = await membershipsPrisma.upsert(params, this.prisma);
+    this.triggerHooks('membership:upsert', membership);
     return membership;
   }
 
@@ -77,8 +80,8 @@ module.exports = class MembershipsService {
    * @param {MembershipDeleteArgs} params
    * @returns {Promise<Membership | null>}
    */
-  static async delete(params) {
-    const result = await membershipsPrisma.remove(params);
+  async delete(params) {
+    const result = await membershipsPrisma.remove(params, this.prisma);
 
     if (!result) {
       return null;
@@ -86,9 +89,9 @@ module.exports = class MembershipsService {
 
     const { deleteResult, membership } = result;
 
-    triggerHooks('membership:delete', membership);
-    membership.repositoryPermissions.forEach((repoPerm) => { triggerHooks('repository_permission:delete', repoPerm); });
-    membership.spacePermissions.forEach((spacePerm) => { triggerHooks('space_permission:delete', spacePerm); });
+    this.triggerHooks('membership:delete', membership);
+    membership.repositoryPermissions.forEach((repoPerm) => { this.triggerHooks('repository_permission:delete', repoPerm); });
+    membership.spacePermissions.forEach((spacePerm) => { this.triggerHooks('space_permission:delete', spacePerm); });
 
     return deleteResult;
   }
@@ -96,24 +99,34 @@ module.exports = class MembershipsService {
   /**
    * @returns {Promise<Array<Membership> | null>}
    */
-  static async removeAll() {
+  async removeAll() {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
-    const memberships = await this.findMany({});
+    /** @param {MembershipsService} service */
+    const processor = async (service) => {
+      const memberships = await service.findMany({});
 
-    if (memberships.length === 0) { return null; }
+      if (memberships.length === 0) { return null; }
 
-    await Promise.all(memberships.map(async (membership) => {
-      await this.delete({
-        where: {
-          username_institutionId: {
-            username: membership.username,
-            institutionId: membership.institutionId,
-          },
-        },
-      });
-    }));
+      await Promise.all(
+        memberships.map(
+          (membership) => service.delete({
+            where: {
+              username_institutionId: {
+                username: membership.username,
+                institutionId: membership.institutionId,
+              },
+            },
+          }),
+        ),
+      );
 
-    return memberships;
+      return memberships;
+    };
+
+    if (this.currentTransaction) {
+      return processor(this);
+    }
+    return MembershipsService.$transaction(processor);
   }
 };

--- a/api/lib/entities/repositories.dto.js
+++ b/api/lib/entities/repositories.dto.js
@@ -8,7 +8,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   updatedAt: Joi.date(),

--- a/api/lib/entities/repositories.service.js
+++ b/api/lib/entities/repositories.service.js
@@ -133,7 +133,7 @@ module.exports = class RepositoriesService extends BasePrismaService {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     /** @param {RepositoriesService} service */
-    const processor = async (service) => {
+    const transaction = async (service) => {
       const repositories = await service.findMany({});
 
       if (repositories.length === 0) { return null; }
@@ -150,8 +150,8 @@ module.exports = class RepositoriesService extends BasePrismaService {
     };
 
     if (this.currentTransaction) {
-      return processor(this);
+      return transaction(this);
     }
-    return RepositoriesService.$transaction(processor);
+    return RepositoriesService.$transaction(transaction);
   }
 };

--- a/api/lib/entities/repository-permissions.dto.js
+++ b/api/lib/entities/repository-permissions.dto.js
@@ -9,7 +9,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   username: Joi.string().trim(),

--- a/api/lib/entities/repository-permissions.service.js
+++ b/api/lib/entities/repository-permissions.service.js
@@ -87,7 +87,7 @@ module.exports = class RepositoryPermissionsService extends BasePrismaService {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     /** * @param {RepositoryPermissionsService} service */
-    const processor = async (service) => {
+    const transaction = async (service) => {
       const permissions = await service.findMany({});
 
       if (permissions.length === 0) { return null; }
@@ -110,8 +110,8 @@ module.exports = class RepositoryPermissionsService extends BasePrismaService {
     };
 
     if (this.currentTransaction) {
-      return processor(this);
+      return transaction(this);
     }
-    return RepositoryPermissionsService.$transaction(processor);
+    return RepositoryPermissionsService.$transaction(transaction);
   }
 };

--- a/api/lib/entities/space-permissions.dto.js
+++ b/api/lib/entities/space-permissions.dto.js
@@ -9,7 +9,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   username: Joi.string().trim(),

--- a/api/lib/entities/space-permissions.service.js
+++ b/api/lib/entities/space-permissions.service.js
@@ -1,7 +1,7 @@
 // @ts-check
 
+const BasePrismaService = require('./base-prisma.service');
 const spacePermissionsPrisma = require('../services/prisma/space-permissions');
-const { triggerHooks } = require('../hooks/hookEmitter');
 
 /* eslint-disable max-len */
 /** @typedef {import('@prisma/client').SpacePermission} SpacePermission */
@@ -13,14 +13,17 @@ const { triggerHooks } = require('../hooks/hookEmitter');
 /** @typedef {import('@prisma/client').Prisma.SpacePermissionDeleteArgs} SpacePermissionDeleteArgs */
 /* eslint-enable max-len */
 
-module.exports = class SpacePermissionsService {
+module.exports = class SpacePermissionsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<SpacePermissionsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {SpacePermissionCreateArgs} params
    * @returns {Promise<SpacePermission>}
    */
-  static async create(params) {
-    const spacePermission = await spacePermissionsPrisma.create(params);
-    triggerHooks('space_permission:create', spacePermission);
+  async create(params) {
+    const spacePermission = await spacePermissionsPrisma.create(params, this.prisma);
+    this.triggerHooks('space_permission:create', spacePermission);
     return spacePermission;
   }
 
@@ -28,25 +31,25 @@ module.exports = class SpacePermissionsService {
    * @param {SpacePermissionFindManyArgs} params
    * @returns {Promise<SpacePermission[]>}
    */
-  static findMany(params) {
-    return spacePermissionsPrisma.findMany(params);
+  findMany(params) {
+    return spacePermissionsPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {SpacePermissionFindUniqueArgs} params
    * @returns {Promise<SpacePermission | null>}
    */
-  static findUnique(params) {
-    return spacePermissionsPrisma.findUnique(params);
+  findUnique(params) {
+    return spacePermissionsPrisma.findUnique(params, this.prisma);
   }
 
   /**
    * @param {SpacePermissionUpdateArgs} params
    * @returns {Promise<SpacePermission>}
    */
-  static async update(params) {
-    const spacePermission = await spacePermissionsPrisma.update(params);
-    triggerHooks('space_permission:update', spacePermission);
+  async update(params) {
+    const spacePermission = await spacePermissionsPrisma.update(params, this.prisma);
+    this.triggerHooks('space_permission:update', spacePermission);
     return spacePermission;
   }
 
@@ -54,9 +57,9 @@ module.exports = class SpacePermissionsService {
    * @param {SpacePermissionUpsertArgs} params
    * @returns {Promise<SpacePermission>}
    */
-  static async upsert(params) {
-    const spacePermission = await spacePermissionsPrisma.upsert(params);
-    triggerHooks('space_permission:upsert', spacePermission);
+  async upsert(params) {
+    const spacePermission = await spacePermissionsPrisma.upsert(params, this.prisma);
+    this.triggerHooks('space_permission:upsert', spacePermission);
     return spacePermission;
   }
 
@@ -64,9 +67,9 @@ module.exports = class SpacePermissionsService {
    * @param {SpacePermissionDeleteArgs} params
    * @returns {Promise<SpacePermission | null>}
    */
-  static async delete(params) {
-    const spacePermission = await spacePermissionsPrisma.remove(params);
-    triggerHooks('space_permission:delete', spacePermission);
+  async delete(params) {
+    const spacePermission = await spacePermissionsPrisma.remove(params, this.prisma);
+    this.triggerHooks('space_permission:delete', spacePermission);
     return spacePermission;
   }
 };

--- a/api/lib/entities/spaces.dto.js
+++ b/api/lib/entities/spaces.dto.js
@@ -8,7 +8,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   id: Joi.string().trim(),

--- a/api/lib/entities/spaces.service.js
+++ b/api/lib/entities/spaces.service.js
@@ -96,7 +96,7 @@ module.exports = class SpacesService extends BasePrismaService {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     /** @param {SpacesService} service */
-    const processor = async (service) => {
+    const transaction = async (service) => {
       const spaces = await service.findMany({});
 
       if (spaces.length === 0) { return null; }
@@ -115,8 +115,8 @@ module.exports = class SpacesService extends BasePrismaService {
     };
 
     if (this.currentTransaction) {
-      return processor(this);
+      return transaction(this);
     }
-    return SpacesService.$transaction(processor);
+    return SpacesService.$transaction(transaction);
   }
 };

--- a/api/lib/entities/step.service.js
+++ b/api/lib/entities/step.service.js
@@ -1,4 +1,5 @@
 // @ts-check
+const BasePrismaService = require('./base-prisma.service');
 const stepPrisma = require('../services/prisma/step');
 
 /* eslint-disable max-len */
@@ -10,44 +11,47 @@ const stepPrisma = require('../services/prisma/step');
 /** @typedef {import('@prisma/client').Prisma.StepCreateArgs} StepCreateArgs */
 /* eslint-enable max-len */
 
-module.exports = class StepsService {
+module.exports = class StepsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<StepsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {StepCreateArgs} params
    * @returns {Promise<Step>}
    */
-  static create(params) {
-    return stepPrisma.create(params);
+  create(params) {
+    return stepPrisma.create(params, this.prisma);
   }
 
   /**
    * @param {StepFindManyArgs} params
    * @returns {Promise<Step[]>}
    */
-  static findMany(params) {
-    return stepPrisma.findMany(params);
+  findMany(params) {
+    return stepPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {StepFindUniqueArgs} params
    * @returns {Promise<Step | null>}
    */
-  static findUnique(params) {
-    return stepPrisma.findUnique(params);
+  findUnique(params) {
+    return stepPrisma.findUnique(params, this.prisma);
   }
 
   /**
    * @param {StepUpdateArgs} params
    * @returns {Promise<Step>}
    */
-  static update(params) {
-    return stepPrisma.update(params);
+  update(params) {
+    return stepPrisma.update(params, this.prisma);
   }
 
   /**
    * @param {StepUpsertArgs} params
    * @returns {Promise<Step>}
    */
-  static upsert(params) {
-    return stepPrisma.upsert(params);
+  upsert(params) {
+    return stepPrisma.upsert(params, this.prisma);
   }
 };

--- a/api/lib/entities/sushi-credentials.dto.js
+++ b/api/lib/entities/sushi-credentials.dto.js
@@ -8,7 +8,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   id: Joi.string().trim(),

--- a/api/lib/entities/sushi-credentials.service.js
+++ b/api/lib/entities/sushi-credentials.service.js
@@ -1,4 +1,5 @@
 // @ts-check
+const BasePrismaService = require('./base-prisma.service');
 const sushiCredentialsPrisma = require('../services/prisma/sushi-credentials');
 
 /* eslint-disable max-len */
@@ -11,81 +12,94 @@ const sushiCredentialsPrisma = require('../services/prisma/sushi-credentials');
 /** @typedef {import('@prisma/client').Prisma.SushiCredentialsDeleteArgs} SushiCredentialsDeleteArgs */
 /* eslint-enable max-len */
 
-module.exports = class SushiCredentialsService {
+module.exports = class SushiCredentialsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<SushiCredentialsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {SushiCredentialsCreateArgs} params
    * @returns {Promise<SushiCredentials>}
    */
-  static create(params) {
-    return sushiCredentialsPrisma.create(params);
+  create(params) {
+    return sushiCredentialsPrisma.create(params, this.prisma);
   }
 
   /**
    * @param {SushiCredentialsFindManyArgs} params
    * @returns {Promise<SushiCredentials[]>}
    */
-  static findMany(params) {
-    return sushiCredentialsPrisma.findMany(params);
+  findMany(params) {
+    return sushiCredentialsPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {SushiCredentialsFindUniqueArgs} params
    * @returns {Promise<SushiCredentials | null>}
    */
-  static findUnique(params) {
-    return sushiCredentialsPrisma.findUnique(params);
+  findUnique(params) {
+    return sushiCredentialsPrisma.findUnique(params, this.prisma);
   }
 
   /**
    * @param {string} id
    * @returns {Promise<SushiCredentials | null>}
    */
-  static findByID(id) {
-    return sushiCredentialsPrisma.findByID(id);
+  findByID(id) {
+    return sushiCredentialsPrisma.findByID(id, this.prisma);
   }
 
   /**
    * @param {SushiCredentialsUpdateArgs} params
    * @returns {Promise<SushiCredentials>}
    */
-  static update(params) {
-    return sushiCredentialsPrisma.update(params);
+  update(params) {
+    return sushiCredentialsPrisma.update(params, this.prisma);
   }
 
   /**
    * @param {SushiCredentialsUpsertArgs} params
    * @returns {Promise<SushiCredentials>}
    */
-  static upsert(params) {
-    return sushiCredentialsPrisma.upsert(params);
+  upsert(params) {
+    return sushiCredentialsPrisma.upsert(params, this.prisma);
   }
 
   /**
    * @param {SushiCredentialsDeleteArgs} params
    * @returns {Promise<SushiCredentials | null>}
    */
-  static delete(params) {
-    return sushiCredentialsPrisma.remove(params);
+  delete(params) {
+    return sushiCredentialsPrisma.remove(params, this.prisma);
   }
 
   /**
    * @returns {Promise<Array<SushiCredentials> | null>}
    */
-  static async removeAll() {
+  async removeAll() {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
-    const sushiCredentials = await this.findMany({});
+    /** @param {SushiCredentialsService} service */
+    const processor = async (service) => {
+      const sushiCredentials = await service.findMany({});
 
-    if (sushiCredentials.length === 0) { return null; }
+      if (sushiCredentials.length === 0) { return null; }
 
-    await Promise.all(sushiCredentials.map(async (sushiCredential) => {
-      await this.delete({
-        where: {
-          id: sushiCredential.id,
-        },
-      });
-    }));
+      await Promise.all(
+        sushiCredentials.map(
+          (sushiCredential) => service.delete({
+            where: {
+              id: sushiCredential.id,
+            },
+          }),
+        ),
+      );
 
-    return sushiCredentials;
+      return sushiCredentials;
+    };
+
+    if (this.currentTransaction) {
+      return processor(this);
+    }
+    return SushiCredentialsService.$transaction(processor);
   }
 };

--- a/api/lib/entities/sushi-credentials.service.js
+++ b/api/lib/entities/sushi-credentials.service.js
@@ -79,7 +79,7 @@ module.exports = class SushiCredentialsService extends BasePrismaService {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     /** @param {SushiCredentialsService} service */
-    const processor = async (service) => {
+    const transaction = async (service) => {
       const sushiCredentials = await service.findMany({});
 
       if (sushiCredentials.length === 0) { return null; }
@@ -98,8 +98,8 @@ module.exports = class SushiCredentialsService extends BasePrismaService {
     };
 
     if (this.currentTransaction) {
-      return processor(this);
+      return transaction(this);
     }
-    return SushiCredentialsService.$transaction(processor);
+    return SushiCredentialsService.$transaction(transaction);
   }
 };

--- a/api/lib/entities/sushi-endpoints.dto.js
+++ b/api/lib/entities/sushi-endpoints.dto.js
@@ -9,7 +9,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   id: Joi.string().trim(),

--- a/api/lib/entities/sushi-endpoints.service.js
+++ b/api/lib/entities/sushi-endpoints.service.js
@@ -1,6 +1,6 @@
 // @ts-check
 const sushiEndpointsPrisma = require('../services/prisma/sushi-endpoints');
-const { triggerHooks } = require('../hooks/hookEmitter');
+const BasePrismaService = require('./base-prisma.service');
 
 /* eslint-disable max-len */
 /** @typedef {import('@prisma/client').SushiEndpoint} SushiEndpoint */
@@ -12,85 +12,103 @@ const { triggerHooks } = require('../hooks/hookEmitter');
 /** @typedef {import('@prisma/client').Prisma.SushiEndpointDeleteArgs} SushiEndpointDeleteArgs */
 /* eslint-enable max-len */
 
-module.exports = class SushiEndpointsService {
+module.exports = class SushiEndpointsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<SushiEndpointsService>} */
+  static $transaction = super.$transaction;
+
   /**
    * @param {SushiEndpointCreateArgs} params
    * @returns {Promise<SushiEndpoint>}
    */
-  static create(params) {
-    return sushiEndpointsPrisma.create(params);
+  create(params) {
+    return sushiEndpointsPrisma.create(params, this.prisma);
   }
 
   /**
    * @param {SushiEndpointFindManyArgs} params
    * @returns {Promise<SushiEndpoint[]>}
    */
-  static findMany(params) {
-    return sushiEndpointsPrisma.findMany(params);
+  findMany(params) {
+    return sushiEndpointsPrisma.findMany(params, this.prisma);
   }
 
   /**
    * @param {SushiEndpointFindUniqueArgs} params
    * @returns {Promise<SushiEndpoint | null>}
    */
-  static findUnique(params) {
-    return sushiEndpointsPrisma.findUnique(params);
+  findUnique(params) {
+    return sushiEndpointsPrisma.findUnique(params, this.prisma);
   }
 
   /**
    * @param {string} id
    * @returns {Promise<SushiEndpoint | null>}
    */
-  static findByID(id) {
-    return sushiEndpointsPrisma.findByID(id);
+  findByID(id) {
+    return sushiEndpointsPrisma.findByID(id, this.prisma);
   }
 
   /**
    * @param {SushiEndpointUpdateArgs} params
    * @returns {Promise<SushiEndpoint>}
    */
-  static update(params) {
-    return sushiEndpointsPrisma.update(params);
+  update(params) {
+    return sushiEndpointsPrisma.update(params, this.prisma);
   }
 
   /**
    * @param {SushiEndpointUpsertArgs} params
    * @returns {Promise<SushiEndpoint>}
    */
-  static upsert(params) {
-    return sushiEndpointsPrisma.upsert(params);
+  upsert(params) {
+    return sushiEndpointsPrisma.upsert(params, this.prisma);
   }
 
   /**
    * @param {SushiEndpointDeleteArgs} params
    * @returns {Promise<SushiEndpoint | null>}
    */
-  static async delete(params) {
-    const { deleteResult, deletedEndpoint } = await sushiEndpointsPrisma.remove(params);
+  async delete(params) {
+    const result = await sushiEndpointsPrisma.remove(params, this.prisma);
+    if (!result) {
+      return null;
+    }
 
-    triggerHooks('sushi_endpoint:delete', deletedEndpoint);
-    deletedEndpoint.credentials.forEach((credentials) => { triggerHooks('sushi_credentials:delete', credentials); });
+    const { deleteResult, deletedEndpoint } = result;
+
+    this.triggerHooks('sushi_endpoint:delete', deletedEndpoint);
+    deletedEndpoint.credentials.forEach((credentials) => { this.triggerHooks('sushi_credentials:delete', credentials); });
     return deleteResult;
   }
 
   /**
    * @returns {Promise<Array<SushiEndpoint> | null>}
    */
-  static async removeAll() {
+  async removeAll() {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
-    const sushiEndpoints = await this.findMany({});
+    /** @param {SushiEndpointsService} service */
+    const processor = async (service) => {
+      const sushiEndpoints = await service.findMany({});
 
-    if (sushiEndpoints.length === 0) { return null; }
+      if (sushiEndpoints.length === 0) { return null; }
 
-    await Promise.all(sushiEndpoints.map(async (sushiEndpoint) => {
-      await this.delete({
-        where: {
-          id: sushiEndpoint.id,
-        },
-      });
-    }));
+      await Promise.all(
+        sushiEndpoints.map(
+          (sushiEndpoint) => service.delete({
+            where: {
+              id: sushiEndpoint.id,
+            },
+          }),
+        ),
+      );
 
-    return sushiEndpoints;
+      return sushiEndpoints;
+    };
+
+    if (this.currentTransaction) {
+      return processor(this);
+    }
+    return SushiEndpointsService.$transaction(processor);
   }
 };

--- a/api/lib/entities/sushi-endpoints.service.js
+++ b/api/lib/entities/sushi-endpoints.service.js
@@ -88,7 +88,7 @@ module.exports = class SushiEndpointsService extends BasePrismaService {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     /** @param {SushiEndpointsService} service */
-    const processor = async (service) => {
+    const transaction = async (service) => {
       const sushiEndpoints = await service.findMany({});
 
       if (sushiEndpoints.length === 0) { return null; }
@@ -107,8 +107,8 @@ module.exports = class SushiEndpointsService extends BasePrismaService {
     };
 
     if (this.currentTransaction) {
-      return processor(this);
+      return transaction(this);
     }
-    return SushiEndpointsService.$transaction(processor);
+    return SushiEndpointsService.$transaction(transaction);
   }
 };

--- a/api/lib/entities/users.dto.js
+++ b/api/lib/entities/users.dto.js
@@ -9,7 +9,7 @@ const {
 
 /**
  * Base schema
- * @type import('joi').SchemaLike
+ * @type {import('joi').SchemaLike}
  */
 const schema = {
   username: Joi.string().min(1),

--- a/api/lib/entities/users.service.js
+++ b/api/lib/entities/users.service.js
@@ -142,7 +142,7 @@ module.exports = class UsersService extends BasePrismaService {
    * @returns {Promise<User>}
    */
   async acceptTerms(username) {
-    const user = usersPrisma.acceptTerms(username);
+    const user = await usersPrisma.acceptTerms(username);
     this.triggerHooks('user:update', user);
     return user;
   }

--- a/api/lib/entities/users.service.js
+++ b/api/lib/entities/users.service.js
@@ -2,9 +2,9 @@
 const config = require('config');
 const jwt = require('jsonwebtoken');
 const { addHours } = require('date-fns');
+const BasePrismaService = require('./base-prisma.service');
 const elasticUsers = require('../services/elastic/users');
 const usersPrisma = require('../services/prisma/users');
-const { triggerHooks } = require('../hooks/hookEmitter');
 
 const secret = config.get('auth.secret');
 const adminUsername = config.get('admin.username');
@@ -23,146 +23,7 @@ const passwordResetValidity = config.get('passwordResetValidity');
  */
 /* eslint-enable max-len */
 
-module.exports = class UsersService {
-  /**
-   * @returns {Promise<User>}
-   */
-  static async createAdmin() {
-    const username = config.get('admin.username');
-    const email = config.get('admin.email');
-    const fullName = config.get('admin.fullName');
-
-    const adminData = {
-      username,
-      email,
-      fullName,
-      isAdmin: true,
-      metadata: { acceptedTerms: true },
-    };
-
-    const admin = await usersPrisma.upsert({
-      where: { username },
-      update: adminData,
-      create: adminData,
-    });
-
-    triggerHooks('user:create-admin', admin);
-
-    return admin;
-  }
-
-  /**
-   * @param {UserCreateArgs} params
-   * @returns {Promise<User>}
-   */
-  static async create(params) {
-    const user = await usersPrisma.create(params);
-    triggerHooks('user:create', user);
-    return user;
-  }
-
-  /**
-   * @param {UserFindManyArgs} params
-   * @returns {Promise<User[]>}
-   */
-  static findMany(params) {
-    return usersPrisma.findMany(params);
-  }
-
-  /**
-   * @param {UserFindUniqueArgs} params
-   * @returns {Promise<User | null>}
-   */
-  static findUnique(params) {
-    return usersPrisma.findUnique(params);
-  }
-
-  /**
-   * @param {string} username
-   * @returns {Promise<User | null>}
-   */
-  static findByUsername(username) {
-    return usersPrisma.findUnique({ where: { username } });
-  }
-
-  /*
-   * @param {UserFindUniqueOrThrowArgs} params
-   * @returns {Promise<User>}
-   */
-  static findUniqueOrThrow(params) {
-    return usersPrisma.findUniqueOrThrow(params);
-  }
-
-  /**
-   * @param {string} domain
-   * @returns {Promise<{email: string}[]> | null}
-   */
-  static findEmailOfCorrespondentsWithDomain(domain) {
-    return usersPrisma.findEmailOfCorrespondentsWithDomain(domain);
-  }
-
-  /**
-   * @param {UserUpdateArgs} params
-   * @returns {Promise<User>}
-   */
-  static async update(params) {
-    // TODO manage role
-    const user = await usersPrisma.update(params);
-    triggerHooks('user:update', user);
-    return user;
-  }
-
-  /**
-   * Accept terms for user.
-   * @param {string} username - Username.
-   *
-   * @returns {Promise<User>}
-   */
-  static async acceptTerms(username) {
-    const user = usersPrisma.acceptTerms(username);
-    triggerHooks('user:update', user);
-    return user;
-  }
-
-  /**
-   * @param {UserUpsertArgs} params
-   * @returns {Promise<User>}
-   */
-  static async upsert(params) {
-    const user = await usersPrisma.upsert(params);
-    triggerHooks('user:upsert', user);
-    return user;
-  }
-
-  /**
-   * @param {UserDeleteArgs} params
-   * @returns {Promise<User | null>}
-   */
-  static async delete(params) {
-    const { deleteResult, deletedUser } = await usersPrisma.remove(params);
-
-    triggerHooks('user:delete', deletedUser);
-
-    deletedUser?.memberships?.forEach((element) => {
-      triggerHooks('memberships:delete', element);
-
-      element.repositoryPermissions.forEach((repoPerm) => { triggerHooks('repository_permission:delete', repoPerm); });
-      element.spacePermissions.forEach((spacePerm) => { triggerHooks('space_permission:delete', spacePerm); });
-    });
-
-    return deleteResult;
-  }
-
-  /**
-   * @param {string} username
-   * @returns {Promise<User | null>}
-   */
-  static removeByUsername(username) {
-    const deletedUser = usersPrisma.removeByUsername(username);
-    triggerHooks('user:delete', deletedUser);
-    return deletedUser;
-  }
-
+module.exports = class UsersService extends BasePrismaService {
   /**
    * @param {string} username
    * @param {string} password
@@ -170,19 +31,6 @@ module.exports = class UsersService {
    */
   static async updatePassword(username, password) {
     await elasticUsers.updatePassword(username, password);
-  }
-
-  /**
-   * @param {string} username
-   * @returns {Promise<string | null>}
-   */
-  static async generateToken(username) {
-    const user = await UsersService.findByUsername(username);
-    if (!user) {
-      // TODO throw ?
-      return null;
-    }
-    return jwt.sign({ username: user.username, email: user.email }, secret);
   }
 
   static async generateTokenForActivate(username) {
@@ -197,9 +45,169 @@ module.exports = class UsersService {
   }
 
   /**
+   * @returns {Promise<User>}
+   */
+  async createAdmin() {
+    const username = config.get('admin.username');
+    const email = config.get('admin.email');
+    const fullName = config.get('admin.fullName');
+
+    const adminData = {
+      username,
+      email,
+      fullName,
+      isAdmin: true,
+      metadata: { acceptedTerms: true },
+    };
+
+    const admin = await usersPrisma.upsert(
+      {
+        where: { username },
+        update: adminData,
+        create: adminData,
+      },
+      this.prisma,
+    );
+
+    this.triggerHooks('user:create-admin', admin);
+
+    return admin;
+  }
+
+  /**
+   * @param {UserCreateArgs} params
+   * @returns {Promise<User>}
+   */
+  async create(params) {
+    const user = await usersPrisma.create(params, this.prisma);
+    this.triggerHooks('user:create', user);
+    return user;
+  }
+
+  /**
+   * @param {UserFindManyArgs} params
+   * @returns {Promise<User[]>}
+   */
+  findMany(params) {
+    return usersPrisma.findMany(params, this.prisma);
+  }
+
+  /**
+   * @param {UserFindUniqueArgs} params
+   * @returns {Promise<User | null>}
+   */
+  findUnique(params) {
+    return usersPrisma.findUnique(params, this.prisma);
+  }
+
+  /**
+   * @param {string} username
+   * @returns {Promise<User | null>}
+   */
+  findByUsername(username) {
+    return usersPrisma.findUnique({ where: { username } }, this.prisma);
+  }
+
+  /**
+   * @param {UserFindUniqueOrThrowArgs} params
+   * @returns {Promise<User>}
+   */
+  findUniqueOrThrow(params) {
+    return usersPrisma.findUniqueOrThrow(params, this.prisma);
+  }
+
+  /**
+   * @param {string} domain
+   * @returns {Promise<{email: string}[]> | null}
+   */
+  findEmailOfCorrespondentsWithDomain(domain) {
+    return usersPrisma.findEmailOfCorrespondentsWithDomain(domain, this.prisma);
+  }
+
+  /**
+   * @param {UserUpdateArgs} params
+   * @returns {Promise<User>}
+   */
+  async update(params) {
+    // TODO manage role
+    const user = await usersPrisma.update(params, this.prisma);
+    this.triggerHooks('user:update', user);
+    return user;
+  }
+
+  /**
+   * Accept terms for user.
+   * @param {string} username - Username.
+   *
+   * @returns {Promise<User>}
+   */
+  async acceptTerms(username) {
+    const user = usersPrisma.acceptTerms(username);
+    this.triggerHooks('user:update', user);
+    return user;
+  }
+
+  /**
+   * @param {UserUpsertArgs} params
+   * @returns {Promise<User>}
+   */
+  async upsert(params) {
+    const user = await usersPrisma.upsert(params, this.prisma);
+    this.triggerHooks('user:upsert', user);
+    return user;
+  }
+
+  /**
+   * @param {UserDeleteArgs} params
+   * @returns {Promise<User | null>}
+   */
+  async delete(params) {
+    const result = await usersPrisma.remove(params, this.prisma);
+    if (!result) {
+      return null;
+    }
+
+    const { deleteResult, deletedUser } = result;
+
+    this.triggerHooks('user:delete', deletedUser);
+
+    deletedUser?.memberships?.forEach((element) => {
+      this.triggerHooks('memberships:delete', element);
+
+      element.repositoryPermissions.forEach((repoPerm) => { this.triggerHooks('repository_permission:delete', repoPerm); });
+      element.spacePermissions.forEach((spacePerm) => { this.triggerHooks('space_permission:delete', spacePerm); });
+    });
+
+    return deleteResult;
+  }
+
+  /**
+   * @param {string} username
+   * @returns {Promise<User | null>}
+   */
+  removeByUsername(username) {
+    const deletedUser = usersPrisma.removeByUsername(username);
+    this.triggerHooks('user:delete', deletedUser);
+    return deletedUser;
+  }
+
+  /**
+   * @param {string} username
+   * @returns {Promise<string | null>}
+   */
+  async generateToken(username) {
+    const user = await this.findByUsername(username);
+    if (!user) {
+      // TODO throw ?
+      return null;
+    }
+    return jwt.sign({ username: user.username, email: user.email }, secret);
+  }
+
+  /**
    * @returns {Promise<Array<User> | null>}
    */
-  static async removeAll() {
+  async removeAll() {
     if (process.env.NODE_ENV !== 'dev') { return null; }
 
     const users = await this.findMany({

--- a/api/lib/hooks/elastic/memberships.js
+++ b/api/lib/hooks/elastic/memberships.js
@@ -3,7 +3,7 @@ const { registerHook } = require('../hookEmitter');
 
 const { appLogger } = require('../../services/logger');
 
-const usersService = require('../../entities/users.service');
+const UsersService = require('../../entities/users.service');
 const { syncUser } = require('../../services/sync/elastic');
 
 /**
@@ -17,6 +17,7 @@ const { syncUser } = require('../../services/sync/elastic');
  * @returns {Promise<void>}
  */
 const onMembershipChange = async (membership) => {
+  const usersService = new UsersService();
   const user = await usersService.findUnique({
     where: {
       username: membership.username,

--- a/api/lib/hooks/elastic/space-permissions.js
+++ b/api/lib/hooks/elastic/space-permissions.js
@@ -3,7 +3,7 @@ const { registerHook } = require('../hookEmitter');
 
 const { appLogger } = require('../../services/logger');
 
-const usersService = require('../../entities/users.service');
+const UsersService = require('../../entities/users.service');
 const { syncUser } = require('../../services/sync/elastic');
 
 /**
@@ -16,6 +16,7 @@ const { syncUser } = require('../../services/sync/elastic');
  * @returns {Promise<void>}
  */
 const onSpacePermissionModified = async (permission) => {
+  const usersService = new UsersService();
   const user = await usersService.findUnique({
     where: {
       username: permission.username,

--- a/api/lib/hooks/hookEmitter.js
+++ b/api/lib/hooks/hookEmitter.js
@@ -56,7 +56,7 @@ const hookEmitter = new EventEmitter();
  * @param {string} event The event name
  * @param {*} payload The payload of the event
  *
- * @returns Returns `true` if the event had listeners, `false` otherwise.
+ * @returns {boolean} Returns `true` if the event had listeners, `false` otherwise.
  */
 const triggerHooks = (event, ...payload) => {
   appLogger.verbose(`[hooks] "${event}" triggered`);
@@ -73,7 +73,7 @@ const triggerHooks = (event, ...payload) => {
  * @param {(payload) => string | number} [opts.uniqueResolver]
  * @param {boolean} [opts.queue] Should the hook be queued
  *
- * @returns Returns a reference to the EventEmitter
+ * @returns {EventEmitter} Returns a reference to the EventEmitter
  */
 const registerHook = (event, handler, opts = {}) => {
   let fnc = (key, payload) => handler(payload);

--- a/api/lib/services/auth.js
+++ b/api/lib/services/auth.js
@@ -1,9 +1,9 @@
 const { auth } = require('config');
 const jwt = require('koa-jwt');
-const institutionsService = require('../entities/institutions.service');
-const sushiEndpointService = require('../entities/sushi-endpoints.service');
-const sushiCredentialsService = require('../entities/sushi-credentials.service');
-const usersService = require('../entities/users.service');
+const InstitutionsService = require('../entities/institutions.service');
+const SushiEndpointService = require('../entities/sushi-endpoints.service');
+const SushiCredentialsService = require('../entities/sushi-credentials.service');
+const UsersService = require('../entities/users.service');
 const RepositoriesService = require('../entities/repositories.service');
 const SpacesService = require('../entities/spaces.service');
 
@@ -24,6 +24,8 @@ const requireUser = async (ctx, next) => {
     ctx.throw(401, ctx.$t('errors.auth.noUsername'));
     return;
   }
+
+  const usersService = new UsersService();
 
   const user = await usersService.findUnique({ where: { username } });
 
@@ -103,7 +105,8 @@ function fetchModel(modelName, opts = {}) {
     };
 
     switch (modelName) {
-      case 'institution':
+      case 'institution': {
+        const institutionsService = new InstitutionsService();
         item = modelId && (await institutionsService.findUnique({
           where: { id: modelId },
           include: {
@@ -113,23 +116,32 @@ function fetchModel(modelName, opts = {}) {
           },
         }));
         break;
+      }
 
-      case 'sushi-endpoint':
+      case 'sushi-endpoint': {
+        const sushiEndpointService = new SushiEndpointService();
         item = modelId && await sushiEndpointService.findUnique(findOptions);
         break;
+      }
 
-      case 'sushi':
+      case 'sushi': {
+        const sushiCredentialsService = new SushiCredentialsService();
         item = modelId && await sushiCredentialsService.findUnique(findOptions);
         break;
+      }
 
-      case 'repository':
+      case 'repository': {
+        const repositoriesService = new RepositoriesService();
         findOptions.where = { pattern: modelId };
-        item = modelId && await RepositoriesService.findUnique(findOptions);
+        item = modelId && await repositoriesService.findUnique(findOptions);
         break;
+      }
 
-      case 'space':
-        item = modelId && await SpacesService.findUnique(findOptions);
+      case 'space': {
+        const spacesService = new SpacesService();
+        item = modelId && await spacesService.findUnique(findOptions);
         break;
+      }
 
       default:
     }

--- a/api/lib/services/images.js
+++ b/api/lib/services/images.js
@@ -12,7 +12,7 @@ module.exports = class ImagesService {
 
   /**
    * Remove a logo with a given ID
-   * @static
+   *
    * @param {String} logoId
    * @return {Promise}
    */
@@ -25,7 +25,6 @@ module.exports = class ImagesService {
   /**
    * Take a Base64 image, resize it and store it
    *
-   * @static
    * @param {String} base64logo
    */
   static async storeLogo(base64logo) {

--- a/api/lib/services/jobs.js
+++ b/api/lib/services/jobs.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { Queue, Worker } = require('bullmq');
 
 const { appLogger } = require('./logger');
-const harvestJobService = require('../entities/harvest-job.service');
+const HarvestJobService = require('../entities/harvest-job.service');
 
 const harvestConcurrency = Number.parseInt(config.get('jobs.harvest.concurrency'), 10);
 const redisConfig = config.get('redis');
@@ -20,9 +20,11 @@ const harvestWorker = new Worker('sushi-harvest', workerFile, {
 async function checkTask(taskId, jobId) {
   if (!taskId) { return; }
 
+  const harvestJobService = new HarvestJobService();
+
   const task = await harvestJobService.findUnique({ where: { id: taskId } });
 
-  if (!task || harvestJobService.isDone(task)) { return; }
+  if (!task || HarvestJobService.isDone(task)) { return; }
 
   appLogger.verbose(`${logPrefix} Job [${jobId}] stopped unexpectedly, setting task from status [${task.status}] to [failed]...`);
 

--- a/api/lib/services/prisma/actions.js
+++ b/api/lib/services/prisma/actions.js
@@ -2,52 +2,60 @@
 const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').Action} Action */
-/** @typedef {import('@prisma/client').Prisma.ActionUpdateArgs} ActionUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.ActionUpsertArgs} ActionUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.ActionFindUniqueArgs} ActionFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.ActionFindManyArgs} ActionFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.ActionCreateArgs} ActionCreateArgs */
+/**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('@prisma/client').Action} Action
+ * @typedef {import('@prisma/client').Prisma.ActionUpdateArgs} ActionUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.ActionUpsertArgs} ActionUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.ActionFindUniqueArgs} ActionFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.ActionFindManyArgs} ActionFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.ActionCreateArgs} ActionCreateArgs
+ */
 /* eslint-enable max-len */
 
 /**
  * @param {ActionCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Action>}
  */
-function create(params) {
-  return prisma.action.create(params);
+function create(params, tx = prisma) {
+  return tx.action.create(params);
 }
 
 /**
  * @param {ActionFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Action[]>}
  */
-function findMany(params) {
-  return prisma.action.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.action.findMany(params);
 }
 
 /**
  * @param {ActionFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Action | null>}
  */
-function findUnique(params) {
-  return prisma.action.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.action.findUnique(params);
 }
 
 /**
  * @param {ActionUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Action>}
  */
-function update(params) {
-  return prisma.action.update(params);
+function update(params, tx = prisma) {
+  return tx.action.update(params);
 }
 
 /**
  * @param {ActionUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Action>}
  */
-function upsert(params) {
-  return prisma.action.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.action.upsert(params);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/harvest-job.js
+++ b/api/lib/services/prisma/harvest-job.js
@@ -2,6 +2,7 @@
 const { client: prisma, Prisma } = require('./index');
 
 /* eslint-disable max-len */
+/** @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient */
 /** @typedef {import('@prisma/client').HarvestJob} HarvestJob */
 /** @typedef {import('@prisma/client').Prisma.HarvestJobUpdateArgs} HarvestJobUpdateArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestJobUpsertArgs} HarvestJobUpsertArgs */
@@ -10,85 +11,95 @@ const { client: prisma, Prisma } = require('./index');
 /** @typedef {import('@prisma/client').Prisma.HarvestJobFindUniqueArgs} HarvestJobFindUniqueArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestJobFindFirstArgs} HarvestJobFindFirstArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestJobFindManyArgs} HarvestJobFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestJobCountArgs} HarvestJobCountArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestJobGroupByArgs} HarvestJobGroupByArgs */
-/** @typedef {import('@prisma/client').Prisma.GetHarvestJobGroupByPayload<{ by: keyof HarvestJob }>} GetHarvestJobGroupByPayload */
+/** @typedef {import('@prisma/client').Prisma.HarvestJobAggregateArgs} HarvestJobAggregateArgs */
+/** @typedef {import('@prisma/client').Prisma.HarvestJobCountArgs} HarvestJobCountArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestJobCreateArgs} HarvestJobCreateArgs */
 /* eslint-enable max-len */
 
 /**
  * @param {HarvestJobCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<HarvestJob>}
  */
-function create(params) {
-  return prisma.harvestJob.create(params);
+function create(params, tx = prisma) {
+  return tx.harvestJob.create(params);
 }
 
 /**
  * @param {HarvestJobFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<HarvestJob[]>}
  */
-function findMany(params) {
-  return prisma.harvestJob.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.harvestJob.findMany(params);
 }
 
 /**
  * @param {HarvestJobFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<HarvestJob | null>}
  */
-function findUnique(params) {
-  return prisma.harvestJob.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.harvestJob.findUnique(params);
 }
 
 /**
  * @param {HarvestJobFindFirstArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<HarvestJob | null>}
  */
-function findFirst(params) {
-  return prisma.harvestJob.findFirst(params);
-}
-
-/**
- * @param {HarvestJobCountArgs} params
- * @returns {Promise<number>}
- */
-function count(params) {
-  return prisma.harvestJob.count(params);
+function findFirst(params, tx = prisma) {
+  return tx.harvestJob.findFirst(params);
 }
 
 /**
  * @param {HarvestJobGroupByArgs} params
- * @returns {Promise<GetHarvestJobGroupByPayload>}
+ * @param {TransactionClient} [tx]
+ * @returns
  */
-function groupBy(params) {
-  return prisma.harvestJob.groupBy(params);
+function groupBy(params, tx = prisma) {
+  // @ts-ignore
+  return tx.harvestJob.groupBy(params);
+}
+
+/**
+ * @param {HarvestJobCountArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<number>}
+ */
+function count(params, tx = prisma) {
+  return tx.harvestJob.count(params);
 }
 
 /**
  * @param {HarvestJobUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<HarvestJob>}
  */
-function update(params) {
-  return prisma.harvestJob.update(params);
+function update(params, tx = prisma) {
+  return tx.harvestJob.update(params);
 }
 
 /**
  * @param {HarvestJobUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<HarvestJob>}
  */
-function upsert(params) {
-  return prisma.harvestJob.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.harvestJob.upsert(params);
 }
 
 /**
  * @param {HarvestJobDeleteArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<HarvestJob | null>}
  */
-async function remove(params) {
+async function remove(params, tx = prisma) {
   let job;
 
   try {
-    job = await prisma.harvestJob.delete(params);
+    job = await tx.harvestJob.delete(params);
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       return null;
@@ -101,10 +112,11 @@ async function remove(params) {
 
 /**
  * @param {HarvestJobDeleteManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<{ count: number }>}
  */
-function removeMany(params) {
-  return prisma.harvestJob.deleteMany(params);
+function removeMany(params, tx = prisma) {
+  return tx.harvestJob.deleteMany(params);
 }
 
 /**
@@ -144,8 +156,8 @@ module.exports = {
   findMany,
   findUnique,
   findFirst,
-  count,
   groupBy,
+  count,
   update,
   upsert,
   remove,

--- a/api/lib/services/prisma/harvest.js
+++ b/api/lib/services/prisma/harvest.js
@@ -2,6 +2,7 @@
 const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
+/** @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient */
 /** @typedef {import('@prisma/client').Harvest} Harvest */
 /** @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs */
@@ -12,42 +13,47 @@ const { client: prisma } = require('./index');
 
 /**
  * @param {HarvestCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Harvest>}
  */
-function create(params) {
-  return prisma.harvest.create(params);
+function create(params, tx = prisma) {
+  return tx.harvest.create(params);
 }
 
 /**
  * @param {HarvestFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Harvest[]>}
  */
-function findMany(params) {
-  return prisma.harvest.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.harvest.findMany(params);
 }
 
 /**
  * @param {HarvestFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Harvest | null>}
  */
-function findUnique(params) {
-  return prisma.harvest.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.harvest.findUnique(params);
 }
 
 /**
  * @param {HarvestUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Harvest>}
  */
-function update(params) {
-  return prisma.harvest.update(params);
+function update(params, tx = prisma) {
+  return tx.harvest.update(params);
 }
 
 /**
  * @param {HarvestUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Harvest>}
  */
-function upsert(params) {
-  return prisma.harvest.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.harvest.upsert(params);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/institutions.js
+++ b/api/lib/services/prisma/institutions.js
@@ -163,7 +163,7 @@ function validate(id, tx = prisma) {
  */
 async function remove(params, tx) {
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const institution = await txx.institution.findUnique({
       where: params.where,
       include: {
@@ -214,9 +214,9 @@ async function remove(params, tx) {
 
   let transactionResult;
   if (tx) {
-    transactionResult = await processor(tx);
+    transactionResult = await transaction(tx);
   } else {
-    transactionResult = await prisma.$transaction(processor);
+    transactionResult = await prisma.$transaction(transaction);
   }
 
   return transactionResult;
@@ -230,7 +230,7 @@ async function removeAll(tx = prisma) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const institutions = await findMany({}, txx);
 
     if (institutions.length === 0) { return null; }
@@ -252,9 +252,9 @@ async function removeAll(tx = prisma) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 /**

--- a/api/lib/services/prisma/institutions.js
+++ b/api/lib/services/prisma/institutions.js
@@ -11,35 +11,46 @@ const {
 
 /* eslint-disable max-len */
 /**
- * @typedef {import('@prisma/client').Membership} Membership
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
  * @typedef {import('@prisma/client').Institution} Institution
- * @typedef {import('@prisma/client').Repository} Repository
  * @typedef {import('@prisma/client').Prisma.InstitutionUpdateArgs} InstitutionUpdateArgs
  * @typedef {import('@prisma/client').Prisma.InstitutionUpsertArgs} InstitutionUpsertArgs
  * @typedef {import('@prisma/client').Prisma.InstitutionFindUniqueArgs} InstitutionFindUniqueArgs
  * @typedef {import('@prisma/client').Prisma.InstitutionFindManyArgs} InstitutionFindManyArgs
  * @typedef {import('@prisma/client').Prisma.InstitutionCreateArgs} InstitutionCreateArgs
  * @typedef {import('@prisma/client').Prisma.InstitutionDeleteArgs} InstitutionDeleteArgs
- * @typedef {{deletedInstitution: Institution, deletedRepos: Repository[], institution: Institution }} InstitutionRemoved
- * @returns {Promise<RemoveInstitution | null>}
+ *
+ * @typedef {import('@prisma/client').Membership} Membership
+ * @typedef {import('@prisma/client').Repository} Repository
+ * @typedef {import('@prisma/client').Space} Space
+ * @typedef {import('@prisma/client').SushiCredentials} SushiCredentials
+ * @typedef {import('@prisma/client').RepositoryPermission} RepositoryPermission
+ * @typedef {import('@prisma/client').SpacePermission} SpacePermission
+ *
+ * @typedef {Repository & { institutions: Institution[] }} OldInstitutionRepository
+ * @typedef {Membership & { repositoryPermissions: RepositoryPermission[], spacePermissions: SpacePermission[] }} OldInstitutionMembership
+ * @typedef {Institution & { memberships: OldInstitutionMembership[], repositories: OldInstitutionRepository[], sushiCredentials: SushiCredentials[], spaces: Space[] }} OldInstitution
+ * @typedef {{deletedInstitution: Institution, deletedRepos: Repository[], institution: OldInstitution }} InstitutionRemoved
  */
 /* eslint-enable max-len */
 
 /**
  * @param {InstitutionCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution>}
  */
-function create(params) {
-  return prisma.institution.create(params);
+function create(params, tx = prisma) {
+  return tx.institution.create(params);
 }
 
 /**
  * @param {Institution} institution
  * @param {string} username
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution>}
  */
-function createAsUser(institution, username) {
-  return prisma.institution.create({
+function createAsUser(institution, username, tx = prisma) {
+  return tx.institution.create({
     data: {
       ...institution,
       social: institution.social || Prisma.DbNull,
@@ -62,33 +73,36 @@ function createAsUser(institution, username) {
 
 /**
  * @param {InstitutionFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution[]>}
  */
-function findMany(params) {
-  return prisma.institution.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.institution.findMany(params);
 }
 
 /**
  * @param {InstitutionFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution | null>}
  */
-function findUnique(params) {
-  return prisma.institution.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.institution.findUnique(params);
 }
 
 /**
  * @param {string} id
  * @param {Object | null} includes
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution | null>}
  */
-function findByID(id, includes = null) {
+function findByID(id, includes = null, tx = prisma) {
   let include;
   if (includes) {
     include = {
       ...includes,
     };
   }
-  return prisma.institution.findUnique({
+  return tx.institution.findUnique({
     where: { id },
     include,
   });
@@ -96,27 +110,30 @@ function findByID(id, includes = null) {
 
 /**
  * @param {InstitutionUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution>}
  */
-function update(params) {
-  return prisma.institution.update(params);
+function update(params, tx = prisma) {
+  return tx.institution.update(params);
 }
 
 /**
  * @param {InstitutionUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution>}
  */
-function upsert(params) {
-  return prisma.institution.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.institution.upsert(params);
 }
 
 /**
  * @param {string} institutionId
  * @param {string} subInstitutionId
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution>}
  */
-function addSubInstitution(institutionId, subInstitutionId) {
-  return prisma.institution.update({
+function addSubInstitution(institutionId, subInstitutionId, tx = prisma) {
+  return tx.institution.update({
     where: { id: institutionId },
     include: { childInstitutions: true },
     data: {
@@ -129,10 +146,11 @@ function addSubInstitution(institutionId, subInstitutionId) {
 
 /**
  * @param {string} id
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution>}
  */
-function validate(id) {
-  return prisma.institution.update({
+function validate(id, tx = prisma) {
+  return tx.institution.update({
     where: { id },
     data: { validated: true },
   });
@@ -140,11 +158,13 @@ function validate(id) {
 
 /**
  * @param {InstitutionDeleteArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<InstitutionRemoved | null>}
  */
-async function remove(params) {
-  const transactionResult = await prisma.$transaction(async (tx) => {
-    const institution = await tx.institution.findUnique({
+async function remove(params, tx) {
+  /** @param {TransactionClient} txx */
+  const processor = async (txx) => {
+    const institution = await txx.institution.findUnique({
       where: params.where,
       include: {
         memberships: {
@@ -164,22 +184,17 @@ async function remove(params) {
     }
 
     const deletedRepos = [];
-    const findArgs = { where: { institutionId: institution.id } };
-
-    await tx.repositoryPermission.deleteMany(findArgs);
-    await tx.spacePermission.deleteMany(findArgs);
-    await tx.membership.deleteMany(findArgs);
 
     await Promise.all(
       institution.repositories.map((r) => {
         // If last institution, delete repo
         if (r.institutions.length <= 1) {
           deletedRepos.push(r);
-          return tx.repository.delete({ where: { pattern: r.pattern } });
+          return txx.repository.delete({ where: { pattern: r.pattern } });
         }
 
         // Otherwise disconnect institution from repo
-        return tx.repository.update({
+        return txx.repository.update({
           where: { pattern: r.pattern },
           data: {
             institutions: {
@@ -189,50 +204,66 @@ async function remove(params) {
         });
       }),
     );
-    await tx.space.deleteMany(findArgs);
-
-    await tx.sushiCredentials.deleteMany(findArgs);
 
     return {
-      deletedInstitution: await tx.institution.delete(params),
+      deletedInstitution: await txx.institution.delete(params),
       deletedRepos,
       institution,
     };
-  });
+  };
 
-  if (!transactionResult) {
-    return null;
+  let transactionResult;
+  if (tx) {
+    transactionResult = await processor(tx);
+  } else {
+    transactionResult = await prisma.$transaction(processor);
   }
 
   return transactionResult;
 }
 
 /**
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Institution[] | null>}
  */
-async function removeAll() {
+async function removeAll(tx = prisma) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
-  const institutions = await findMany({});
+  /** @param {TransactionClient} txx */
+  const processor = async (txx) => {
+    const institutions = await findMany({}, txx);
 
-  if (institutions.length === 0) { return null; }
+    if (institutions.length === 0) { return null; }
 
-  await Promise.all(institutions.map(async (institution) => {
-    await remove({
-      where: {
-        id: institution.id,
-      },
-    });
-  }));
+    await Promise.all(
+      institutions.map(
+        (institution) => remove(
+          {
+            where: {
+              id: institution.id,
+            },
+          },
+          txx,
+        ),
+      ),
+    );
 
-  return institutions;
+    return institutions;
+  };
+
+  if (tx) {
+    return processor(tx);
+  }
+  return prisma.$transaction(processor);
 }
 
 /**
+ * @param {string} institutionId
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Membership[]>}
  */
-function getContacts(institutionId) {
-  return prisma.membership.findMany({
+function getContacts(institutionId, tx = prisma) {
+  return tx.membership.findMany({
     where: {
       institutionId,
       roles: {

--- a/api/lib/services/prisma/log.js
+++ b/api/lib/services/prisma/log.js
@@ -2,62 +2,71 @@
 const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').Log} Log */
-/** @typedef {import('@prisma/client').Prisma.LogUpdateArgs} LogUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.LogUpsertArgs} LogUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.LogFindUniqueArgs} LogFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.LogFindManyArgs} LogFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.LogCreateArgs} LogCreateArgs */
+/**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('@prisma/client').Log} Log
+ * @typedef {import('@prisma/client').Prisma.LogUpdateArgs} LogUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.LogUpsertArgs} LogUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.LogFindUniqueArgs} LogFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.LogFindManyArgs} LogFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.LogCreateArgs} LogCreateArgs
+ */
 /* eslint-enable max-len */
 
 /**
  * @param {LogCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Log>}
  */
-function create(params) {
-  return prisma.log.create(params);
+function create(params, tx = prisma) {
+  return tx.log.create(params);
 }
 
 /**
  * @param {LogFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Log[]>}
  */
-function findMany(params) {
-  return prisma.log.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.log.findMany(params);
 }
 
 /**
  * @param {LogFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Log | null>}
  */
-function findUnique(params) {
-  return prisma.log.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.log.findUnique(params);
 }
 
 /**
  * @param {LogUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Log>}
  */
-function update(params) {
-  return prisma.log.update(params);
+function update(params, tx = prisma) {
+  return tx.log.update(params);
 }
 
 /**
  * @param {LogUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Log>}
  */
-function upsert(params) {
-  return prisma.log.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.log.upsert(params);
 }
 
 /**
  * @param {string} jobId - identifier of the associated harvest job
  * @param {string} level - log level
  * @param {string} message - log message
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Log>}
  */
-function log(jobId, level, message) {
-  return prisma.log.create({ data: { jobId, level, message } });
+function log(jobId, level, message, tx = prisma) {
+  return tx.log.create({ data: { jobId, level, message } });
 }
 
 module.exports = {

--- a/api/lib/services/prisma/memberships.js
+++ b/api/lib/services/prisma/memberships.js
@@ -99,7 +99,7 @@ function upsert(params, tx = prisma) {
  */
 async function remove(params, tx = prisma) {
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const membership = await txx.membership.findUnique({
       where: params.where,
       include: {
@@ -120,9 +120,9 @@ async function remove(params, tx = prisma) {
 
   let transactionResult;
   if (tx) {
-    transactionResult = await processor(tx);
+    transactionResult = await transaction(tx);
   } else {
-    transactionResult = await prisma.$transaction(processor);
+    transactionResult = await prisma.$transaction(transaction);
   }
 
   return transactionResult;
@@ -136,7 +136,7 @@ async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const memberships = await findMany({}, txx);
 
     if (memberships.length === 0) { return null; }
@@ -159,9 +159,9 @@ async function removeAll(tx) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/repositories.js
+++ b/api/lib/services/prisma/repositories.js
@@ -107,7 +107,7 @@ function connectInstitution(pattern, institutionId, tx = prisma) {
  */
 async function disconnectInstitution(pattern, institutionId, tx) {
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const currentRepository = await txx.repository.findUnique({
       where: { pattern },
       include: {
@@ -146,9 +146,9 @@ async function disconnectInstitution(pattern, institutionId, tx) {
 
   let transactionResult;
   if (tx) {
-    transactionResult = await processor(tx);
+    transactionResult = await transaction(tx);
   } else {
-    transactionResult = await prisma.$transaction(processor);
+    transactionResult = await prisma.$transaction(transaction);
   }
 
   return transactionResult;
@@ -186,7 +186,7 @@ async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const repositories = await findMany({}, txx);
 
     if (repositories.length === 0) { return null; }
@@ -202,9 +202,9 @@ async function removeAll(tx) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/repositories.js
+++ b/api/lib/services/prisma/repositories.js
@@ -3,6 +3,7 @@ const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
 /**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
  * @typedef {import('@prisma/client').Repository} Repository
  * @typedef {import('@prisma/client').Prisma.RepositoryUpdateArgs} RepositoryUpdateArgs
  * @typedef {import('@prisma/client').Prisma.RepositoryUpsertArgs} RepositoryUpsertArgs
@@ -14,8 +15,8 @@ const { client: prisma } = require('./index');
  *
  * @typedef {import('@prisma/client').RepositoryPermission} RepositoryPermission
  * @typedef {import('@prisma/client').Institution} Institution
- * @typedef {Repository & { permissions: RepositoryPermission[], institutions: Institution[] }} OldRepository
  *
+ * @typedef {Repository & { permissions: RepositoryPermission[], institutions: Institution[] }} OldRepository
  * @typedef {{deleteResult: Repository, deletedRepository: OldRepository }} RepositoryRemoved
  * @typedef {{newRepository: Repository, oldRepository: OldRepository }} RepositoryUpdated
  */
@@ -23,67 +24,75 @@ const { client: prisma } = require('./index');
 
 /**
  * @param {RepositoryCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Repository>}
  */
-function create(params) {
-  return prisma.repository.create(params);
+function create(params, tx = prisma) {
+  return tx.repository.create(params);
 }
 
 /**
  * @param {RepositoryFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Repository[]>}
  */
-function findMany(params) {
-  return prisma.repository.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.repository.findMany(params);
 }
 
 /**
  * @param {RepositoryFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Repository | null>}
  */
-function findUnique(params) {
-  return prisma.repository.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.repository.findUnique(params);
 }
 
 /**
  * @param {RepositoryFindFirstArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Repository | null>}
  */
-function findFirst(params) {
-  return prisma.repository.findFirst(params);
+function findFirst(params, tx = prisma) {
+  return tx.repository.findFirst(params);
 }
 
 /**
  * @param {string} pattern
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Repository | null>}
  */
-function findByPattern(pattern) {
-  return prisma.repository.findUnique({ where: { pattern } });
+function findByPattern(pattern, tx = prisma) {
+  return tx.repository.findUnique({ where: { pattern } });
 }
 
 /**
  * @param {RepositoryUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Repository>}
  */
-function update(params) {
-  return prisma.repository.update(params);
+function update(params, tx = prisma) {
+  return tx.repository.update(params);
 }
 
 /**
  * @param {RepositoryUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Repository>}
  */
-function upsert(params) {
-  return prisma.repository.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.repository.upsert(params);
 }
 
 /**
  *
  * @param {string} pattern
  * @param {string} institutionId
+ * @param {TransactionClient} [tx]
  */
-function connectInstitution(pattern, institutionId) {
-  return prisma.repository.update({
+function connectInstitution(pattern, institutionId, tx = prisma) {
+  return tx.repository.update({
     where: { pattern },
     data: { institutions: { connect: { id: institutionId } } },
   });
@@ -93,11 +102,13 @@ function connectInstitution(pattern, institutionId) {
  * Disconnect a repository from an institution and remove all associated permissions
  * @param {string} pattern
  * @param {string} institutionId
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryUpdated | null>}
  */
-async function disconnectInstitution(pattern, institutionId) {
-  const transactionResult = await prisma.$transaction(async (tx) => {
-    const currentRepository = await tx.repository.findUnique({
+async function disconnectInstitution(pattern, institutionId, tx) {
+  /** @param {TransactionClient} txx */
+  const processor = async (txx) => {
+    const currentRepository = await txx.repository.findUnique({
       where: { pattern },
       include: {
         permissions: { where: { institutionId } },
@@ -109,14 +120,14 @@ async function disconnectInstitution(pattern, institutionId) {
       return null;
     }
 
-    await tx.repositoryPermission.deleteMany({
+    await txx.repositoryPermission.deleteMany({
       where: {
         repositoryPattern: currentRepository.pattern,
         institutionId,
       },
     });
 
-    const updatedRepository = await tx.repository.update({
+    const updatedRepository = await txx.repository.update({
       where: { pattern },
       data: {
         institutions: {
@@ -131,70 +142,69 @@ async function disconnectInstitution(pattern, institutionId) {
       newRepository: updatedRepository,
       oldRepository: currentRepository,
     };
-  });
+  };
 
-  if (!transactionResult) {
-    return null;
+  let transactionResult;
+  if (tx) {
+    transactionResult = await processor(tx);
+  } else {
+    transactionResult = await prisma.$transaction(processor);
   }
+
   return transactionResult;
 }
 
 /**
  * @param {RepositoryDeleteArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryRemoved | null>}
  */
-async function remove(params) {
-  const transactionResult = await prisma.$transaction(async (tx) => {
-    const repository = await tx.repository.findUnique({
-      where: params.where,
-      include: {
-        permissions: true,
-        institutions: true,
-      },
-    });
-
-    if (!repository) {
-      return null;
-    }
-
-    await tx.repositoryPermission.deleteMany({
-      where: {
-        repositoryPattern: repository.pattern,
-      },
-    });
-
-    return {
-      deleteResult: await tx.repository.delete(params),
-      deletedRepository: repository,
-    };
+async function remove(params, tx = prisma) {
+  const repository = await tx.repository.findUnique({
+    where: params.where,
+    include: {
+      permissions: true,
+      institutions: true,
+    },
   });
 
-  if (!transactionResult) {
+  if (!repository) {
     return null;
   }
 
-  return transactionResult;
+  return {
+    deleteResult: await tx.repository.delete(params),
+    deletedRepository: repository,
+  };
 }
 
 /**
- * @returns {Promise<Array<Repository> | null>}
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Repository[] | null>}
  */
-async function removeAll() {
+async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
-  const repositories = await findMany({});
+  /** @param {TransactionClient} txx */
+  const processor = async (txx) => {
+    const repositories = await findMany({}, txx);
 
-  if (repositories.length === 0) { return null; }
+    if (repositories.length === 0) { return null; }
 
-  await Promise.all(repositories.map(async (repository) => {
-    await remove({
-      where: {
-        pattern: repository.pattern,
-      },
-    });
-  }));
+    await Promise.all(
+      repositories.map((repository) => remove(
+        { where: { pattern: repository.pattern } },
+        txx,
+      )),
+    );
 
-  return repositories;
+    return repositories;
+  };
+
+  if (tx) {
+    return processor(tx);
+  }
+  return prisma.$transaction(processor);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/repository-permissions.js
+++ b/api/lib/services/prisma/repository-permissions.js
@@ -2,47 +2,54 @@
 const { client: prisma, Prisma } = require('./index');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').RepositoryPermission} RepositoryPermission */
-/** @typedef {import('@prisma/client').Prisma.RepositoryPermissionUpdateArgs} RepositoryPermissionUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.RepositoryPermissionUpsertArgs} RepositoryPermissionUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.RepositoryPermissionFindUniqueArgs} RepositoryPermissionFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.RepositoryPermissionFindManyArgs} RepositoryPermissionFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.RepositoryPermissionCreateArgs} RepositoryPermissionCreateArgs */
-/** @typedef {import('@prisma/client').Prisma.RepositoryPermissionDeleteArgs} RepositoryPermissionDeleteArgs */
+/**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('@prisma/client').RepositoryPermission} RepositoryPermission
+ * @typedef {import('@prisma/client').Prisma.RepositoryPermissionUpdateArgs} RepositoryPermissionUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.RepositoryPermissionUpsertArgs} RepositoryPermissionUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.RepositoryPermissionFindUniqueArgs} RepositoryPermissionFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.RepositoryPermissionFindManyArgs} RepositoryPermissionFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.RepositoryPermissionCreateArgs} RepositoryPermissionCreateArgs
+ * @typedef {import('@prisma/client').Prisma.RepositoryPermissionDeleteArgs} RepositoryPermissionDeleteArgs
+ */
 /* eslint-enable max-len */
 
 /**
  * @param {RepositoryPermissionCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryPermission>}
  */
-function create(params) {
-  return prisma.repositoryPermission.create(params);
+function create(params, tx = prisma) {
+  return tx.repositoryPermission.create(params);
 }
 
 /**
  * @param {RepositoryPermissionFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryPermission[]>}
  */
-function findMany(params) {
-  return prisma.repositoryPermission.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.repositoryPermission.findMany(params);
 }
 
 /**
  * @param {RepositoryPermissionFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryPermission | null>}
  */
-function findUnique(params) {
-  return prisma.repositoryPermission.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.repositoryPermission.findUnique(params);
 }
 
 /**
  * @param {string} institutionId
  * @param {string} pattern
  * @param {string} username
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryPermission | null>}
  */
-function findById(institutionId, pattern, username) {
-  return prisma.repositoryPermission.findUnique({
+function findById(institutionId, pattern, username, tx = prisma) {
+  return tx.repositoryPermission.findUnique({
     where: {
       username_institutionId_repositoryPattern: {
         username,
@@ -55,28 +62,31 @@ function findById(institutionId, pattern, username) {
 
 /**
  * @param {RepositoryPermissionUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryPermission>}
  */
-function update(params) {
-  return prisma.repositoryPermission.update(params);
+function update(params, tx = prisma) {
+  return tx.repositoryPermission.update(params);
 }
 
 /**
  * @param {RepositoryPermissionUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryPermission>}
  */
-function upsert(params) {
-  return prisma.repositoryPermission.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.repositoryPermission.upsert(params);
 }
 
 /**
  * @param {RepositoryPermissionDeleteArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<RepositoryPermission | null>}
  */
-async function remove(params) {
+async function remove(params, tx = prisma) {
   let permission;
   try {
-    permission = await prisma.repositoryPermission.delete(params);
+    permission = await tx.repositoryPermission.delete(params);
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       return null;
@@ -87,26 +97,43 @@ async function remove(params) {
   return permission;
 }
 
-async function removeAll() {
+/**
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<RepositoryPermission[] | null>}
+ */
+async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
-  const permissions = await findMany({});
+  /** @param {TransactionClient} txx */
+  const processor = async (txx) => {
+    const permissions = await findMany({}, txx);
 
-  if (permissions.length === 0) { return null; }
+    if (permissions.length === 0) { return null; }
 
-  await Promise.all(permissions.map(async (permission) => {
-    await remove({
-      where: {
-        username_institutionId_repositoryPattern: {
-          username: permission.username,
-          institutionId: permission.institutionId,
-          repositoryPattern: permission.repositoryPattern,
-        },
-      },
-    });
-  }));
+    await Promise.all(
+      permissions.map(
+        (permission) => remove(
+          {
+            where: {
+              username_institutionId_repositoryPattern: {
+                username: permission.username,
+                institutionId: permission.institutionId,
+                repositoryPattern: permission.repositoryPattern,
+              },
+            },
+          },
+          txx,
+        ),
+      ),
+    );
 
-  return permissions;
+    return permissions;
+  };
+
+  if (tx) {
+    return processor(tx);
+  }
+  return prisma.$transaction(processor);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/repository-permissions.js
+++ b/api/lib/services/prisma/repository-permissions.js
@@ -105,7 +105,7 @@ async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const permissions = await findMany({}, txx);
 
     if (permissions.length === 0) { return null; }
@@ -131,9 +131,9 @@ async function removeAll(tx) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/space-permissions.js
+++ b/api/lib/services/prisma/space-permissions.js
@@ -2,6 +2,7 @@
 const { client: prisma, Prisma } = require('./index');
 
 /* eslint-disable max-len */
+/** @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient */
 /** @typedef {import('@prisma/client').SpacePermission} SpacePermission */
 /** @typedef {import('@prisma/client').Prisma.SpacePermissionUpdateArgs} SpacePermissionUpdateArgs */
 /** @typedef {import('@prisma/client').Prisma.SpacePermissionUpsertArgs} SpacePermissionUpsertArgs */
@@ -13,53 +14,59 @@ const { client: prisma, Prisma } = require('./index');
 
 /**
  * @param {SpacePermissionCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SpacePermission>}
  */
-function create(params) {
-  return prisma.spacePermission.create(params);
+function create(params, tx = prisma) {
+  return tx.spacePermission.create(params);
 }
 
 /**
  * @param {SpacePermissionFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SpacePermission[]>}
  */
-function findMany(params) {
-  return prisma.spacePermission.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.spacePermission.findMany(params);
 }
 
 /**
  * @param {SpacePermissionFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SpacePermission | null>}
  */
-function findUnique(params) {
-  return prisma.spacePermission.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.spacePermission.findUnique(params);
 }
 
 /**
  * @param {SpacePermissionUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SpacePermission>}
  */
-function update(params) {
-  return prisma.spacePermission.update(params);
+function update(params, tx = prisma) {
+  return tx.spacePermission.update(params);
 }
 
 /**
  * @param {SpacePermissionUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SpacePermission>}
  */
-function upsert(params) {
-  return prisma.spacePermission.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.spacePermission.upsert(params);
 }
 
 /**
  * @param {SpacePermissionDeleteArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SpacePermission | null>}
  */
-async function remove(params) {
+async function remove(params, tx = prisma) {
   let spacePermission;
 
   try {
-    spacePermission = await prisma.spacePermission.delete(params);
+    spacePermission = await tx.spacePermission.delete(params);
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
       return null;

--- a/api/lib/services/prisma/spaces.js
+++ b/api/lib/services/prisma/spaces.js
@@ -3,6 +3,7 @@ const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
 /**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
  * @typedef {import('@prisma/client').Space} Space
  * @typedef {import('@prisma/client').Prisma.SpaceUpdateArgs} SpaceUpdateArgs
  * @typedef {import('@prisma/client').Prisma.SpaceUpsertArgs} SpaceUpsertArgs
@@ -11,111 +12,124 @@ const { client: prisma } = require('./index');
  * @typedef {import('@prisma/client').Prisma.SpaceCreateArgs} SpaceCreateArgs
  * @typedef {import('@prisma/client').Prisma.SpaceDeleteArgs} SpaceDeleteArgs
  * @typedef {import('@prisma/client').Prisma.SpacePermissionDeleteManyArgs} SpacePermissionDeleteManyArgs
- * @typedef {{deleteResult: Space, deletedSpace: Space }} SpaceRemoved
+ *
+ * @typedef {import('@prisma/client').SpacePermission} SpacePermission
+ *
+ * @typedef {import('@prisma/client').Space & { permissions: SpacePermission[] }} OldSpace
+ * @typedef {{deleteResult: Space, deletedSpace: OldSpace }} SpaceRemoved
  */
 /* eslint-enable max-len */
 
 /**
-   * @param {SpaceCreateArgs} params
-   * @returns {Promise<Space>}
-   */
-function create(params) {
-  return prisma.space.create(params);
+ * @param {SpaceCreateArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Space>}
+ */
+function create(params, tx = prisma) {
+  return tx.space.create(params);
 }
 
 /**
-   * @param {SpaceFindManyArgs} params
-   * @returns {Promise<Space[]>}
-   */
-function findMany(params) {
-  return prisma.space.findMany(params);
+ * @param {SpaceFindManyArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Space[]>}
+ */
+function findMany(params, tx = prisma) {
+  return tx.space.findMany(params);
 }
 
 /**
-   * @param {SpaceFindUniqueArgs} params
-   * @returns {Promise<Space | null>}
-   */
-function findUnique(params) {
-  return prisma.space.findUnique(params);
+ * @param {SpaceFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Space | null>}
+ */
+function findUnique(params, tx = prisma) {
+  return tx.space.findUnique(params);
 }
 
 /**
-   * @param {string} id
-   * @returns {Promise<Space | null>}
-   */
-function findByID(id) {
-  return prisma.space.findUnique({ where: { id } });
+ * @param {string} id
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Space | null>}
+ */
+function findByID(id, tx = prisma) {
+  return tx.space.findUnique({ where: { id } });
 }
 
 /**
-   * @param {SpaceUpdateArgs} params
-   * @returns {Promise<Space>}
-   */
-function update(params) {
-  return prisma.space.update(params);
+ * @param {SpaceUpdateArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Space>}
+ */
+function update(params, tx = prisma) {
+  return tx.space.update(params);
 }
 
 /**
-   * @param {SpaceUpsertArgs} params
-   * @returns {Promise<Space>}
-   */
-function upsert(params) {
-  return prisma.space.upsert(params);
+ * @param {SpaceUpsertArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Space>}
+ */
+function upsert(params, tx = prisma) {
+  return tx.space.upsert(params);
 }
 
 /**
-   * @param {SpaceDeleteArgs} params
-   * @returns {Promise<SpaceRemoved | null>}
-   */
-async function remove(params) {
-  const { deleteResult, deletedSpace } = await prisma.$transaction(async (tx) => {
-    const space = await tx.space.findUnique({
-      where: params.where,
-      include: {
-        permissions: true,
-      },
-    });
-
-    if (!space) {
-      return [null, null];
-    }
-
-    await tx.spacePermission.deleteMany({
-      where: { spaceId: space.id },
-    });
-
-    return {
-      deleteResult: await tx.space.delete(params),
-      deletedSpace: space,
-    };
+ * @param {SpaceDeleteArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SpaceRemoved | null>}
+ */
+async function remove(params, tx = prisma) {
+  const space = await tx.space.findUnique({
+    where: params.where,
+    include: {
+      permissions: true,
+    },
   });
 
-  if (!deletedSpace) {
+  if (!space) {
     return null;
   }
 
-  return { deleteResult, deletedSpace };
+  return {
+    deleteResult: await tx.space.delete(params),
+    deletedSpace: space,
+  };
 }
 
 /**
-   * @returns {Promise<Array<Space> | null>}
-   */
-async function removeAll() {
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Array<Space> | null>}
+ */
+async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
-  const spaces = await findMany({});
+  /** @param {TransactionClient} txx */
+  const processor = async (txx) => {
+    const spaces = await findMany({}, txx);
 
-  if (spaces.length === 0) { return null; }
+    if (spaces.length === 0) { return null; }
 
-  await Promise.all(spaces.map(async (space) => {
-    await remove({
-      where: {
-        id: space.id,
-      },
-    });
-  }));
+    await Promise.all(
+      spaces.map(
+        (space) => remove(
+          {
+            where: {
+              id: space.id,
+            },
+          },
+          txx,
+        ),
+      ),
+    );
 
-  return spaces;
+    return spaces;
+  };
+
+  if (tx) {
+    return processor(tx);
+  }
+  return prisma.$transaction(processor);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/spaces.js
+++ b/api/lib/services/prisma/spaces.js
@@ -105,7 +105,7 @@ async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const spaces = await findMany({}, txx);
 
     if (spaces.length === 0) { return null; }
@@ -127,9 +127,9 @@ async function removeAll(tx) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/step.js
+++ b/api/lib/services/prisma/step.js
@@ -2,52 +2,60 @@
 const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').Step} Step */
-/** @typedef {import('@prisma/client').Prisma.StepUpdateArgs} StepUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.StepUpsertArgs} StepUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.StepFindUniqueArgs} StepFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.StepFindManyArgs} StepFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.StepCreateArgs} StepCreateArgs */
+/**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('@prisma/client').Step} Step
+ * @typedef {import('@prisma/client').Prisma.StepUpdateArgs} StepUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.StepUpsertArgs} StepUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.StepFindUniqueArgs} StepFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.StepFindManyArgs} StepFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.StepCreateArgs} StepCreateArgs
+ */
 /* eslint-enable max-len */
 
 /**
  * @param {StepCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Step>}
  */
-function create(params) {
-  return prisma.step.create(params);
+function create(params, tx = prisma) {
+  return tx.step.create(params);
 }
 
 /**
  * @param {StepFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Step[]>}
  */
-function findMany(params) {
-  return prisma.step.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.step.findMany(params);
 }
 
 /**
  * @param {StepFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Step | null>}
  */
-function findUnique(params) {
-  return prisma.step.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.step.findUnique(params);
 }
 
 /**
  * @param {StepUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Step>}
  */
-function update(params) {
-  return prisma.step.update(params);
+function update(params, tx = prisma) {
+  return tx.step.update(params);
 }
 
 /**
  * @param {StepUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Step>}
  */
-function upsert(params) {
-  return prisma.step.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.step.upsert(params);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/sushi-credentials.js
+++ b/api/lib/services/prisma/sushi-credentials.js
@@ -88,7 +88,7 @@ async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const sushiCredentials = await findMany({}, txx);
 
     if (sushiCredentials.length === 0) { return null; }
@@ -104,9 +104,9 @@ async function removeAll(tx) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/sushi-endpoints.js
+++ b/api/lib/services/prisma/sushi-endpoints.js
@@ -102,7 +102,7 @@ async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
   /** @param {TransactionClient} txx */
-  const processor = async (txx) => {
+  const transaction = async (txx) => {
     const sushiEndpoints = await findMany({}, txx);
 
     if (sushiEndpoints.length === 0) { return null; }
@@ -118,9 +118,9 @@ async function removeAll(tx) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/sushi-endpoints.js
+++ b/api/lib/services/prisma/sushi-endpoints.js
@@ -3,119 +3,124 @@ const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
 /**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
  * @typedef {import('@prisma/client').SushiEndpoint} SushiEndpoint
+ * @typedef {import('@prisma/client').SushiCredentials} SushiCredentials
  * @typedef {import('@prisma/client').Prisma.SushiEndpointUpdateArgs} SushiEndpointUpdateArgs
  * @typedef {import('@prisma/client').Prisma.SushiEndpointUpsertArgs} SushiEndpointUpsertArgs
  * @typedef {import('@prisma/client').Prisma.SushiEndpointFindUniqueArgs} SushiEndpointFindUniqueArgs
  * @typedef {import('@prisma/client').Prisma.SushiEndpointFindManyArgs} SushiEndpointFindManyArgs
  * @typedef {import('@prisma/client').Prisma.SushiEndpointCreateArgs} SushiEndpointCreateArgs
  * @typedef {import('@prisma/client').Prisma.SushiEndpointDeleteArgs} SushiEndpointDeleteArgs
- * @typedef {{deleteResult: SushiEndpoint, deletedEndpoint: SushiEndpoint }} SushiEndpointRemoved
+ * @typedef {{deleteResult: SushiEndpoint, deletedEndpoint: (SushiEndpoint & { credentials: SushiCredentials[] }) }} SushiEndpointRemoved
  */
 
 /* eslint-enable max-len */
 
 /**
  * @param {SushiEndpointCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SushiEndpoint>}
  */
-function create(params) {
-  return prisma.sushiEndpoint.create(params);
+function create(params, tx = prisma) {
+  return tx.sushiEndpoint.create(params);
 }
 
 /**
  * @param {SushiEndpointFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SushiEndpoint[]>}
  */
-function findMany(params) {
-  return prisma.sushiEndpoint.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.sushiEndpoint.findMany(params);
 }
 
 /**
  * @param {SushiEndpointFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SushiEndpoint | null>}
  */
-function findUnique(params) {
-  return prisma.sushiEndpoint.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.sushiEndpoint.findUnique(params);
 }
 
 /**
  * @param {string} id
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SushiEndpoint | null>}
  */
-function findByID(id) {
-  return prisma.sushiEndpoint.findUnique({ where: { id } });
+function findByID(id, tx = prisma) {
+  return tx.sushiEndpoint.findUnique({ where: { id } });
 }
 
 /**
  * @param {SushiEndpointUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SushiEndpoint>}
  */
-function update(params) {
-  return prisma.sushiEndpoint.update(params);
+function update(params, tx = prisma) {
+  return tx.sushiEndpoint.update(params);
 }
 
 /**
  * @param {SushiEndpointUpsertArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SushiEndpoint>}
  */
-function upsert(params) {
-  return prisma.sushiEndpoint.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.sushiEndpoint.upsert(params);
 }
 
 /**
  * @param {SushiEndpointDeleteArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<SushiEndpointRemoved | null>}
  */
-async function remove(params) {
-  const { deleteResult, deletedEndpoint } = await prisma.$transaction(async (tx) => {
-    const endpoint = await tx.sushiEndpoint.findUnique({
-      where: params.where,
-      include: {
-        credentials: true,
-      },
-    });
-
-    if (!endpoint) {
-      return [null, null];
-    }
-
-    await tx.sushiCredentials.deleteMany({
-      where: { endpointId: endpoint.id },
-    });
-
-    return {
-      deleteResult: await tx.sushiEndpoint.delete(params),
-      deletedEndpoint: endpoint,
-    };
+async function remove(params, tx = prisma) {
+  const endpoint = await tx.sushiEndpoint.findUnique({
+    where: params.where,
+    include: {
+      credentials: true,
+    },
   });
 
-  if (!deletedEndpoint) {
+  if (!endpoint) {
     return null;
   }
 
-  return { deleteResult, deletedEndpoint };
+  return {
+    deleteResult: await tx.sushiEndpoint.delete(params),
+    deletedEndpoint: endpoint,
+  };
 }
 
 /**
- * @returns {Promise<Array<SushiEndpoint> | null>}
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SushiEndpoint[] | null>}
  */
-async function removeAll() {
+async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
-  const sushiEndpoints = await findMany({});
+  /** @param {TransactionClient} txx */
+  const processor = async (txx) => {
+    const sushiEndpoints = await findMany({}, txx);
 
-  if (sushiEndpoints.length === 0) { return null; }
+    if (sushiEndpoints.length === 0) { return null; }
 
-  await Promise.all(sushiEndpoints.map(async (sushiEndpoint) => {
-    await remove({
-      where: {
-        id: sushiEndpoint.id,
-      },
-    });
-  }));
+    await Promise.all(
+      sushiEndpoints.map((sushiEndpoint) => remove(
+        { where: { id: sushiEndpoint.id } },
+        txx,
+      )),
+    );
 
-  return sushiEndpoints;
+    return sushiEndpoints;
+  };
+
+  if (tx) {
+    return processor(tx);
+  }
+  return prisma.$transaction(processor);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/users.js
+++ b/api/lib/services/prisma/users.js
@@ -126,7 +126,6 @@ function acceptTerms(username, tx = prisma) {
 
 /**
  * @param {UserUpsertArgs} params
-spacePermissions
  * @param {TransactionClient} [tx]
  * @returns {Promise<User>}
  */

--- a/api/lib/services/prisma/users.js
+++ b/api/lib/services/prisma/users.js
@@ -179,8 +179,8 @@ function removeByUsername(username, tx = prisma) {
 async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
 
-  /**  */
-  const processor = async (txx) => {
+  /** @param {TransactionClient} txx } */
+  const transaction = async (txx) => {
     const users = await findMany(
       { where: { NOT: { username: adminUsername } } },
       txx,
@@ -196,9 +196,9 @@ async function removeAll(tx) {
   };
 
   if (tx) {
-    return processor(tx);
+    return transaction(tx);
   }
-  return prisma.$transaction(processor);
+  return prisma.$transaction(transaction);
 }
 
 module.exports = {

--- a/api/lib/services/prisma/users.js
+++ b/api/lib/services/prisma/users.js
@@ -13,6 +13,7 @@ const {
 
 /* eslint-disable max-len */
 /**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
  * @typedef {import('@prisma/client').User} User
  * @typedef {import('@prisma/client').Prisma.UserUpsertArgs} UserUpsertArgs
  * @typedef {import('@prisma/client').Prisma.UserFindUniqueArgs} UserFindUniqueArgs
@@ -21,56 +22,69 @@ const {
  * @typedef {import('@prisma/client').Prisma.UserUpdateArgs} UserUpdateArgs
  * @typedef {import('@prisma/client').Prisma.UserCreateArgs} UserCreateArgs
  * @typedef {import('@prisma/client').Prisma.UserDeleteArgs} UserDeleteArgs
- * @typedef {{deleteResult: User, deletedUser: User }} UserRemoved
+ *
+ * @typedef {import('@prisma/client').Membership} Membership
+ * @typedef {import('@prisma/client').RepositoryPermission} RepositoryPermission
+ * @typedef {import('@prisma/client').SpacePermission} SpacePermission
+ *
+ * @typedef {Membership & { repositoryPermissions: RepositoryPermission[], spacePermissions: SpacePermission[] }} OldUserMembership
+ * @typedef {User & { memberships: OldUserMembership[] }} OldUser
+ * @typedef {{ deleteResult: User, deletedUser: OldUser }} UserRemoved
  */
 /* eslint-enable max-len */
 
 /**
  * @param {UserCreateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User>}
  */
-function create(params) {
-  return prisma.user.create(params);
+function create(params, tx = prisma) {
+  return tx.user.create(params);
 }
 
 /**
  * @param {UserFindManyArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User[]>}
  */
-function findMany(params) {
-  return prisma.user.findMany(params);
+function findMany(params, tx = prisma) {
+  return tx.user.findMany(params);
 }
 
 /**
  * @param {UserFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User | null>}
  */
-function findUnique(params) {
-  return prisma.user.findUnique(params);
+function findUnique(params, tx = prisma) {
+  return tx.user.findUnique(params);
 }
 
 /**
  * @param {string} username
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User | null>}
  */
-function findByUsername(username) {
-  return prisma.user.findUnique({ where: { username } });
+function findByUsername(username, tx = prisma) {
+  return tx.user.findUnique({ where: { username } });
 }
 
-/*
+/**
  * @param {UserFindUniqueOrThrowArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User>}
  */
-function findUniqueOrThrow(params) {
-  return prisma.user.findUniqueOrThrow(params);
+function findUniqueOrThrow(params, tx = prisma) {
+  return tx.user.findUniqueOrThrow(params);
 }
 
 /**
  * @param {string} domain
+ * @param {TransactionClient} [tx]
  * @returns {Promise<{email: string}[]> | null}
  */
-function findEmailOfCorrespondentsWithDomain(domain) {
-  return prisma.user.findMany({
+function findEmailOfCorrespondentsWithDomain(domain, tx = prisma) {
+  return tx.user.findMany({
     select: { email: true },
     where: {
       email: { endsWith: `@${domain}` },
@@ -87,21 +101,22 @@ function findEmailOfCorrespondentsWithDomain(domain) {
 
 /**
  * @param {UserUpdateArgs} params
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User>}
  */
-function update(params) {
+function update(params, tx = prisma) {
   // TODO manage role
-  return prisma.user.update(params);
+  return tx.user.update(params);
 }
 
 /**
  * Accept terms for user.
  * @param {string} username - Username.
- *
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User>}
  */
-function acceptTerms(username) {
-  return prisma.user.update({
+function acceptTerms(username, tx = prisma) {
+  return tx.user.update({
     where: { username },
     data: {
       metadata: { acceptedTerms: true },
@@ -111,78 +126,79 @@ function acceptTerms(username) {
 
 /**
  * @param {UserUpsertArgs} params
+spacePermissions
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User>}
  */
-function upsert(params) {
-  return prisma.user.upsert(params);
+function upsert(params, tx = prisma) {
+  return tx.user.upsert(params);
 }
 
 /**
  * @param {UserDeleteArgs} params
+ * @param {TransactionClient} [tx]
  *
  * @returns {Promise<UserRemoved | null>}
  */
-async function remove(params) {
-  const { deleteResult, deletedUser } = await prisma.$transaction(async (tx) => {
-    const user = await tx.user.findUnique({
-      where: params.where,
-      include: {
-        memberships: {
-          include: {
-            repositoryPermissions: true,
-            spacePermissions: true,
-          },
+async function remove(params, tx = prisma) {
+  const user = await tx.user.findUnique({
+    where: params.where,
+    include: {
+      memberships: {
+        include: {
+          repositoryPermissions: true,
+          spacePermissions: true,
         },
       },
-    });
-
-    if (!user) {
-      return [null, null];
-    }
-
-    const findArgs = { where: { username: user.username } };
-
-    await tx.repositoryPermission.deleteMany(findArgs);
-    await tx.spacePermission.deleteMany(findArgs);
-    await tx.membership.deleteMany(findArgs);
-
-    return {
-      deleteResult: await tx.user.delete(params),
-      deletedUser: user,
-    };
+    },
   });
 
-  if (!deletedUser) {
+  if (!user) {
     return null;
   }
 
-  return { deleteResult, deletedUser };
+  return {
+    deleteResult: await tx.user.delete(params),
+    deletedUser: user,
+  };
 }
 
 /**
  * @param {string} username
+ * @param {TransactionClient} [tx]
  * @returns {Promise<User | null>}
  */
-function removeByUsername(username) {
-  return prisma.user.delete({ where: { username } });
+function removeByUsername(username, tx = prisma) {
+  return tx.user.delete({ where: { username } });
 }
 
 /**
+ * @param {TransactionClient} [tx]
  * @returns {Promise<Array<User> | null>}
  */
-async function removeAll() {
+async function removeAll(tx) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
-  const users = await this.findMany({
-    where: { NOT: { username: adminUsername } },
-  });
 
-  if (users.length === 0) { return null; }
+  /**  */
+  const processor = async (txx) => {
+    const users = await findMany(
+      { where: { NOT: { username: adminUsername } } },
+      txx,
+    );
 
-  await Promise.all(users.map(async (user) => {
-    await removeByUsername(user.username);
-  }));
+    if (users.length === 0) { return null; }
 
-  return users;
+    await Promise.all(
+      users.map((user) => removeByUsername(user.username, txx)),
+    );
+
+    return users;
+  };
+
+  if (tx) {
+    return processor(tx);
+  }
+  return prisma.$transaction(processor);
 }
 
 module.exports = {

--- a/api/lib/services/processors/harvest.js
+++ b/api/lib/services/processors/harvest.js
@@ -1,7 +1,6 @@
 const fs = require('fs-extra');
 const crypto = require('crypto');
 const config = require('config');
-const { setTimeout } = require('timers/promises');
 
 const busyBackoffDuration = parseInt(config.get('jobs.harvest.busyBackoffDuration'), 10);
 const deferralBackoffDuration = parseInt(config.get('jobs.harvest.deferralBackoffDuration'), 10);
@@ -30,10 +29,10 @@ require('../../hooks');
 
 const { SUSHI_CODES, ERROR_CODES } = sushiService;
 
-const harvestJobService = require('../../entities/harvest-job.service');
-const stepService = require('../../entities/step.service');
-const logService = require('../../entities/log.service');
-const sushiEndpointService = require('../../entities/sushi-endpoints.service');
+const HarvestJobService = require('../../entities/harvest-job.service');
+const StepService = require('../../entities/step.service');
+const LogService = require('../../entities/log.service');
+const SushiEndpointService = require('../../entities/sushi-endpoints.service');
 
 /* eslint-disable max-len */
 /**
@@ -71,15 +70,19 @@ async function deferJob(job, task, timestamp, lockToken, options = {}) {
     timesDelayed += 1;
   }
 
-  if (timesDelayed > maxDeferrals) {
+  await HarvestJobService.$transaction(async (harvestJobService) => {
+    const logService = new LogService(harvestJobService);
+
+    if (timesDelayed <= maxDeferrals) {
+      return harvestJobService.finish(task, { status: 'delayed' });
+    }
+
     await Promise.all([
       harvestJobService.finish(task, { status: 'failed', errorCode: ERROR_CODES.maxDeferralsExceeded }),
       logService.log(task.id, 'error', 'Maximum deferral times exceeded'),
     ]);
     throw new HarvestError('Maximum number of download deferral exceeded');
-  } else {
-    await harvestJobService.finish(task, { status: 'delayed' });
-  }
+  });
 
   await job.updateData({ ...job.data, timesDelayed });
   await job.moveToDelayed(timestamp, lockToken);
@@ -133,6 +136,9 @@ async function importSushiReport(options = {}) {
   let report;
   let reportContent;
   let logs = [];
+
+  const harvestJobService = new HarvestJobService();
+  const stepService = new StepService();
 
   function saveTask() {
     const newLogs = logs;
@@ -695,6 +701,9 @@ async function importSushiReport(options = {}) {
 async function processJob(job, taskData) {
   const task = taskData;
 
+  const logService = new LogService();
+  const harvestJobService = new HarvestJobService();
+
   if (job.attemptsMade > 1) {
     appLogger.verbose(`[Harvest Job #${job?.id}] New attempt (total: ${job.attemptsMade})`);
     await logService.log(job.id, 'info', `New attempt (total: ${job.attemptsMade})`);
@@ -765,11 +774,19 @@ module.exports = async function handle(job, lockToken) {
 
     if (!task) { exit('timeout', 1); }
 
-    // Try to gracefully fail
-    Promise.all([
-      harvestJobService.finish(task, { status: 'failed' }),
-      logService.log(task.id, 'error', `Timeout of ${jobTimeout}s exceeded`),
-    ]).finally(() => { exit('timeout', 1); });
+    HarvestJobService.$transaction((harvestJobService) => {
+      const logService = LogService.$transaction(harvestJobService);
+
+      // Try to gracefully fail
+      try {
+        Promise.all([
+          harvestJobService.finish(task, { status: 'failed' }),
+          logService.log(task.id, 'error', `Timeout of ${jobTimeout}s exceeded`),
+        ]);
+      } finally {
+        exit('timeout', 1);
+      }
+    });
 
     // Kill process if it's taking too long to gracefully stop
     setTimeout(() => { exit('timeout', 1); }, 3000);
@@ -779,16 +796,28 @@ module.exports = async function handle(job, lockToken) {
     appLogger.debug(`[Harvest Job #${job?.id}] Received SIGTERM, discarding job and exiting with code ${exitCode}`);
 
     // Try to gracefully fail
-    Promise.all([
-      harvestJobService.finish(task, { status: 'cancelled' }),
-      logService.log(task.id, 'error', 'The task was cancelled'),
-    ]).finally(() => { exit('cancel', exitCode); });
+    HarvestJobService.$transaction(async (harvestJobService) => {
+      const logService = new LogService(harvestJobService);
+
+      try {
+        Promise.all([
+          harvestJobService.finish(task, { status: 'cancelled' }),
+          logService.log(task.id, 'error', 'The task was cancelled'),
+        ]);
+      } finally {
+        exit('cancel', exitCode);
+      }
+    });
 
     // Kill process if it's taking too long to gracefully stop
     setTimeout(() => { exit('cancel', exitCode); }, 3000);
   };
 
   process.on('SIGTERM', exitHandler);
+
+  const harvestJobService = new HarvestJobService();
+  const sushiEndpointService = new SushiEndpointService();
+  const logService = new LogService();
 
   const { taskId } = job?.data || {};
 
@@ -831,7 +860,7 @@ module.exports = async function handle(job, lockToken) {
   let result;
 
   // Just a little delay to avoid spamming too fast when harvesting a single platform
-  await setTimeout(500);
+  await new Promise((resolve) => { setTimeout(resolve, 500); });
 
   try {
     result = await processJob(job, task);

--- a/api/lib/services/sync/elastic.js
+++ b/api/lib/services/sync/elastic.js
@@ -74,7 +74,9 @@ const syncRepository = async (repo) => {
     appLogger.error(`[elastic] Role [${allRole}] cannot be upserted:\n${error}`);
   }
 
-  const spacesOfSameType = await SpacesService.findMany({
+  const spacesService = new SpacesService();
+
+  const spacesOfSameType = await spacesService.findMany({
     where: {
       type: repo.type,
       institution: {
@@ -95,7 +97,8 @@ const syncRepository = async (repo) => {
  * @returns {Promise<ThrottledPromisesResult>}
  */
 const syncRepositories = async () => {
-  const repositories = await RepositoriesService.findMany({});
+  const repositoriesService = new RepositoriesService();
+  const repositories = await repositoriesService.findMany({});
 
   const executors = repositories.map((repo) => () => syncRepository(repo));
 
@@ -128,7 +131,8 @@ const syncUser = async (user) => {
  * @returns {Promise<ThrottledPromisesResult>}
  */
 const syncUsers = async () => {
-  const users = await UsersService.findMany({});
+  const usersService = new UsersService();
+  const users = await usersService.findMany({});
 
   const executors = users.map(
     (user) => async () => syncUser(user),

--- a/api/lib/services/sync/ezreeport.js
+++ b/api/lib/services/sync/ezreeport.js
@@ -7,10 +7,15 @@ const reportingUsers = require('../ezreeport/reportingUsers');
 
 const { appLogger } = require('../logger');
 
-const institutionsService = require('../../entities/institutions.service');
-const usersService = require('../../entities/users.service');
+const InstitutionsService = require('../../entities/institutions.service');
+const UsersService = require('../../entities/users.service');
 
 const { syncSchedule } = config.get('ezreeport');
+
+/**
+ * @typedef {import('@prisma/client').Institution} Institution
+ * @typedef {import('@prisma/client').Membership} Membership
+ */
 
 /**
  * @typedef {import('../promises').ThrottledPromisesResult} ThrottledPromisesResult
@@ -27,6 +32,7 @@ const { syncSchedule } = config.get('ezreeport');
  * @returns {Promise<EzrSyncResult<'users'>>}
  */
 async function syncUsers() {
+  const usersService = new UsersService();
   const users = await usersService.findMany({});
 
   appLogger.verbose(`[ezreeport] Synchronizing ${users?.length} users`);
@@ -60,6 +66,9 @@ async function syncUsers() {
  * @returns {Promise<EzrSyncResult<'namespaces' | 'memberships'>>}
  */
 async function syncNamespaces() {
+  const institutionsService = new InstitutionsService();
+  /** @type {(Institution & { memberships: Membership[] })[]} */
+  // @ts-ignore
   const institutions = await institutionsService.findMany({
     include: { memberships: true },
     where: { validated: true },

--- a/api/lib/services/sync/kibana.js
+++ b/api/lib/services/sync/kibana.js
@@ -4,7 +4,7 @@ const { appLogger } = require('../logger');
 const kibana = require('../kibana');
 const assets = require('../assets');
 
-const repositoriesService = require('../../entities/repositories.service');
+const RepositoriesService = require('../../entities/repositories.service');
 const SpacesService = require('../../entities/spaces.service');
 
 const {
@@ -48,6 +48,7 @@ const getSpaceLogo = async (space) => {
  * @param {Space} space - The space we want to sync index patterns
  */
 const syncIndexPatterns = async (space) => {
+  const repositoriesService = new RepositoriesService();
   const repositories = await repositoriesService.findMany({
     where: {
       type: space.type,
@@ -155,7 +156,8 @@ const syncSpace = async (space) => {
  * @returns {Promise<ThrottledPromisesResult>}
  */
 const syncSpaces = async () => {
-  const spaces = await SpacesService.findMany({});
+  const spacesService = new SpacesService();
+  const spaces = await spacesService.findMany({});
 
   const executors = spaces.map((space) => () => syncSpace(space));
 

--- a/api/server.js
+++ b/api/server.js
@@ -8,7 +8,7 @@ const path = require('path');
 const { setTimeout } = require('timers/promises');
 const { STATUS_CODES } = require('http');
 
-const usersService = require('./lib/entities/users.service');
+const UsersService = require('./lib/entities/users.service');
 
 const i18n = require('./lib/services/i18n');
 const metrics = require('./lib/services/metrics');
@@ -194,6 +194,7 @@ async function waitForElasticsearch() {
 }
 
 async function createAdmin() {
+  const usersService = new UsersService();
   try {
     await usersService.createAdmin();
     appLogger.info('Admin user is created');

--- a/api/test/features/indices/create.test.js
+++ b/api/test/features/indices/create.test.js
@@ -5,7 +5,7 @@ const ezmesure = require('../../setup/ezmesure');
 const indicesPrisma = require('../../../lib/services/elastic/indices');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -22,7 +22,7 @@ describe('[indices]: Test create features', () => {
 
   let adminToken;
   beforeAll(async () => {
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     it(`#01 Should create new index [${indexName}]`, async () => {
@@ -51,7 +51,7 @@ describe('[indices]: Test create features', () => {
       // TODO use service
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     it(`#02 Should not create index [${indexName}]`, async () => {

--- a/api/test/features/indices/delete.test.js
+++ b/api/test/features/indices/delete.test.js
@@ -6,7 +6,7 @@ const indicesPrisma = require('../../../lib/services/elastic/indices');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
 
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -23,7 +23,7 @@ describe('[indices]: Test delete features', () => {
 
   let adminToken;
   beforeAll(async () => {
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     beforeEach(async () => {
@@ -53,7 +53,7 @@ describe('[indices]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     beforeEach(async () => {
       await indicesPrisma.create(indexName, null, { ignore: [404] });

--- a/api/test/features/institutions/create.test.js
+++ b/api/test/features/institutions/create.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -30,7 +30,7 @@ describe('[institutions]: Test create features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -102,7 +102,7 @@ describe('[institutions]: Test create features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     it(`#02 Should create new institution [${institutionTest.name}]`, async () => {
       const httpAppResponse = await ezmesure({

--- a/api/test/features/institutions/delete.test.js
+++ b/api/test/features/institutions/delete.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -30,7 +30,7 @@ describe('[institutions]: Test delete features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     let institutionId;
@@ -66,7 +66,7 @@ describe('[institutions]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
       const institution = await institutionsPrisma.create({ data: institutionTest });
       institutionId = institution.id;
     });

--- a/api/test/features/institutions/memberships/create.test.js
+++ b/api/test/features/institutions/memberships/create.test.js
@@ -6,7 +6,7 @@ const institutionsPrisma = require('../../../../lib/services/prisma/institutions
 const membershipsPrisma = require('../../../../lib/services/prisma/memberships');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const { resetDatabase } = require('../../../../lib/services/prisma/utils');
 const { resetElastic } = require('../../../../lib/services/elastic/utils');
@@ -51,7 +51,7 @@ describe('[institutions - memberships]: Test create memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;

--- a/api/test/features/institutions/memberships/delete.test.js
+++ b/api/test/features/institutions/memberships/delete.test.js
@@ -9,7 +9,7 @@ const institutionsPrisma = require('../../../../lib/services/prisma/institutions
 const membershipsPrisma = require('../../../../lib/services/prisma/memberships');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -55,7 +55,7 @@ describe('[institutions - memberships]: Test delete memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;

--- a/api/test/features/institutions/memberships/read.test.js
+++ b/api/test/features/institutions/memberships/read.test.js
@@ -9,7 +9,7 @@ const institutionsPrisma = require('../../../../lib/services/prisma/institutions
 const membershipsPrisma = require('../../../../lib/services/prisma/memberships');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -55,7 +55,7 @@ describe('[institutions - memberships]: Test read memberships features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;

--- a/api/test/features/institutions/memberships/update.test.js
+++ b/api/test/features/institutions/memberships/update.test.js
@@ -9,7 +9,7 @@ const institutionsPrisma = require('../../../../lib/services/prisma/institutions
 const membershipsPrisma = require('../../../../lib/services/prisma/memberships');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -55,7 +55,7 @@ describe('[institutions - memberships]: Test update memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;

--- a/api/test/features/institutions/permissions/create.test.js
+++ b/api/test/features/institutions/permissions/create.test.js
@@ -10,7 +10,7 @@ const institutionsPrisma = require('../../../../lib/services/prisma/institutions
 const membershipsPrisma = require('../../../../lib/services/prisma/memberships');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const repositoryPermissionsPrisma = require('../../../../lib/services/prisma/repository-permissions');
 
@@ -62,7 +62,7 @@ describe('[repository permission]: Test create features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/permissions/delete.test.js
+++ b/api/test/features/institutions/permissions/delete.test.js
@@ -10,7 +10,7 @@ const institutionsPrisma = require('../../../../lib/services/prisma/institutions
 const membershipsPrisma = require('../../../../lib/services/prisma/memberships');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const repositoryPermissionsPrisma = require('../../../../lib/services/prisma/repository-permissions');
 
@@ -62,7 +62,7 @@ describe('[repository permission]: Test delete features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/permissions/update.test.js
+++ b/api/test/features/institutions/permissions/update.test.js
@@ -10,7 +10,7 @@ const institutionsPrisma = require('../../../../lib/services/prisma/institutions
 const membershipsPrisma = require('../../../../lib/services/prisma/memberships');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 const repositoryPermissionsPrisma = require('../../../../lib/services/prisma/repository-permissions');
 
 const adminUsername = config.get('admin.username');
@@ -66,7 +66,7 @@ describe('[repository permission]: Test update features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/read.test.js
+++ b/api/test/features/institutions/read.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -30,7 +30,7 @@ describe('[institutions]: Test read features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -114,7 +114,7 @@ describe('[institutions]: Test read features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
 
       const institution = await institutionsPrisma.create({ data: institutionTest });
       institutionId = institution.id;

--- a/api/test/features/institutions/subinstitutions/create.test.js
+++ b/api/test/features/institutions/subinstitutions/create.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -47,11 +47,11 @@ describe('[institutions - subinstitution]: Test create features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await usersService.generateToken(userTest.username, userPassword);
+    userToken = await UsersService.generateToken(userTest.username, userPassword);
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/subinstitutions/delete.test.js
+++ b/api/test/features/institutions/subinstitutions/delete.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -45,11 +45,11 @@ describe('[institutions - subinstitution]: Test delete features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await usersService.generateToken(userTest.username, userTest.password);
+    userToken = await UsersService.generateToken(userTest.username, userTest.password);
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/subinstitutions/read.test.js
+++ b/api/test/features/institutions/subinstitutions/read.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../../lib/services/prisma/users');
 const usersElastic = require('../../../../lib/services/elastic/users');
-const usersService = require('../../../../lib/entities/users.service');
+const UsersService = require('../../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -47,11 +47,11 @@ describe('[institutions - subinstitution]: Test read features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await usersService.generateToken(userTest.username, userPassword);
+    userToken = await UsersService.generateToken(userTest.username, userPassword);
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/update.test.js
+++ b/api/test/features/institutions/update.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -34,7 +34,7 @@ describe('[institutions]: Test update features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -109,7 +109,7 @@ describe('[institutions]: Test update features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     describe('Institution created by user', () => {
       beforeAll(async () => {

--- a/api/test/features/institutions/validate.test.js
+++ b/api/test/features/institutions/validate.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -30,7 +30,7 @@ describe('[institutions]: Test validate institution features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -91,7 +91,7 @@ describe('[institutions]: Test validate institution features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     let institutionId;
     describe('Institution created by user', () => {

--- a/api/test/features/logs/logs.test.js
+++ b/api/test/features/logs/logs.test.js
@@ -10,7 +10,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const indicesPrisma = require('../../../lib/services/elastic/indices');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const logDir = path.resolve(__dirname, '..', '..', 'sources', 'log');
 
@@ -31,7 +31,7 @@ describe('[logs]: Test insert features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
       await indicesPrisma.create(indexName, null, { ignore: [404] });
     });
     describe(`Add [wiley.csv] in [${indexName}] index`, () => {
@@ -71,7 +71,7 @@ describe('[logs]: Test insert features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     // TODO create roles
     describe(`Add [wiley.csv] in [${indexName}] index who has roles`, () => {

--- a/api/test/features/repositories/create.test.js
+++ b/api/test/features/repositories/create.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const repositoriesPrisma = require('../../../lib/services/prisma/repositories');
 
 const adminUsername = config.get('admin.username');
@@ -41,7 +41,7 @@ describe('[repositories]: Test create features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     });
 
     describe(`Create new repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
@@ -163,7 +163,7 @@ describe('[repositories]: Test create features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe(`Create new repository of type [${ezcounterRepositoryConfig.type}]`, () => {

--- a/api/test/features/repositories/delete.test.js
+++ b/api/test/features/repositories/delete.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const repositoriesPrisma = require('../../../lib/services/prisma/repositories');
 
 const adminUsername = config.get('admin.username');
@@ -36,7 +36,7 @@ describe('[repositories]: Test delete features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     });
 
     describe(`Delete repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
@@ -73,7 +73,7 @@ describe('[repositories]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe(`Delete repository of type [${ezpaarseRepositoryConfig.type}]`, () => {

--- a/api/test/features/repositories/read.test.js
+++ b/api/test/features/repositories/read.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const repositoriesPrisma = require('../../../lib/services/prisma/repositories');
 
 const adminUsername = config.get('admin.username');
@@ -40,7 +40,7 @@ describe('[repositories]: Test read features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     });
     describe(`Get repository of type [${ezcounterRepositoryConfig.type}]`, () => {
       let pattern;
@@ -81,7 +81,7 @@ describe('[repositories]: Test read features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     describe(`Get repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
       let pattern;

--- a/api/test/features/repositories/update.test.js
+++ b/api/test/features/repositories/update.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const repositoriesPrisma = require('../../../lib/services/prisma/repositories');
 
 const adminUsername = config.get('admin.username');
@@ -46,7 +46,7 @@ describe('[repositories]: Test update features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await usersService.generateToken(adminUsername, adminPassword);
+      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     });
     describe(`Update repository of type [${ezpaarseRepositoryConfig.type}] with [${updateRepositoryConfig.type}]`, () => {
       let pattern;
@@ -96,7 +96,7 @@ describe('[repositories]: Test update features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe(`Update repository of type [${ezpaarseRepositoryConfig.type}] with [${updateRepositoryConfig.type}]`, () => {

--- a/api/test/features/spaces/create.test.js
+++ b/api/test/features/spaces/create.test.js
@@ -9,7 +9,7 @@ const spacesPrisma = require('../../../lib/services/prisma/spaces');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -42,7 +42,7 @@ describe('[space]: Test create spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
     spaceConfig.institutionId = institutionId;
@@ -92,7 +92,7 @@ describe('[space]: Test create spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     describe(`Create new space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {
       it('#02 Should not create space', async () => {

--- a/api/test/features/spaces/delete.test.js
+++ b/api/test/features/spaces/delete.test.js
@@ -9,7 +9,7 @@ const spacesPrisma = require('../../../lib/services/prisma/spaces');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -41,7 +41,7 @@ describe('[space]: Test delete spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
   });
@@ -79,7 +79,7 @@ describe('[space]: Test delete spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe(`Delete space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {

--- a/api/test/features/spaces/read.test.js
+++ b/api/test/features/spaces/read.test.js
@@ -9,7 +9,7 @@ const spacesPrisma = require('../../../lib/services/prisma/spaces');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -41,7 +41,7 @@ describe('[space]: Test read spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
     spaceConfig.institutionId = institutionId;
@@ -89,7 +89,7 @@ describe('[space]: Test read spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe(`Get space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {

--- a/api/test/features/spaces/update.test.js
+++ b/api/test/features/spaces/update.test.js
@@ -9,7 +9,7 @@ const spacesPrisma = require('../../../lib/services/prisma/spaces');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -46,7 +46,7 @@ describe('[space]: Test update spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
   });
@@ -112,7 +112,7 @@ describe('[space]: Test update spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
     describe(`Update space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {
       let spaceId;

--- a/api/test/features/sushi-endpoints/create.test.js
+++ b/api/test/features/sushi-endpoints/create.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 
 const adminUsername = config.get('admin.username');
@@ -42,7 +42,7 @@ describe('[sushi-endpoint]: Test create sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Create new sushi-endpoint', () => {
@@ -109,7 +109,7 @@ describe('[sushi-endpoint]: Test create sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe('Create new sushi-endpoint', () => {

--- a/api/test/features/sushi-endpoints/delete.test.js
+++ b/api/test/features/sushi-endpoints/delete.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 
 const adminUsername = config.get('admin.username');
@@ -42,7 +42,7 @@ describe('[sushi-endpoint]: Test update sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Delete sushi-endpoint', () => {
@@ -81,7 +81,7 @@ describe('[sushi-endpoint]: Test update sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe('Delete sushi-endpoint', () => {

--- a/api/test/features/sushi-endpoints/read.test.js
+++ b/api/test/features/sushi-endpoints/read.test.js
@@ -6,7 +6,7 @@ const { resetDatabase } = require('../../../lib/services/prisma/utils');
 const { resetElastic } = require('../../../lib/services/elastic/utils');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 
 const adminUsername = config.get('admin.username');
@@ -43,7 +43,7 @@ describe('[sushi-endpoint]: Test read sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     beforeEach(async () => {
@@ -108,7 +108,7 @@ describe('[sushi-endpoint]: Test read sushi-endpoints features', () => {
       await usersPrisma.create({ data: userTest });
       await usersPrisma.acceptTerms(userTest.username);
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     beforeEach(async () => {

--- a/api/test/features/sushi-endpoints/update.test.js
+++ b/api/test/features/sushi-endpoints/update.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 
 const adminUsername = config.get('admin.username');
@@ -59,7 +59,7 @@ describe('[sushi-endpoint]: Test delete sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Update sushi-endpoint', () => {
@@ -131,7 +131,7 @@ describe('[sushi-endpoint]: Test delete sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe('Update sushi-endpoint', () => {

--- a/api/test/features/sushi/create.test.js
+++ b/api/test/features/sushi/create.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 const sushiCredentialsPrisma = require('../../../lib/services/prisma/sushi-credentials');
 const membershipsPrisma = require('../../../lib/services/prisma/memberships');
@@ -86,7 +86,7 @@ describe('[sushi]: Test create sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -239,7 +239,7 @@ describe('[sushi]: Test create sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await usersService.generateToken(userTest.username, userPassword);
+      userToken = await UsersService.generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/delete.test.js
+++ b/api/test/features/sushi/delete.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 const sushiCredentialsPrisma = require('../../../lib/services/prisma/sushi-credentials');
 const membershipsPrisma = require('../../../lib/services/prisma/memberships');
@@ -84,7 +84,7 @@ describe('[sushi]: Test delete sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -185,7 +185,7 @@ describe('[sushi]: Test delete sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await usersService.generateToken(userTest.username, userPassword);
+      userToken = await UsersService.generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/read.test.js
+++ b/api/test/features/sushi/read.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 const sushiCredentialsPrisma = require('../../../lib/services/prisma/sushi-credentials');
 const membershipsPrisma = require('../../../lib/services/prisma/memberships');
@@ -85,7 +85,7 @@ describe('[sushi]: Test read sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -207,7 +207,7 @@ describe('[sushi]: Test read sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await usersService.generateToken(userTest.username, userPassword);
+      userToken = await UsersService.generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/update.test.js
+++ b/api/test/features/sushi/update.test.js
@@ -8,7 +8,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 const institutionsPrisma = require('../../../lib/services/prisma/institutions');
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const sushiEndpointsPrisma = require('../../../lib/services/prisma/sushi-endpoints');
 const sushiCredentialsPrisma = require('../../../lib/services/prisma/sushi-credentials');
 const membershipsPrisma = require('../../../lib/services/prisma/memberships');
@@ -98,7 +98,7 @@ describe('[sushi]: Test update sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -256,7 +256,7 @@ describe('[sushi]: Test update sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await usersService.generateToken(userTest.username, userPassword);
+      userToken = await UsersService.generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/users/activate.test.js
+++ b/api/test/features/users/activate.test.js
@@ -5,7 +5,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 describe('[users]: Test activate users features', () => {
   const userTest = {
@@ -31,7 +31,7 @@ describe('[users]: Test activate users features', () => {
       beforeAll(async () => {
         await usersPrisma.create({ data: userTest });
         await usersElastic.createUser(userTest);
-        userToken = await usersService.generateTokenForActivate(userTest.username);
+        userToken = await UsersService.generateTokenForActivate(userTest.username);
       });
 
       it(`#01 Should activate user [${userTest.username}]`, async () => {

--- a/api/test/features/users/create.test.js
+++ b/api/test/features/users/create.test.js
@@ -6,7 +6,7 @@ const { resetDatabase } = require('../../../lib/services/prisma/utils');
 const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -28,7 +28,7 @@ describe('[users]: Test create users features', () => {
       let adminToken;
 
       beforeAll(async () => {
-        adminToken = await usersService.generateToken(adminUsername, adminPassword);
+        adminToken = await UsersService.generateToken(adminUsername, adminPassword);
       });
 
       it(`#01 Should create new user [${userTest.username}]`, async () => {

--- a/api/test/features/users/delete.test.js
+++ b/api/test/features/users/delete.test.js
@@ -6,7 +6,7 @@ const { resetDatabase } = require('../../../lib/services/prisma/utils');
 const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 const usersElastic = require('../../../lib/services/elastic/users');
 
 const adminUsername = config.get('admin.username');
@@ -25,7 +25,7 @@ describe('[users]: Test delete users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe(`Delete user [${userTest.username}]`, () => {

--- a/api/test/features/users/read.test.js
+++ b/api/test/features/users/read.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminFullName = config.get('admin.fullName');
 const adminUsername = config.get('admin.username');
@@ -26,7 +26,7 @@ describe('[users]: Test read users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Get all users', () => {
@@ -106,7 +106,7 @@ describe('[users]: Test read users features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await usersService.generateToken(userTest.username, userTest.password);
+      userToken = await UsersService.generateToken(userTest.username, userTest.password);
     });
 
     describe('Get all users', () => {

--- a/api/test/features/users/update.test.js
+++ b/api/test/features/users/update.test.js
@@ -7,7 +7,7 @@ const { resetElastic } = require('../../../lib/services/elastic/utils');
 
 const usersPrisma = require('../../../lib/services/prisma/users');
 const usersElastic = require('../../../lib/services/elastic/users');
-const usersService = require('../../../lib/entities/users.service');
+const UsersService = require('../../../lib/entities/users.service');
 
 const adminUsername = config.get('admin.username');
 const adminPassword = config.get('admin.password');
@@ -32,7 +32,7 @@ describe('[users]: Test update users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await usersService.generateToken(adminUsername, adminPassword);
+    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
   });
   describe('Update', () => {
     describe('As admin', () => {


### PR DESCRIPTION
## When using `lib/services/prisma/myEntity.js`

> [!NOTE]
> `myService` here is just for example, it can be any prisma entity

```js
const { client: prisma } = require('./lib/services/prisma/index');
const myPrismaEntity = require('./lib/services/prisma/myEntity');

// Request without transaction : fallback to PrismaClient
await myPrismaEntity.findAll({});

// Request with transaction
await prisma.$transaction(async (tx) => {
  const res = await myPrismaEntity.findAll({}, tx);
  return res;
});
```

## When using `lib/entities/myService.service.js`

> [!CAUTION]  
> Many static methods are now removed and replaced by their "classic" counterparts

> [!NOTE]
> `myService` here is just for example, it can be any service extending `BasePrismaService`

```js
const MyService = require('./lib/entities/myService.service');
const MyAltService = require('./lib/entities/myService.service');

// Request without transaction : fallback to PrismaClient
const mySrv = new MyService();
await mySrv.findAll({});

// Request with transaction
await MyService.$transaction(async (myService) => {
  const res = await myService.findAll({});

  // You can use the same transaction with multiple services
  // ! Avoid calling `$transaction` in a `$transaction` !
  const myAltService = new MyAltService(myService);
  const res2 = await myAltService.findAll({});

  return [res, res2];
})
```