### PR TITLE
feat(front): added harvest action, now we can film a block buster

### DIFF
--- a/front/components/harvest/HarvestCredentialsTable.vue
+++ b/front/components/harvest/HarvestCredentialsTable.vue
@@ -1,0 +1,127 @@
+<template>
+  <v-row>
+    <v-col cols="6">
+      <v-row>
+        <v-col class="d-flex align-center" style="gap: 0.5rem;">
+          <v-icon>mdi-domain</v-icon>
+
+          {{ $t('institutions.toolbarTitle', { count: institutions.length }) }}
+        </v-col>
+      </v-row>
+
+      <v-row>
+        <v-col class="pt-0">
+          <v-list dense two-line>
+            <v-virtual-scroll :items="institutions" height="300" item-height="64">
+              <template #default="{ item }">
+                <v-list-item :key="item.id">
+                  <v-list-item-content>
+                    <v-list-item-title>
+                      {{ item.name }}
+                    </v-list-item-title>
+
+                    <v-list-item-subtitle v-if="item.acronym">
+                      {{ item.acronym }}
+                    </v-list-item-subtitle>
+                  </v-list-item-content>
+                </v-list-item>
+              </template>
+            </v-virtual-scroll>
+          </v-list>
+        </v-col>
+      </v-row>
+    </v-col>
+
+    <v-divider vertical />
+
+    <v-col cols="6">
+      <v-row>
+        <v-col class="d-flex align-center" style="gap: 0.5rem;">
+          <v-icon>mdi-web</v-icon>
+
+          {{ $t('endpoints.title', { count: endpoints.length }) }}
+        </v-col>
+      </v-row>
+
+      <v-row>
+        <v-col class="pt-0">
+          <v-list dense>
+            <v-virtual-scroll :items="endpoints" height="300" item-height="32">
+              <template #default="{ item }">
+                <v-list-item :key="item.id">
+                  <v-list-item-content>
+                    <v-list-item-title>
+                      {{ item.vendor }}
+                    </v-list-item-title>
+                  </v-list-item-content>
+                </v-list-item>
+              </template>
+            </v-virtual-scroll>
+          </v-list>
+        </v-col>
+      </v-row>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  props: {
+    sessionId: {
+      type: String,
+      required: true,
+    },
+  },
+  emit: ['update:loading'],
+  data: () => ({
+    show: false,
+    credentials: [],
+    valid: false,
+  }),
+  computed: {
+    institutions() {
+      const institutions = new Map(
+        this.credentials
+          .map((credential) => [credential.institutionId, credential.institution]),
+      );
+      return [...institutions.values()].sort((a, b) => a.name.localeCompare(b.name));
+    },
+    endpoints() {
+      const endpoints = new Map(
+        this.credentials
+          .map((credential) => [credential.endpointId, credential.endpoint]),
+      );
+      return [...endpoints.values()].sort((a, b) => a.vendor.localeCompare(b.vendor));
+    },
+  },
+  watch: {
+    sessionId: {
+      immediate: true,
+      async handler() {
+        await this.refreshCredentials();
+      },
+    },
+  },
+  methods: {
+    async refreshCredentials() {
+      this.$emit('update:loading', true);
+      try {
+        const { data } = await this.$axios.get(
+          `/harvests-sessions/${this.sessionId}/credentials`,
+          { params: { include: ['endpoint', 'institution'] } },
+        );
+        this.credentials = data;
+      } catch (e) {
+        this.$store.dispatch('snacks/error', this.$t('harvest.sessions.unableToRetrieveCredentials'));
+      }
+      this.$emit('update:loading', false);
+    },
+  },
+});
+</script>
+
+<style scoped>
+
+</style>

--- a/front/components/harvest/HarvestJobTable.vue
+++ b/front/components/harvest/HarvestJobTable.vue
@@ -111,6 +111,59 @@
       <template #[`item.updatedAt`]="{ value }">
         <LocalDate v-if="value" :date="value" />
       </template>
+
+      <template #[`item.actions`]="{ item }">
+        <v-menu>
+          <template #activator="{ on, attrs }">
+            <v-btn
+              icon
+              v-bind="attrs"
+              v-on="on"
+            >
+              <v-icon>
+                mdi-cog
+              </v-icon>
+            </v-btn>
+          </template>
+
+          <v-list>
+            <v-list-item :disabled="!cancellableStatus.has(item.status)" @click="cancelJob(item)">
+              <v-list-item-icon>
+                <v-icon>mdi-cancel</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ $t('cancel') }}
+                </v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+
+            <v-list-item :disabled="!cancellableStatus.has(item.status)" @click="deleteJob(item)">
+              <v-list-item-icon>
+                <v-icon>mdi-delete</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ $t('delete') }}
+                </v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+
+            <v-divider />
+
+            <v-list-item @click="copyId(item)">
+              <v-list-item-icon>
+                <v-icon>mdi-identifier</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ $t('copyId') }}
+                </v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+      </template>
     </v-data-table>
 
     <HarvestJobFilters
@@ -126,11 +179,15 @@
       :statuses="meta?.statuses ?? []"
       @input="refreshJobs(1)"
     />
+
+    <ConfirmDialog ref="confirmDialog" />
   </section>
 </template>
 
 <script>
 import { defineComponent } from 'vue';
+
+import ConfirmDialog from '~/components/ConfirmDialog.vue';
 import ToolBar from '~/components/space/ToolBar.vue';
 import HarvestJobCard from '~/components/harvest/HarvestJobCard.vue';
 import LocalDate from '~/components/LocalDate.vue';
@@ -142,6 +199,7 @@ export default defineComponent({
     LocalDate,
     HarvestJobCard,
     HarvestJobFilters,
+    ConfirmDialog,
   },
   props: {
     sessionId: {
@@ -172,6 +230,8 @@ export default defineComponent({
     tableOptions: {},
 
     refreshing: false,
+
+    cancellableStatus: new Set(['waiting', 'running', 'delayed']),
   }),
   computed: {
     tableHeaders() {
@@ -206,6 +266,11 @@ export default defineComponent({
         {
           text: this.$t('harvest.jobs.updatedAt'),
           value: 'updatedAt',
+        },
+        {
+          text: this.$t('actions'),
+          value: 'actions',
+          width: 0,
         },
       ];
     },
@@ -308,6 +373,62 @@ export default defineComponent({
       }
 
       this.refreshing = false;
+    },
+    async cancelJob(item) {
+      const confirmed = await this.$refs.confirmDialog?.open({
+        title: this.$t('areYouSure'),
+        agreeText: this.$t('cancel'),
+        agreeIcon: 'mdi-cancel',
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.refreshing = true;
+      try {
+        const { data } = await this.$axios.post(`/tasks/${item.id}/_cancel`, {});
+        if (data.status === item.status) {
+          throw new Error("Cancellation wasn't successful");
+        }
+      } catch (e) {
+        this.$store.dispatch('snacks/error', this.$t('harvest.jobs.unableToStop'));
+      }
+
+      this.refreshJobs();
+    },
+    async deleteJob(item) {
+      const confirmed = await this.$refs.confirmDialog?.open({
+        title: this.$t('areYouSure'),
+        agreeText: this.$t('delete'),
+        agreeIcon: 'mdi-delete',
+      });
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.refreshing = true;
+      try {
+        await this.$axios.delete(`/tasks/${item.id}`, {});
+      } catch (e) {
+        this.$store.dispatch('snacks/error', this.$t('harvest.jobs.unableToDelete'));
+      }
+
+      this.refreshJobs();
+    },
+    async copyId(item) {
+      if (!navigator.clipboard) {
+        this.$store.dispatch('snacks/error', this.$t('unableToCopyId'));
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(item.id);
+      } catch (e) {
+        this.$store.dispatch('snacks/error', this.$t('unableToCopyId'));
+        return;
+      }
+      this.$store.dispatch('snacks/info', this.$t('idCopied'));
     },
   },
 });

--- a/front/components/harvest/HarvestJobTable.vue
+++ b/front/components/harvest/HarvestJobTable.vue
@@ -138,7 +138,7 @@
               </v-list-item-content>
             </v-list-item>
 
-            <v-list-item :disabled="!cancellableStatus.has(item.status)" @click="deleteJob(item)">
+            <v-list-item @click="deleteJob(item)">
               <v-list-item-icon>
                 <v-icon>mdi-delete</v-icon>
               </v-list-item-icon>

--- a/front/components/harvest/HarvestJobTable.vue
+++ b/front/components/harvest/HarvestJobTable.vue
@@ -138,7 +138,7 @@
               </v-list-item-content>
             </v-list-item>
 
-            <v-list-item :disabled="!deletableStatus.has(item.status)" @click="deleteJob(item)">
+            <v-list-item :disabled="unDeletableStatus.has(item.status)" @click="deleteJob(item)">
               <v-list-item-icon>
                 <v-icon>mdi-delete</v-icon>
               </v-list-item-icon>
@@ -232,7 +232,7 @@ export default defineComponent({
     refreshing: false,
 
     cancellableStatus: new Set(['waiting', 'running', 'delayed']),
-    deletableStatus: new Set(['running']),
+    unDeletableStatus: new Set(['running']),
   }),
   computed: {
     tableHeaders() {

--- a/front/components/harvest/HarvestJobTable.vue
+++ b/front/components/harvest/HarvestJobTable.vue
@@ -138,7 +138,7 @@
               </v-list-item-content>
             </v-list-item>
 
-            <v-list-item @click="deleteJob(item)">
+            <v-list-item :disabled="!deletableStatus.has(item.status)" @click="deleteJob(item)">
               <v-list-item-icon>
                 <v-icon>mdi-delete</v-icon>
               </v-list-item-icon>
@@ -232,6 +232,7 @@ export default defineComponent({
     refreshing: false,
 
     cancellableStatus: new Set(['waiting', 'running', 'delayed']),
+    deletableStatus: new Set(['running']),
   }),
   computed: {
     tableHeaders() {

--- a/front/components/harvest/HarvestSessionHeader.vue
+++ b/front/components/harvest/HarvestSessionHeader.vue
@@ -14,6 +14,49 @@
 
         <v-row>
           <v-col>
+            <v-menu
+              :disabled="counts.credentials.all <= 0"
+              transition="slide-y-transition"
+              min-width="800"
+              bottom
+              offset-y
+            >
+              <template #activator="{ attrs, on }">
+                <v-chip
+                  :color="counts.credentials.harvestable > 0 ? 'success' : 'error'"
+                  small
+                  class="mr-2"
+                  v-bind="attrs"
+                  v-on="on"
+                >
+                  <v-icon left small>
+                    mdi-key
+                  </v-icon>
+
+                  {{
+                    $tc(
+                      'harvest.sessions.counts.credentials',
+                      counts.credentials.harvestable ?? counts.credentials.all,
+                    )
+                  }}
+                </v-chip>
+              </template>
+
+              <v-card>
+                <v-card-title>
+                  {{ credentialsTitle }}
+                </v-card-title>
+
+                <v-card-subtitle v-if="counts.credentials.harvestable !== counts.credentials.all">
+                  {{ $t('harvest.sessions.credentialsTooltip', counts.credentials) }}
+                </v-card-subtitle>
+
+                <v-card-text>
+                  <HarvestCredentialsTable :session-id="session.id" />
+                </v-card-text>
+              </v-card>
+            </v-menu>
+
             <template v-for="tag in chips">
               <v-tooltip
                 v-if="!tag.hide"
@@ -113,6 +156,7 @@
 import { defineComponent } from 'vue';
 import { parseISO } from 'date-fns';
 import ProgressLinearStack from '~/components/ProgressLinearStack.vue';
+import HarvestCredentialsTable from '~/components/harvest/HarvestCredentialsTable.vue';
 
 const STATUS_ICONS = {
   success: { icon: 'mdi-check', color: 'green' },
@@ -125,6 +169,7 @@ const STATUS_ICONS = {
 export default defineComponent({
   components: {
     ProgressLinearStack,
+    HarvestCredentialsTable,
   },
   props: {
     session: {
@@ -243,15 +288,6 @@ export default defineComponent({
           text: `${this.session.beginDate} ~ ${this.session.endDate}`,
         },
         {
-          key: `${this.session.id}-credentials`,
-          icon: 'mdi-key',
-          text: this.$tc(
-            'harvest.sessions.counts.credentials',
-            this.counts.credentials.harvestable ?? this.counts.credentials.all,
-          ),
-          tooltip: this.$t('harvest.sessions.credentialsTooltip', this.counts.credentials),
-        },
-        {
           key: `${this.session.id}-reports`,
           icon: 'mdi-file',
           text: this.$tc('harvest.sessions.counts.reportTypes', this.counts.reportTypes),
@@ -264,6 +300,13 @@ export default defineComponent({
           text: this.runningTime,
         },
       ];
+    },
+    credentialsTitle() {
+      let total = this.counts.credentials.harvestable;
+      if (this.counts.credentials.harvestable !== this.counts.credentials.all) {
+        total = `${total}/${this.counts.credentials.all}`;
+      }
+      return this.$t('institutions.sushi.title', { total });
     },
   },
 });

--- a/front/locales/en.json
+++ b/front/locales/en.json
@@ -765,7 +765,9 @@
       "updated": "Items Updated",
       "failed": "Items Not Retrieved",
       "unableToRetrive": "Unable to retrieve harvesting tasks",
-      "unableToRetriveMeta": "Unable to retrieve information about harvesting tasks"
+      "unableToRetriveMeta": "Unable to retrieve information about harvesting tasks",
+      "unableToStop": "Unable to stop the harvesting task",
+      "unableToDelete": "Unable to delete the harvesting task"
     }
   },
   "sync": {

--- a/front/locales/fr.json
+++ b/front/locales/fr.json
@@ -765,7 +765,9 @@
       "updated": "Éléments mis à jour",
       "failed": "Éléments non récupérés",
       "unableToRetrive": "Impossible de récupérer les tâches de moissonnage",
-      "unableToRetriveMeta": "Impossible de récupérer les informations à propos des tâches de moissonnage"
+      "unableToRetriveMeta": "Impossible de récupérer les informations à propos des tâches de moissonnage",
+      "unableToStop": "Impossible de stopper la tâche de moissonnage",
+      "unableToDelete": "Impossible de supprimer la tâche de moissonnage"
     }
   },
   "sync": {

--- a/front/pages/admin/harvests.vue
+++ b/front/pages/admin/harvests.vue
@@ -48,6 +48,27 @@
                     {{ open ? 'mdi-chevron-up' : 'mdi-chevron-down' }}
                   </v-icon>
                 </v-btn>
+
+                <v-menu>
+                  <template #activator="{ attrs, on }">
+                    <v-btn icon class="ml-2" v-bind="attrs" v-on="on">
+                      <v-icon>mdi-dots-horizontal</v-icon>
+                    </v-btn>
+                  </template>
+
+                  <v-list>
+                    <v-list-item @click="copyId(item)">
+                      <v-list-item-icon>
+                        <v-icon>mdi-identifier</v-icon>
+                      </v-list-item-icon>
+                      <v-list-item-content>
+                        <v-list-item-title>
+                          {{ $t('copyId') }}
+                        </v-list-item-title>
+                      </v-list-item-content>
+                    </v-list-item>
+                  </v-list>
+                </v-menu>
               </template>
             </v-expansion-panel-header>
 
@@ -143,6 +164,19 @@ export default defineComponent({
       }
 
       this.refreshing = false;
+    },
+    async copyId(item) {
+      if (!navigator.clipboard) {
+        this.$store.dispatch('snacks/error', this.$t('unableToCopyId'));
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(item.id);
+      } catch (e) {
+        this.$store.dispatch('snacks/error', this.$t('unableToCopyId'));
+        return;
+      }
+      this.$store.dispatch('snacks/info', this.$t('idCopied'));
     },
   },
 });


### PR DESCRIPTION
## Added details on concerned credentials

![image](https://github.com/ezpaarse-project/ezmesure/assets/34627360/8569ddb5-a052-4a93-9da4-bbc5412c5800)

## Added actions on harvest sessions

For now it's just a "Copy ID" action, but there's room for more.

![image](https://github.com/ezpaarse-project/ezmesure/assets/34627360/52e477d0-aa96-4679-b724-ed2547a31b55)

## Added actions for harvest jobs

You can cancel, delete and copy id from there.

![image](https://github.com/ezpaarse-project/ezmesure/assets/34627360/c6640c19-9408-41d9-bc3b-f3590c25b75b)
