### PR TITLE
feature: added sushi harest status

### DIFF
--- a/api/lib/controllers/harvests-sessions/index.js
+++ b/api/lib/controllers/harvests-sessions/index.js
@@ -15,6 +15,7 @@ const {
 
 const {
   getAll,
+  getOne,
   getManyStatus,
   createOne,
   startOne,
@@ -69,6 +70,19 @@ router.route({
     query: Joi.object({
       harvestIds: Joi.array().single().items(Joi.string()),
     }).rename('harvestIds[]', 'harvestIds'),
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/:harvestId',
+  handler: [
+    getOne,
+  ],
+  validate: {
+    params: {
+      harvestId: Joi.string().trim().required(),
+    },
   },
 });
 

--- a/api/lib/controllers/institutions/actions.js
+++ b/api/lib/controllers/institutions/actions.js
@@ -689,6 +689,8 @@ exports.removeInstitutionMember = async (ctx) => {
 };
 
 exports.getSushiData = async (ctx) => {
+  const { include: propsToInclude } = ctx.query;
+
   const sushiCredentialsService = new SushiCredentialsService();
 
   ctx.type = 'json';
@@ -699,6 +701,7 @@ exports.getSushiData = async (ctx) => {
     },
     include: {
       endpoint: true,
+      ...propsToPrismaInclude(propsToInclude, ['harvests']),
     },
   });
 };

--- a/api/lib/controllers/institutions/index.js
+++ b/api/lib/controllers/institutions/index.js
@@ -92,10 +92,11 @@ router.route({
     params: {
       institutionId: Joi.string().trim().required(),
     },
-    query: {
+    query: Joi.object({
       latestImportTask: Joi.boolean().default(false),
       connection: Joi.string().valid('working', 'faulty', 'untested'),
-    },
+      include: Joi.array().single().items(Joi.string().valid('harvests')),
+    }).rename('include[]', 'include'),
   },
 });
 
@@ -124,7 +125,7 @@ router.route({
   ],
   validate: {
     params: {
-      institutionId: Joi.string().trim().required(),
+      institutionId: Joi.string().trim().required(), include: ['harvests'],
     },
     query: Joi.object({
       include: Joi.array().single().items(Joi.string().valid(...repositoryIncludableFields)),

--- a/api/lib/controllers/openapi.json
+++ b/api/lib/controllers/openapi.json
@@ -795,6 +795,14 @@
             "default": {},
             "description": "Additional job parameters"
           },
+          "startedAt": {
+            "type": "string",
+            "default": null,
+            "format": "date-time",
+            "example": "2020-11-05T17:07:31.967Z",
+            "description": "First start of the session",
+            "readOnly": true
+          },
           "createdAt": {
             "$ref": "#/components/schemas/ItemCreationDate"
           },
@@ -816,18 +824,6 @@
         "properties": {
           "id": {
             "$ref": "#/components/schemas/ItemID"
-          },
-          "beginDate": {
-            "description": "Begin date of the period to be harvested",
-            "type": "string",
-            "format": "date",
-            "pattern": "yyyy-MM"
-          },
-          "endDate": {
-            "description": "End date of the period to be harvested",
-            "type": "string",
-            "format": "date",
-            "pattern": "yyyy-MM"
           },
           "isActive": {
             "type": "boolean",
@@ -6192,6 +6188,30 @@
                     "pattern": "yyyy-MM",
                     "required": true
                   },
+                  "credentialsQuery": {
+                    "type": "object",
+                    "description": "Query used to get credentials to harvest",
+                    "properties": {
+                      "ids": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ItemID"
+                        }
+                      },
+                      "institutionIds": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ItemID"
+                        }
+                      },
+                      "endpointIds": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ItemID"
+                        }
+                      }
+                    }
+                  },
                   "reportTypes": {
                     "type": "array",
                     "items": {
@@ -6352,6 +6372,30 @@
                     "format": "date",
                     "pattern": "yyyy-MM",
                     "required": true
+                  },
+                  "credentialsQuery": {
+                    "type": "object",
+                    "description": "Query used to get credentials to harvest",
+                    "properties": {
+                      "ids": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ItemID"
+                        }
+                      },
+                      "institutionIds": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ItemID"
+                        }
+                      },
+                      "endpointIds": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/ItemID"
+                        }
+                      }
+                    }
                   },
                   "reportTypes": {
                     "type": "array",

--- a/api/lib/entities/harvest-session.dto.js
+++ b/api/lib/entities/harvest-session.dto.js
@@ -15,6 +15,7 @@ const schema = {
   id: Joi.string().trim(),
   updatedAt: Joi.date(),
   createdAt: Joi.date(),
+  startedAt: Joi.date(),
 
   credentialsQuery: Joi.object().pattern(Joi.string(), Joi.any()),
   beginDate: Joi.string().regex(/^\d{4}-\d{2}$/),
@@ -42,6 +43,7 @@ const immutableFields = [
   'id',
   'updatedAt',
   'createdAt',
+  'startedAt',
   'jobs',
 ];
 
@@ -61,7 +63,7 @@ const includableFields = [
 const adminCreateSchema = withModifiers(
   schema,
   ignoreFields(immutableFields),
-  requireFields(['credentialsQuery', 'beginDate', 'endDate', 'reportTypes']),
+  requireFields(['credentialsQuery', 'reportTypes']),
   withDefaults({
     timeout: 600,
     allowFaulty: false,
@@ -78,6 +80,7 @@ const adminCreateSchema = withModifiers(
 const adminUpdateSchema = withModifiers(
   schema,
   ignoreFields(immutableFields),
+  requireFields(['credentialsQuery', 'reportTypes']),
 );
 
 module.exports = {

--- a/api/lib/entities/harvest-session.service.js
+++ b/api/lib/entities/harvest-session.service.js
@@ -146,8 +146,6 @@ module.exports = class HarvestSessionService extends BasePrismaService {
 
       return {
         id: session.id,
-        beginDate: session.beginDate,
-        endDate: session.endDate,
 
         isActive: activeJobsCount > 0,
         runningTime,
@@ -478,7 +476,7 @@ module.exports = class HarvestSessionService extends BasePrismaService {
           }
 
           // Add jobs
-          return Promise.all(
+          const jobs = await Promise.all(
             reportTypes.map(
               async (reportType) => {
                 const data = {
@@ -518,6 +516,15 @@ module.exports = class HarvestSessionService extends BasePrismaService {
               },
             ),
           );
+
+          if (!session.startedAt) {
+            await harvestSessionService.update({
+              where: { id: session.id },
+              data: { startedAt: new Date() },
+            });
+          }
+
+          return jobs;
         }),
       );
     };

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -238,6 +238,8 @@ model HarvestSession {
   ignoreValidation    Boolean?
   /// Parameters to pass to jobs
   params              Json?        @default("{}")
+  /// Start date
+  startedAt           DateTime?
   /// Creation date
   createdAt           DateTime     @default(now())
   /// Latest update date

--- a/front/components/ConfirmDialog.vue
+++ b/front/components/ConfirmDialog.vue
@@ -19,7 +19,7 @@
           @click="disagree"
         >
           <v-icon v-if="disagreeIcon" left>
-            {{ agreeIcon }}
+            {{ disagreeIcon }}
           </v-icon>
 
           {{ disagreeText || $t('cancel') }}

--- a/front/components/HarvestMatrix.vue
+++ b/front/components/HarvestMatrix.vue
@@ -89,6 +89,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    initialYear: {
+      type: Number,
+      default: undefined,
+    },
   },
   data() {
     return {
@@ -102,6 +106,10 @@ export default {
     sushiId: {
       immediate: true,
       handler() { this.refreshHarvests(); },
+    },
+    initialYear: {
+      immediate: true,
+      handler(val) { if (val != null) { this.year = val; } },
     },
     year() {
       this.refreshHarvests();

--- a/front/components/HarvestMatrixDialog.vue
+++ b/front/components/HarvestMatrixDialog.vue
@@ -4,7 +4,7 @@
     scrollable
     width="1400"
   >
-    <HarvestMatrix :sushi-item="sushi">
+    <HarvestMatrix :sushi-item="sushi" :initial-year="year">
       <template #actions>
         <v-card-actions>
           <v-spacer />
@@ -28,12 +28,14 @@ export default {
   data() {
     return {
       show: false,
+      year: null,
       sushi: null,
     };
   },
   methods: {
-    display(sushi) {
+    display(sushi, year) {
       this.sushi = sushi;
+      this.year = year;
       this.show = true;
     },
   },

--- a/front/components/HarvestStateCell.vue
+++ b/front/components/HarvestStateCell.vue
@@ -70,26 +70,7 @@
 
 <script>
 import LogsPreview from '~/components/LogsPreview.vue';
-
-const colors = new Map([
-  ['waiting', 'grey'],
-  ['running', 'blue'],
-  ['finished', 'green'],
-  ['failed', 'red'],
-  ['interrupted', 'red'],
-  ['cancelled', 'red'],
-  ['delayed', 'blue'],
-]);
-
-const icons = new Map([
-  ['waiting', 'mdi-clock-outline'],
-  ['running', 'mdi-play'],
-  ['finished', 'mdi-check'],
-  ['failed', 'mdi-exclamation'],
-  ['interrupted', 'mdi-progress-close'],
-  ['cancelled', 'mdi-cancel'],
-  ['delayed', 'mdi-update'],
-]);
+import { colors, icons } from './harvest/state';
 
 export default {
   components: {

--- a/front/components/SushiConnectionIcon.vue
+++ b/front/components/SushiConnectionIcon.vue
@@ -35,10 +35,6 @@
         </v-icon>
 
         {{ chipText }}
-
-        <v-icon small right>
-          mdi-chevron-down
-        </v-icon>
       </v-chip>
     </template>
 

--- a/front/components/harvest/HarvestJobCard.vue
+++ b/front/components/harvest/HarvestJobCard.vue
@@ -137,7 +137,7 @@ export default defineComponent({
           key: 'updated',
           label: this.$t('harvest.jobs.updated'),
           icon: 'mdi-file-replace',
-          color: 'warning',
+          color: 'info',
           value: this.harvest.result.updated.toLocaleString(),
         },
         {

--- a/front/components/harvest/HarvestJobCard.vue
+++ b/front/components/harvest/HarvestJobCard.vue
@@ -45,6 +45,7 @@
                   :key="month"
                   outlined
                   small
+                  class="mr-2"
                 >
                   {{ month }}
                 </v-chip>

--- a/front/components/harvest/HarvestJobTable.vue
+++ b/front/components/harvest/HarvestJobTable.vue
@@ -5,7 +5,6 @@
 
       <v-btn
         text
-        color="primary"
         @click="showFiltrerDrawer = true"
       >
         <v-badge
@@ -22,7 +21,6 @@
       </v-btn>
 
       <v-btn
-        color="primary"
         text
         :loading="refreshing"
         @click.stop="refreshJobs()"

--- a/front/components/harvest/HarvestJobTable.vue
+++ b/front/components/harvest/HarvestJobTable.vue
@@ -39,7 +39,7 @@
       :options.sync="tableOptions"
       :server-items-length="jobsCount"
       item-key="id"
-      sort-by="createdAt"
+      sort-by="startedAt"
       sort-desc
       @update:options="refreshJobs()"
     >
@@ -104,7 +104,11 @@
         </v-menu>
       </template>
 
-      <template #[`item.createdAt`]="{ value }">
+      <template #[`item.startedAt`]="{ value }">
+        <LocalDate v-if="value" :date="value" />
+      </template>
+
+      <template #[`item.updatedAt`]="{ value }">
         <LocalDate v-if="value" :date="value" />
       </template>
     </v-data-table>
@@ -194,8 +198,12 @@ export default defineComponent({
           align: 'center',
         },
         {
-          text: this.$t('harvest.jobs.createdAt'),
-          value: 'createdAt',
+          text: this.$t('harvest.jobs.startedAt'),
+          value: 'startedAt',
+        },
+        {
+          text: this.$t('harvest.jobs.updatedAt'),
+          value: 'updatedAt',
         },
       ];
     },

--- a/front/components/harvest/HarvestSessionHeader.vue
+++ b/front/components/harvest/HarvestSessionHeader.vue
@@ -1,0 +1,268 @@
+<template>
+  <div>
+    <v-row>
+      <v-col>
+        <v-row>
+          <v-col>
+            {{ $t('harvest.sessions.name', { createdAt }) }}
+
+            <span class="text--secondary mx-2" style="font-size: 0.75em;">
+              ({{ session.id }})
+            </span>
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col>
+            <template v-for="tag in chips">
+              <v-tooltip
+                v-if="!tag.hide"
+                :key="tag.key"
+                :disabled="!tag.tooltip"
+                top
+              >
+                <template #activator="{ attrs, on }">
+                  <v-chip
+                    outlined
+                    small
+                    class="mr-2"
+                    v-bind="attrs"
+                    v-on="on"
+                  >
+                    <v-icon v-if="tag.icon" left small>
+                      {{ tag.icon }}
+                    </v-icon>
+
+                    {{ tag.text }}
+                  </v-chip>
+                </template>
+
+                {{ tag.tooltip || '' }}
+              </v-tooltip>
+            </template>
+          </v-col>
+        </v-row>
+      </v-col>
+
+      <v-col cols="4" align-self="center">
+        <v-row>
+          <v-col v-if="hasStarted" class="d-flex align-center">
+            <div style="width: 32px">
+              <v-progress-circular
+                v-if="status?.isActive"
+                color="primary"
+                width="2"
+                indeterminate
+              />
+            </div>
+
+            <v-menu
+              :disabled="!metrics"
+              transition="slide-y-transition"
+              open-on-hover
+              bottom
+              offset-y
+            >
+              <template #activator="{ attrs, on }">
+                <div style="flex: 1;" v-bind="attrs" v-on="on">
+                  <ProgressLinearStack
+                    :value="bars"
+                    height="8"
+                  />
+                </div>
+              </template>
+
+              <v-simple-table>
+                <template #default>
+                  <tbody>
+                    <template v-for="row in table">
+                      <tr v-if="row.value > 0" :key="row.key">
+                        <td>
+                          <v-icon
+                            v-if="row.header.icon"
+                            :color="row.header.color"
+                            class="mr-2"
+                          >
+                            {{ row.header.icon }}
+                          </v-icon>
+
+                          {{ row.header.text }}
+                        </td>
+
+                        <td>{{ row.value }}</td>
+                      </tr>
+                    </template>
+                  </tbody>
+                </template>
+              </v-simple-table>
+            </v-menu>
+          </v-col>
+
+          <v-col v-else align-self="center" style="text-align: end;">
+            <v-chip color="error">
+              {{ $t('harvest.sessions.notStarted') }}
+            </v-chip>
+          </v-col>
+        </v-row>
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+import { parseISO } from 'date-fns';
+import ProgressLinearStack from '~/components/ProgressLinearStack.vue';
+
+const STATUS_ICONS = {
+  success: { icon: 'mdi-check', color: 'green' },
+  failed: { icon: 'mdi-alert-circle-outline', color: 'red' },
+  active: { icon: 'mdi-play', color: 'blue' },
+  delayed: { icon: 'mdi-update', color: 'blue' },
+  pending: { icon: 'mdi-clock-outline' },
+};
+
+export default defineComponent({
+  components: {
+    ProgressLinearStack,
+  },
+  props: {
+    session: {
+      type: Object,
+      required: true,
+    },
+    status: {
+      type: Object,
+      default: () => undefined,
+    },
+    hasStarted: {
+      type: Boolean,
+      default: () => false,
+    },
+  },
+  computed: {
+    createdAt() {
+      return this.$dateFunctions.format(parseISO(this.session.createdAt), 'PPPpp');
+    },
+    runningTime() {
+      return this.$dateFunctions.msToLocalDistance(
+        this.status?.runningTime,
+        { format: ['days', 'hours', 'minutes', 'seconds'] },
+      );
+    },
+    counts() {
+      return {
+        reportTypes: this.session.reportTypes.length,
+        // eslint-disable-next-line no-underscore-dangle
+        credentials: this.status?._count.credentials ?? {},
+      };
+    },
+    metrics() {
+      // eslint-disable-next-line no-underscore-dangle
+      const count = this.status?._count;
+      if (!count) {
+        return undefined;
+      }
+
+      const { jobStatuses } = count;
+      return {
+        pending: jobStatuses.waiting ?? 0,
+        success: jobStatuses.finished ?? 0,
+        active: jobStatuses.running ?? 0,
+        delayed: jobStatuses.delayed ?? 0,
+        failed: (jobStatuses.failed ?? 0)
+          + (jobStatuses.interrupted ?? 0)
+          + (jobStatuses.cancelled ?? 0),
+      };
+    },
+    table() {
+      return Object.entries(this.metrics ?? {})
+        .map(([name, value]) => ({
+          key: name,
+          header: {
+            ...STATUS_ICONS[name],
+            text: this.$t(`harvest.sessions.metrics.${name}`),
+          },
+          value,
+        }));
+    },
+    bars() {
+      if (!this.status) {
+        return [
+          {
+            key: `${this.session.id}-unknown`,
+            type: 'buffer',
+            value: 1,
+            color: 'primary',
+          },
+        ];
+      }
+
+      // eslint-disable-next-line no-underscore-dangle
+      const getValue = (value) => (value / this.session._count.jobs);
+
+      return [
+        {
+          key: `${this.session.id}-success`,
+          color: 'success',
+          value: getValue(this.metrics.success),
+        },
+        {
+          key: `${this.session.id}-failed`,
+          color: 'error',
+          value: getValue(this.metrics.failed),
+        },
+        {
+          key: `${this.session.id}-active`,
+          color: 'blue',
+          value: getValue(this.metrics.active),
+        },
+        {
+          key: `${this.session.id}-delayed`,
+          type: 'buffer',
+          color: 'blue',
+          value: getValue(this.metrics.delayed),
+        },
+        {
+          key: `${this.session.id}-pending`,
+          type: 'stream',
+          color: 'grey',
+          value: getValue(this.metrics.pending),
+        },
+      ];
+    },
+    chips() {
+      return [
+        {
+          key: `${this.session.id}-period`,
+          icon: 'mdi-calendar-range',
+          text: `${this.session.beginDate} ~ ${this.session.endDate}`,
+        },
+        {
+          key: `${this.session.id}-credentials`,
+          icon: 'mdi-key',
+          text: this.$tc(
+            'harvest.sessions.counts.credentials',
+            this.counts.credentials.harvestable ?? this.counts.credentials.all,
+          ),
+          tooltip: this.$t('harvest.sessions.credentialsTooltip', this.counts.credentials),
+        },
+        {
+          key: `${this.session.id}-reports`,
+          icon: 'mdi-file',
+          text: this.$tc('harvest.sessions.counts.reportTypes', this.counts.reportTypes),
+        },
+        {
+          key: `${this.session.id}-runningTime`,
+          icon: 'mdi-timer-outline',
+          hide: !this.status?.runningTime,
+          text: this.runningTime,
+        },
+      ];
+    },
+  },
+});
+</script>
+
+<style>
+</style>

--- a/front/components/harvest/HarvestSessionHeader.vue
+++ b/front/components/harvest/HarvestSessionHeader.vue
@@ -4,7 +4,7 @@
       <v-col>
         <v-row>
           <v-col>
-            {{ $t('harvest.sessions.name', { createdAt }) }}
+            {{ sessionName }}
 
             <span class="text--secondary mx-2" style="font-size: 0.75em;">
               ({{ session.id }})
@@ -141,8 +141,12 @@ export default defineComponent({
     },
   },
   computed: {
-    createdAt() {
-      return this.$dateFunctions.format(parseISO(this.session.createdAt), 'PPPpp');
+    sessionName() {
+      if (this.hasStarted) {
+        const startedAt = this.$dateFunctions.format(parseISO(this.session.startedAt), 'PPPp');
+        return this.$t('harvest.sessions.name', { startedAt });
+      }
+      return this.$t('harvest.sessions.pendingSession');
     },
     runningTime() {
       return this.$dateFunctions.msToLocalDistance(

--- a/front/components/harvest/state.js
+++ b/front/components/harvest/state.js
@@ -1,0 +1,19 @@
+export const colors = new Map([
+  ['waiting', 'grey'],
+  ['running', 'blue'],
+  ['finished', 'green'],
+  ['failed', 'red'],
+  ['interrupted', 'red'],
+  ['cancelled', 'red'],
+  ['delayed', 'blue'],
+]);
+
+export const icons = new Map([
+  ['waiting', 'mdi-clock-outline'],
+  ['running', 'mdi-play'],
+  ['finished', 'mdi-check'],
+  ['failed', 'mdi-exclamation'],
+  ['interrupted', 'mdi-progress-close'],
+  ['cancelled', 'mdi-cancel'],
+  ['delayed', 'mdi-update'],
+]);

--- a/front/components/sushis/CredentialHarvestState.vue
+++ b/front/components/sushis/CredentialHarvestState.vue
@@ -1,0 +1,37 @@
+<template>
+  <v-chip
+    v-if="lastHarvest"
+    :color="chipColor"
+    small
+    outlined
+    class="white--text"
+    @click="$emit('click', { lastHarvest, harvestDate })"
+  >
+    <v-icon left small>
+      {{ chipIcon }}
+    </v-icon>
+
+    <LocalDate :date="harvestDate" />
+  </v-chip>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { parseISO } from 'date-fns';
+import { colors, icons } from '../harvest/state';
+import LocalDate from '../LocalDate.vue';
+
+const props = defineProps({
+  harvests: {
+    type: Array,
+    required: true,
+  },
+});
+
+defineEmits(['click']);
+
+const lastHarvest = computed(() => props.harvests.at(0));
+const harvestDate = computed(() => lastHarvest.value && parseISO(lastHarvest.value.harvestedAt));
+const chipColor = computed(() => lastHarvest.value && colors.get(lastHarvest.value.status));
+const chipIcon = computed(() => lastHarvest.value && icons.get(lastHarvest.value.status));
+</script>

--- a/front/components/sushis/CredentialHarvestState.vue
+++ b/front/components/sushis/CredentialHarvestState.vue
@@ -5,13 +5,13 @@
     small
     outlined
     class="white--text"
-    @click="$emit('click', { lastHarvest, harvestDate })"
+    @click="$emit('click', lastHarvest)"
   >
     <v-icon left small>
       {{ chipIcon }}
     </v-icon>
 
-    <LocalDate :date="harvestDate" />
+    <LocalDate :date="lastHarvest.harvestDate" />
   </v-chip>
 </template>
 
@@ -30,8 +30,12 @@ const props = defineProps({
 
 defineEmits(['click']);
 
-const lastHarvest = computed(() => props.harvests.at(0));
-const harvestDate = computed(() => lastHarvest.value && parseISO(lastHarvest.value.harvestedAt));
+const lastHarvest = computed(
+  () => props.harvests
+    .map((harvest) => ({ ...harvest, harvestDate: parseISO(harvest.harvestedAt) }))
+    .sort((a, b) => b.harvestDate - a.harvestDate)
+    .at(0),
+);
 const chipColor = computed(() => lastHarvest.value && colors.get(lastHarvest.value.status));
 const chipIcon = computed(() => lastHarvest.value && icons.get(lastHarvest.value.status));
 </script>

--- a/front/locales/en.json
+++ b/front/locales/en.json
@@ -723,7 +723,8 @@
   },
   "harvest": {
     "sessions": {
-      "name": "Harvesting from {createdAt}",
+      "pendingSession": "Pending harvest...",
+      "name": "Harvest of {startedAt}",
       "metrics": {
         "success": "Success",
         "failed": "Failed",
@@ -749,7 +750,8 @@
       "beginDate": "Start Date",
       "endDate": "End Date",
       "period": "Period",
-      "createdAt": "Requested on",
+      "startedAt": "Started at",
+      "updatedAt": "Updated at",
       "runningTime": "Processing Time",
       "index": "Insertion Index",
       "coveredPeriods": "Covered Months",

--- a/front/locales/en.json
+++ b/front/locales/en.json
@@ -423,6 +423,7 @@
       "validateMyCredentials": "Validate my credentials",
       "resumeEntryQuestion": "Resume your entry ?",
       "resumeEntryDesc": "You have declared the completion of your credentials on {date}. Do you want to resume your entry ?",
+      "lastHarvest": "Last harvest",
       "readyPopup": {
         "inProgress": "Your credentials are still being entered. When they are ready to be harvested, declare the completion of your entry by clicking on the button below.",
         "completed": "You have declared the completion of your credentials on {date}. These will be eligible to be included in future harvesting rounds. If adjustments are still needed, please declare it by clicking on the button below."

--- a/front/locales/fr.json
+++ b/front/locales/fr.json
@@ -424,6 +424,7 @@
       "validateMyCredentials": "Valider mes identifiants",
       "resumeEntryQuestion": "Reprendre votre saisie ?",
       "resumeEntryDesc": "Vous avez déclaré la fin de saisie de vos identifiants le {date}. Souhaitez-vous la reprendre ?",
+      "lastHarvest": "Dernier moissonnage",
       "readyPopup": {
         "inProgress": "Vos identifiants sont encore en cours de saisie. Lorsque ces derniers seront prêts à être moissonnés, déclarez la fin de votre saisie en cliquant sur le bouton ci-dessous.",
         "completed": "Vous avez déclaré la fin de saisie de vos identifiants le {date}. Ces derniers pourront faire partie des prochaines vagues de moissonnage. Si des ajustements sont encore nécessaires, déclarez-le en cliquant sur le bouton ci-dessous."
@@ -546,7 +547,7 @@
     "nInvalidCredentials": "1 identifiant invalide|{count} identifiants invalides",
     "nOperationalCredentials": "1 identifiant fonctionnel|{count} identifiants fonctionnels",
     "nProblematicEndpoints": "1 point d'accès problématique|{count} points d'accès problématiques",
-    "nErrsCredentials": "1 identifiant indique que le point d'accès est problématique|{count} identifiant indique que le point d'accès est problématique",
+    "nErrsCredentials": "1 identifiant indique que le point d'accès est problématique|{count} identifiants indiquent que le point d'accès est problématique",
     "deleteNbCredentials": "Vous allez supprimer {count} identifiant SUSHI.|Vous allez supprimer {count} identifiants SUSHI.",
     "scope": "Périmètre",
     "unchangeableParam": "Paramètre non modifiable défini au niveau du point d'accès.",

--- a/front/locales/fr.json
+++ b/front/locales/fr.json
@@ -723,7 +723,8 @@
   },
   "harvest": {
     "sessions": {
-      "name": "Moissonnage du {createdAt}",
+      "pendingSession": "Moissonnage en attente...",
+      "name": "Moissonnage du {startedAt}",
       "metrics": {
         "success": "Réussi",
         "failed": "Échoué",
@@ -749,7 +750,8 @@
       "beginDate": "Date de début",
       "endDate": "Date de fin",
       "period": "Période",
-      "createdAt": "Demandé le",
+      "startedAt": "Démarré le",
+      "updatedAt": "Mis à jour le",
       "runningTime": "Durée de traitement",
       "index": "Index d'insertion",
       "coveredPeriods": "Mois concernés",

--- a/front/pages/admin/harvests.vue
+++ b/front/pages/admin/harvests.vue
@@ -95,8 +95,7 @@ export default defineComponent({
       return this.sessions.map((item) => ({
         item,
         status: this.sessionStatuses[item.id],
-        // eslint-disable-next-line no-underscore-dangle
-        hasStarted: item._count.jobs > 0,
+        hasStarted: !!item.startedAt,
       }));
     },
   },

--- a/front/pages/admin/harvests.vue
+++ b/front/pages/admin/harvests.vue
@@ -4,7 +4,6 @@
       <v-spacer />
 
       <v-btn
-        color="primary"
         text
         :loading="refreshing"
         @click.stop="refreshHarvests"
@@ -28,120 +27,34 @@
       <template #default="{ items }">
         <v-expansion-panels>
           <v-expansion-panel
-            v-for="item in items"
-            :key="item.data.id"
-            :readonly="item.data._count.jobs <= 0"
+            v-for="{ item, status, hasStarted } in items"
+            :key="item.id"
+            :readonly="!hasStarted"
           >
-            <v-expansion-panel-header>
-              <div style="flex: 1">
-                <div class="mb-2">
-                  {{ $t('harvest.sessions.name', { createdAt: item.createdAtLocale }) }}
-
-                  <span class="text--secondary mx-2" style="font-size: 0.75em;">
-                    ({{ item.data.id }})
-                  </span>
-                </div>
-
-                <div class="d-flex flex-wrap" style="gap: 0.5rem">
-                  <v-tooltip
-                    v-for="tag in sessionChips[item.data.id]"
-                    :key="tag.key"
-                    :disabled="!tag.tooltip"
-                    bottom
-                  >
-                    <template #activator="{ attrs, on }">
-                      <v-chip
-                        outlined
-                        small
-                        v-bind="attrs"
-                        v-on="on"
-                      >
-                        <v-icon v-if="tag.icon" left small>
-                          {{ tag.icon }}
-                        </v-icon>
-
-                        {{ tag.text }}
-                      </v-chip>
-                    </template>
-
-                    {{ tag.tooltip || '' }}
-                  </v-tooltip>
-                </div>
-              </div>
-
-              <div
-                class="d-flex align-center flex-row-reverse mr-2"
-                style="flex: 0.4"
-              >
-                <div v-if="!item.hasStarted" style="text-align: end;">
-                  <v-chip color="error">
-                    {{ $t('harvest.sessions.notStarted') }}
-                  </v-chip>
-                </div>
-                <template v-else>
-                  <v-menu
-                    :disabled="!item.metrics"
-                    transition="slide-y-transition"
-                    open-on-hover
-                    bottom
-                    offset-y
-                  >
-                    <template #activator="{ attrs, on }">
-                      <div style="flex: 1;" v-bind="attrs" v-on="on">
-                        <ProgressLinearStack
-                          :value="item.bars"
-                          height="8"
-                        />
-                      </div>
-                    </template>
-
-                    <v-simple-table>
-                      <template #default>
-                        <tbody>
-                          <template
-                            v-for="([name, count]) in Object.entries(item.metrics ?? {})"
-                          >
-                            <tr
-                              v-if="count > 0"
-                              :key="name"
-                            >
-                              <td>
-                                <v-icon
-                                  v-if="statusIcons[name]"
-                                  :color="statusIcons[name].color"
-                                  class="mr-2"
-                                >
-                                  {{ statusIcons[name].icon }}
-                                </v-icon>
-                                {{ $t(`harvest.sessions.metrics.${name}`) }}
-                              </td>
-                              <td>{{ count }}</td>
-                            </tr>
-                          </template>
-                        </tbody>
-                      </template>
-                    </v-simple-table>
-                  </v-menu>
-
-                  <v-progress-circular
-                    v-if="item.status.isActive"
-                    color="primary"
-                    width="2"
-                    indeterminate
-                  />
-                  <div v-else style="width: 32px;" />
-                </template>
-              </div>
-
-              <template v-if="item.data._count.jobs <= 0" #actions>
-                <div />
+            <v-expansion-panel-header
+              disable-icon-rotate
+              :style="{ cursor: hasStarted ? undefined : 'default' }"
+            >
+              <template #actions="{ open }">
+                <div v-if="!hasStarted" />
+                <v-btn v-else icon>
+                  <v-icon>
+                    {{ open ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
+                  </v-icon>
+                </v-btn>
               </template>
+
+              <HarvestSessionHeader
+                :session="item"
+                :status="status"
+                :has-started="hasStarted"
+              />
             </v-expansion-panel-header>
 
             <v-expansion-panel-content>
               <HarvestJobTable
-                :ref="(ref) => (tables[item.data.id] = ref)"
-                :session-id="item.data.id"
+                :ref="(ref) => (tables[item.id] = ref)"
+                :session-id="item.id"
                 :disabled-filters="['harvestId']"
               />
             </v-expansion-panel-content>
@@ -154,18 +67,17 @@
 
 <script>
 import { defineComponent } from 'vue';
-import { parseISO } from 'date-fns';
-import ProgressLinearStack from '~/components/ProgressLinearStack.vue';
 import ToolBar from '~/components/space/ToolBar.vue';
 import HarvestJobTable from '~/components/harvest/HarvestJobTable.vue';
+import HarvestSessionHeader from '~/components/harvest/HarvestSessionHeader.vue';
 
 export default defineComponent({
   layout: 'space',
   middleware: ['auth', 'terms', 'isAdmin'],
   components: {
-    ProgressLinearStack,
     ToolBar,
     HarvestJobTable,
+    HarvestSessionHeader,
   },
   data: () => ({
     refreshing: false,
@@ -177,150 +89,18 @@ export default defineComponent({
     sessionStatuses: {},
 
     tables: {},
-    openedTooltips: {},
-
-    statusIcons: {
-      success: { icon: 'mdi-check', color: 'green' },
-      failed: { icon: 'mdi-alert-circle-outline', color: 'red' },
-      active: { icon: 'mdi-play', color: 'blue' },
-      delayed: { icon: 'mdi-update', color: 'blue' },
-      pending: { icon: 'mdi-clock-outline' },
-    },
   }),
   computed: {
     sessionItems() {
-      return this.sessions.map((item) => {
-        const status = this.sessionStatuses[item.id];
-
-        const metrics = this.computeMetrics(item);
-
-        return {
-          data: item,
-          status: status ?? {},
-          // eslint-disable-next-line no-underscore-dangle
-          hasStarted: item._count.jobs > 0,
-
-          metrics,
-          counts: this.computeCounts(item),
-          bars: this.computeBars(item, metrics),
-
-          createdAtLocale: this.$dateFunctions.format(parseISO(item.createdAt), 'PPPpp'),
-
-          runningTime: this.$dateFunctions.msToLocalDistance(
-            status?.runningTime,
-            { format: ['days', 'hours', 'minutes', 'seconds'] },
-          ),
-
-        };
-      });
-    },
-    sessionChips() {
-      const chipsPerSession = {};
-
-      // eslint-disable-next-line no-restricted-syntax
-      for (const item of this.sessionItems) {
-        chipsPerSession[item.data.id] = [
-          {
-            key: `${item.data.id}-period`,
-            icon: 'mdi-calendar-range',
-            text: `${item.data.beginDate} ~ ${item.data.endDate}`,
-          },
-          {
-            key: `${item.data.id}-credentials`,
-            icon: 'mdi-key',
-            text: this.$tc(
-              'harvest.sessions.counts.credentials',
-              item.counts.credentials.harvestable || item.counts.credentials.all,
-            ),
-            tooltip: this.$t('harvest.sessions.credentialsTooltip', item.counts.credentials),
-          },
-          {
-            key: `${item.data.id}-reports`,
-            icon: 'mdi-file',
-            text: this.$tc('harvest.sessions.counts.reportTypes', item.counts.reportTypes),
-          },
-          {
-            key: `${item.data.id}-runningTime`,
-            icon: 'mdi-timer-outline',
-            text: item.runningTime,
-          },
-        ];
-      }
-
-      return chipsPerSession;
+      return this.sessions.map((item) => ({
+        item,
+        status: this.sessionStatuses[item.id],
+        // eslint-disable-next-line no-underscore-dangle
+        hasStarted: item._count.jobs > 0,
+      }));
     },
   },
   methods: {
-    computeMetrics(session) {
-      // eslint-disable-next-line no-underscore-dangle
-      const { jobStatuses } = this.sessionStatuses[session.id]?._count ?? { jobStatuses: {} };
-      return {
-        pending: jobStatuses.waiting ?? 0,
-        success: jobStatuses.finished ?? 0,
-        active: jobStatuses.running ?? 0,
-        delayed: jobStatuses.delayed ?? 0,
-        failed: (jobStatuses.failed ?? 0)
-          + (jobStatuses.interrupted ?? 0)
-          + (jobStatuses.cancelled ?? 0),
-      };
-    },
-    computeBars(session, metrics) {
-      const status = this.sessionStatuses[session.id];
-      if (!status) {
-        return [
-          {
-            key: `${session.id}-unknown`,
-            type: 'buffer',
-            value: 1,
-            color: 'primary',
-          },
-        ];
-      }
-
-      // eslint-disable-next-line no-underscore-dangle
-      const getValue = (value) => (value / session._count.jobs);
-
-      return [
-        {
-          key: `${session.id}-success`,
-          color: 'success',
-          value: getValue(metrics.success),
-        },
-        {
-          key: `${session.id}-failed`,
-          color: 'error',
-          value: getValue(metrics.failed),
-        },
-        {
-          key: `${session.id}-active`,
-          color: 'blue',
-          value: getValue(metrics.active),
-        },
-        {
-          key: `${session.id}-delayed`,
-          type: 'buffer',
-          color: 'blue',
-          value: getValue(metrics.delayed),
-        },
-        {
-          key: `${session.id}-pending`,
-          type: 'stream',
-          color: 'grey',
-          value: getValue(metrics.pending),
-        },
-      ];
-    },
-
-    computeCounts(session) {
-      const status = this.sessionStatuses[session.id];
-
-      return {
-        reportTypes: session.reportTypes.length,
-        // eslint-disable-next-line no-underscore-dangle
-        credentials: status?._count.credentials ?? {},
-      };
-    },
-
     async refreshHarvests() {
       this.refreshing = true;
 

--- a/front/pages/admin/harvests.vue
+++ b/front/pages/admin/harvests.vue
@@ -35,6 +35,12 @@
               disable-icon-rotate
               :style="{ cursor: hasStarted ? undefined : 'default' }"
             >
+              <HarvestSessionHeader
+                :session="item"
+                :status="status"
+                :has-started="hasStarted"
+              />
+
               <template #actions="{ open }">
                 <div v-if="!hasStarted" />
                 <v-btn v-else icon>
@@ -43,12 +49,6 @@
                   </v-icon>
                 </v-btn>
               </template>
-
-              <HarvestSessionHeader
-                :session="item"
-                :status="status"
-                :has-started="hasStarted"
-              />
             </v-expansion-panel-header>
 
             <v-expansion-panel-content>


### PR DESCRIPTION
## Features

- Renamed harvest session using start date
- Added sushi harvest status
![image](https://github.com/ezpaarse-project/ezmesure/assets/34627360/69be307c-d880-4407-8cb9-60c3b23cb503)

## Fixs

- removed chevron on sushi checks
- fixed route to get one harvest session