### PR TITLE
test(api): fix use of UserService as a constructor

### DIFF
--- a/api/test/features/indices/create.test.js
+++ b/api/test/features/indices/create.test.js
@@ -22,7 +22,7 @@ describe('[indices]: Test create features', () => {
 
   let adminToken;
   beforeAll(async () => {
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     it(`#01 Should create new index [${indexName}]`, async () => {
@@ -51,7 +51,7 @@ describe('[indices]: Test create features', () => {
       // TODO use service
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     it(`#02 Should not create index [${indexName}]`, async () => {

--- a/api/test/features/indices/delete.test.js
+++ b/api/test/features/indices/delete.test.js
@@ -23,7 +23,7 @@ describe('[indices]: Test delete features', () => {
 
   let adminToken;
   beforeAll(async () => {
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     beforeEach(async () => {
@@ -53,7 +53,7 @@ describe('[indices]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     beforeEach(async () => {
       await indicesPrisma.create(indexName, null, { ignore: [404] });

--- a/api/test/features/institutions/create.test.js
+++ b/api/test/features/institutions/create.test.js
@@ -30,7 +30,7 @@ describe('[institutions]: Test create features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -102,7 +102,7 @@ describe('[institutions]: Test create features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     it(`#02 Should create new institution [${institutionTest.name}]`, async () => {
       const httpAppResponse = await ezmesure({

--- a/api/test/features/institutions/delete.test.js
+++ b/api/test/features/institutions/delete.test.js
@@ -30,7 +30,7 @@ describe('[institutions]: Test delete features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     let institutionId;
@@ -66,7 +66,7 @@ describe('[institutions]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
       const institution = await institutionsPrisma.create({ data: institutionTest });
       institutionId = institution.id;
     });

--- a/api/test/features/institutions/memberships/create.test.js
+++ b/api/test/features/institutions/memberships/create.test.js
@@ -51,7 +51,7 @@ describe('[institutions - memberships]: Test create memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -150,7 +150,7 @@ describe('[institutions - memberships]: Test create memberships features', () =>
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await usersService
+      userManagerToken = await (new UsersService())
         .generateToken(userManagerTest.username, userManagerPassword);
     });
     describe(`With permission [${allPermission}]`, () => {

--- a/api/test/features/institutions/memberships/delete.test.js
+++ b/api/test/features/institutions/memberships/delete.test.js
@@ -55,7 +55,7 @@ describe('[institutions - memberships]: Test delete memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -130,7 +130,7 @@ describe('[institutions - memberships]: Test delete memberships features', () =>
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await usersService
+      userManagerToken = await (new UsersService())
         .generateToken(userManagerTest.username, userManagerPassword);
     });
     describe(`With permission [${allPermission}]`, () => {

--- a/api/test/features/institutions/memberships/read.test.js
+++ b/api/test/features/institutions/memberships/read.test.js
@@ -55,7 +55,7 @@ describe('[institutions - memberships]: Test read memberships features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -139,7 +139,7 @@ describe('[institutions - memberships]: Test read memberships features', () => {
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await usersService
+      userManagerToken = await (new UsersService())
         .generateToken(userManagerTest.username, userManagerPassword);
     });
     describe(`As user with permission [${allPermission}]`, () => {

--- a/api/test/features/institutions/memberships/update.test.js
+++ b/api/test/features/institutions/memberships/update.test.js
@@ -55,7 +55,7 @@ describe('[institutions - memberships]: Test update memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -160,7 +160,7 @@ describe('[institutions - memberships]: Test update memberships features', () =>
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await usersService
+      userManagerToken = await (new UsersService())
         .generateToken(userManagerTest.username, userManagerPassword);
     });
     describe(`With permission [${allPermission}]`, () => {

--- a/api/test/features/institutions/permissions/create.test.js
+++ b/api/test/features/institutions/permissions/create.test.js
@@ -62,7 +62,7 @@ describe('[repository permission]: Test create features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/permissions/delete.test.js
+++ b/api/test/features/institutions/permissions/delete.test.js
@@ -62,7 +62,7 @@ describe('[repository permission]: Test delete features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/permissions/update.test.js
+++ b/api/test/features/institutions/permissions/update.test.js
@@ -66,7 +66,7 @@ describe('[repository permission]: Test update features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/read.test.js
+++ b/api/test/features/institutions/read.test.js
@@ -30,7 +30,7 @@ describe('[institutions]: Test read features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -114,7 +114,7 @@ describe('[institutions]: Test read features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
 
       const institution = await institutionsPrisma.create({ data: institutionTest });
       institutionId = institution.id;

--- a/api/test/features/institutions/subinstitutions/create.test.js
+++ b/api/test/features/institutions/subinstitutions/create.test.js
@@ -47,11 +47,11 @@ describe('[institutions - subinstitution]: Test create features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await UsersService.generateToken(userTest.username, userPassword);
+    userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/subinstitutions/delete.test.js
+++ b/api/test/features/institutions/subinstitutions/delete.test.js
@@ -45,11 +45,11 @@ describe('[institutions - subinstitution]: Test delete features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await UsersService.generateToken(userTest.username, userTest.password);
+    userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/subinstitutions/read.test.js
+++ b/api/test/features/institutions/subinstitutions/read.test.js
@@ -47,11 +47,11 @@ describe('[institutions - subinstitution]: Test read features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await UsersService.generateToken(userTest.username, userPassword);
+    userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/update.test.js
+++ b/api/test/features/institutions/update.test.js
@@ -34,7 +34,7 @@ describe('[institutions]: Test update features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -109,7 +109,7 @@ describe('[institutions]: Test update features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     describe('Institution created by user', () => {
       beforeAll(async () => {

--- a/api/test/features/institutions/validate.test.js
+++ b/api/test/features/institutions/validate.test.js
@@ -30,7 +30,7 @@ describe('[institutions]: Test validate institution features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
 
   describe('As admin', () => {
@@ -91,7 +91,7 @@ describe('[institutions]: Test validate institution features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     let institutionId;
     describe('Institution created by user', () => {

--- a/api/test/features/logs/logs.test.js
+++ b/api/test/features/logs/logs.test.js
@@ -31,7 +31,7 @@ describe('[logs]: Test insert features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
       await indicesPrisma.create(indexName, null, { ignore: [404] });
     });
     describe(`Add [wiley.csv] in [${indexName}] index`, () => {
@@ -71,7 +71,7 @@ describe('[logs]: Test insert features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     // TODO create roles
     describe(`Add [wiley.csv] in [${indexName}] index who has roles`, () => {

--- a/api/test/features/repositories/create.test.js
+++ b/api/test/features/repositories/create.test.js
@@ -41,7 +41,7 @@ describe('[repositories]: Test create features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     });
 
     describe(`Create new repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
@@ -163,7 +163,7 @@ describe('[repositories]: Test create features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe(`Create new repository of type [${ezcounterRepositoryConfig.type}]`, () => {

--- a/api/test/features/repositories/delete.test.js
+++ b/api/test/features/repositories/delete.test.js
@@ -36,7 +36,7 @@ describe('[repositories]: Test delete features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     });
 
     describe(`Delete repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
@@ -73,7 +73,7 @@ describe('[repositories]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe(`Delete repository of type [${ezpaarseRepositoryConfig.type}]`, () => {

--- a/api/test/features/repositories/read.test.js
+++ b/api/test/features/repositories/read.test.js
@@ -40,7 +40,7 @@ describe('[repositories]: Test read features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     });
     describe(`Get repository of type [${ezcounterRepositoryConfig.type}]`, () => {
       let pattern;
@@ -81,7 +81,7 @@ describe('[repositories]: Test read features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     describe(`Get repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
       let pattern;

--- a/api/test/features/repositories/update.test.js
+++ b/api/test/features/repositories/update.test.js
@@ -46,7 +46,7 @@ describe('[repositories]: Test update features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     });
     describe(`Update repository of type [${ezpaarseRepositoryConfig.type}] with [${updateRepositoryConfig.type}]`, () => {
       let pattern;
@@ -96,7 +96,7 @@ describe('[repositories]: Test update features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe(`Update repository of type [${ezpaarseRepositoryConfig.type}] with [${updateRepositoryConfig.type}]`, () => {

--- a/api/test/features/spaces/create.test.js
+++ b/api/test/features/spaces/create.test.js
@@ -42,7 +42,7 @@ describe('[space]: Test create spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
     spaceConfig.institutionId = institutionId;
@@ -92,7 +92,7 @@ describe('[space]: Test create spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     describe(`Create new space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {
       it('#02 Should not create space', async () => {

--- a/api/test/features/spaces/delete.test.js
+++ b/api/test/features/spaces/delete.test.js
@@ -41,7 +41,7 @@ describe('[space]: Test delete spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
   });
@@ -79,7 +79,7 @@ describe('[space]: Test delete spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe(`Delete space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {

--- a/api/test/features/spaces/read.test.js
+++ b/api/test/features/spaces/read.test.js
@@ -41,7 +41,7 @@ describe('[space]: Test read spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
     spaceConfig.institutionId = institutionId;
@@ -89,7 +89,7 @@ describe('[space]: Test read spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe(`Get space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {

--- a/api/test/features/spaces/update.test.js
+++ b/api/test/features/spaces/update.test.js
@@ -46,7 +46,7 @@ describe('[space]: Test update spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
   });
@@ -112,7 +112,7 @@ describe('[space]: Test update spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
     describe(`Update space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {
       let spaceId;

--- a/api/test/features/sushi-endpoints/create.test.js
+++ b/api/test/features/sushi-endpoints/create.test.js
@@ -42,7 +42,7 @@ describe('[sushi-endpoint]: Test create sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Create new sushi-endpoint', () => {
@@ -109,7 +109,7 @@ describe('[sushi-endpoint]: Test create sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe('Create new sushi-endpoint', () => {

--- a/api/test/features/sushi-endpoints/delete.test.js
+++ b/api/test/features/sushi-endpoints/delete.test.js
@@ -42,7 +42,7 @@ describe('[sushi-endpoint]: Test update sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Delete sushi-endpoint', () => {
@@ -81,7 +81,7 @@ describe('[sushi-endpoint]: Test update sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe('Delete sushi-endpoint', () => {

--- a/api/test/features/sushi-endpoints/read.test.js
+++ b/api/test/features/sushi-endpoints/read.test.js
@@ -43,7 +43,7 @@ describe('[sushi-endpoint]: Test read sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     beforeEach(async () => {
@@ -108,7 +108,7 @@ describe('[sushi-endpoint]: Test read sushi-endpoints features', () => {
       await usersPrisma.create({ data: userTest });
       await usersPrisma.acceptTerms(userTest.username);
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     beforeEach(async () => {

--- a/api/test/features/sushi-endpoints/update.test.js
+++ b/api/test/features/sushi-endpoints/update.test.js
@@ -59,7 +59,7 @@ describe('[sushi-endpoint]: Test delete sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Update sushi-endpoint', () => {
@@ -131,7 +131,7 @@ describe('[sushi-endpoint]: Test delete sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe('Update sushi-endpoint', () => {

--- a/api/test/features/sushi/create.test.js
+++ b/api/test/features/sushi/create.test.js
@@ -86,7 +86,7 @@ describe('[sushi]: Test create sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -239,7 +239,7 @@ describe('[sushi]: Test create sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await UsersService.generateToken(userTest.username, userPassword);
+      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/delete.test.js
+++ b/api/test/features/sushi/delete.test.js
@@ -84,7 +84,7 @@ describe('[sushi]: Test delete sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -185,7 +185,7 @@ describe('[sushi]: Test delete sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await UsersService.generateToken(userTest.username, userPassword);
+      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/read.test.js
+++ b/api/test/features/sushi/read.test.js
@@ -85,7 +85,7 @@ describe('[sushi]: Test read sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -207,7 +207,7 @@ describe('[sushi]: Test read sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await UsersService.generateToken(userTest.username, userPassword);
+      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/update.test.js
+++ b/api/test/features/sushi/update.test.js
@@ -98,7 +98,7 @@ describe('[sushi]: Test update sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -256,7 +256,7 @@ describe('[sushi]: Test update sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await UsersService.generateToken(userTest.username, userPassword);
+      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/users/create.test.js
+++ b/api/test/features/users/create.test.js
@@ -28,7 +28,7 @@ describe('[users]: Test create users features', () => {
       let adminToken;
 
       beforeAll(async () => {
-        adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+        adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
       });
 
       it(`#01 Should create new user [${userTest.username}]`, async () => {

--- a/api/test/features/users/delete.test.js
+++ b/api/test/features/users/delete.test.js
@@ -25,7 +25,7 @@ describe('[users]: Test delete users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe(`Delete user [${userTest.username}]`, () => {

--- a/api/test/features/users/impersonate.test.js
+++ b/api/test/features/users/impersonate.test.js
@@ -45,8 +45,8 @@ describe('[users]: Test impersonation features', () => {
     await usersElastic.createUser(regularUser);
 
     const usersService = new UsersService();
-    adminToken = await usersService.generateToken(adminUsername);
-    regularUserToken = await usersService.generateToken(regularUser.username);
+    adminToken = await (new UsersService()).generateToken(adminUsername);
+    regularUserToken = await (new UsersService()).generateToken(regularUser.username);
   });
 
   describe('An admin', () => {

--- a/api/test/features/users/read.test.js
+++ b/api/test/features/users/read.test.js
@@ -26,7 +26,7 @@ describe('[users]: Test read users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('As admin', () => {
     describe('Get all users', () => {
@@ -106,7 +106,7 @@ describe('[users]: Test read users features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await UsersService.generateToken(userTest.username, userTest.password);
+      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
     });
 
     describe('Get all users', () => {

--- a/api/test/features/users/update.test.js
+++ b/api/test/features/users/update.test.js
@@ -32,7 +32,7 @@ describe('[users]: Test update users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await UsersService.generateToken(adminUsername, adminPassword);
+    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
   });
   describe('Update', () => {
     describe('As admin', () => {


### PR DESCRIPTION
Fixes tests that still make use of UsersService static methods which now requires the service to be instantiated