### PR TITLE
feat: added way to update sushiReadySince without updating whole institution

### DIFF
--- a/api/lib/controllers/institutions/admin.js
+++ b/api/lib/controllers/institutions/admin.js
@@ -1,5 +1,4 @@
 const config = require('config');
-const kibana = require('../../services/kibana');
 
 const { sendMail, generateMail } = require('../../services/mail');
 
@@ -21,27 +20,6 @@ function sendValidateInstitution(receivers) {
     ...generateMail('validated-institution'),
   });
 }
-
-exports.getInstitutionState = async (ctx) => {
-  const { institution } = ctx.state;
-
-  const spaces = await institution.getSpaces();
-
-  const patterns = await Promise.all(
-    spaces
-      .filter((space) => space && space.id)
-      .map((space) => kibana.getIndexPatterns({ spaceId: space.id, perPage: 1000 })),
-  );
-
-  ctx.type = 'json';
-  ctx.status = 200;
-  ctx.body = {
-    spaces,
-    indices: await institution.getIndices(),
-    indexPatterns: patterns.reduce((acc, current) => [...acc, ...current], []),
-    roles: await institution.checkRoles(),
-  };
-};
 
 exports.validateInstitution = async (ctx) => {
   const { body = {} } = ctx.request;

--- a/api/lib/controllers/institutions/index.js
+++ b/api/lib/controllers/institutions/index.js
@@ -20,6 +20,7 @@ const {
   importInstitutions,
   getInstitution,
   updateInstitution,
+  updateInstitutionSushiReady,
 } = require('./actions');
 
 const memberships = require('./memberships');
@@ -33,10 +34,7 @@ const {
   removeSubInstitution,
 } = require('./subinstitutions');
 
-const {
-  getInstitutionState,
-  validateInstitution,
-} = require('./admin');
+const { validateInstitution } = require('./admin');
 
 router.use(sushi.prefix('/:institutionId/sushi').middleware());
 router.use(repositories.prefix('/:institutionId/repositories').middleware());
@@ -111,6 +109,25 @@ router.route({
   },
 });
 
+router.route({
+  method: 'PUT',
+  path: '/:institutionId/sushiReadySince',
+  handler: [
+    fetchInstitution(),
+    requireMemberPermissions(FEATURES.sushi.write),
+    updateInstitutionSushiReady,
+  ],
+  validate: {
+    type: 'json',
+    params: {
+      institutionId: Joi.string().trim().required(),
+    },
+    body: {
+      value: Joi.date().allow(null),
+    },
+  },
+});
+
 router.use(requireAdmin);
 
 router.route({
@@ -119,20 +136,6 @@ router.route({
   handler: [
     fetchInstitution(),
     deleteInstitution,
-  ],
-  validate: {
-    params: {
-      institutionId: Joi.string().trim().required(),
-    },
-  },
-});
-
-router.route({
-  method: 'GET',
-  path: '/:institutionId/state',
-  handler: [
-    fetchInstitution(),
-    getInstitutionState,
   ],
   validate: {
     params: {

--- a/api/lib/controllers/institutions/sushi/index.js
+++ b/api/lib/controllers/institutions/sushi/index.js
@@ -33,4 +33,5 @@ router.route({
     query: standardQueryParams.manyValidation,
   },
 });
+
 module.exports = router;

--- a/api/lib/controllers/openapi.json
+++ b/api/lib/controllers/openapi.json
@@ -3249,7 +3249,8 @@
                 "properties": {
                   "value": {
                     "type": "string",
-                    "format": "date-time"
+                    "format": "date-time",
+                    "nullable": true
                   }
                 },
                 "required": [
@@ -3260,7 +3261,8 @@
           }
         },
         "tags": [
-          "Institutions"
+          "Institutions",
+          "Sushi"
         ]
       }
     },

--- a/api/lib/controllers/openapi.json
+++ b/api/lib/controllers/openapi.json
@@ -3207,6 +3207,63 @@
         ]
       }
     },
+    "/institutions/{id}/sushiReadySince": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "id",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "put": {
+        "summary": "Change sushi readiness state of an institution",
+        "operationId": "put-institutions-id-sushiReadySince",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "description": "Change sushi readiness state of an institution",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": [
+                  "value"
+                ]
+              }
+            }
+          }
+        },
+        "tags": [
+          "Institutions"
+        ]
+      }
+    },
     "/institutions/{id}": {
       "parameters": [
         {
@@ -4027,179 +4084,6 @@
             "description": "Forbidden"
           }
         }
-      }
-    },
-    "/institutions/{id}/state": {
-      "parameters": [
-        {
-          "schema": {
-            "type": "string"
-          },
-          "name": "id",
-          "in": "path",
-          "required": true,
-          "description": "ID of the institution"
-        }
-      ],
-      "get": {
-        "summary": "Get institution state",
-        "tags": [
-          "Institutions",
-          "Administration"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "description": "",
-                  "type": "object",
-                  "x-examples": {
-                    "example-1": {
-                      "space": {
-                        "id": "toulouse",
-                        "name": "toulouse",
-                        "description": "Université Toulouse-II",
-                        "disabledFeatures": []
-                      },
-                      "indices": [
-                        "toulouse",
-                        "toulouse-foo",
-                        "toulouse-foobar"
-                      ],
-                      "indexPatterns": [
-                        {
-                          "id": "902cf200-b97c-11eb-aae3-e9a25566a440",
-                          "title": "toulouse*",
-                          "timeFieldName": "datetime"
-                        },
-                        {
-                          "id": "34a502d0-b391-11e9-8339-63cd4d0c5d94",
-                          "title": "univ-example",
-                          "timeFieldName": "datetime"
-                        }
-                      ],
-                      "roles": {
-                        "base": {
-                          "name": "toulouse",
-                          "exists": true
-                        },
-                        "readonly": {
-                          "name": "toulouse_read_only",
-                          "exists": true
-                        }
-                      }
-                    }
-                  },
-                  "properties": {
-                    "spaces": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/Space"
-                      }
-                    },
-                    "indices": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "indexPatterns": {
-                      "type": "array",
-                      "uniqueItems": true,
-                      "minItems": 1,
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "title": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "timeFieldName": {
-                            "type": "string",
-                            "minLength": 1
-                          },
-                          "spaceId": {
-                            "type": "string",
-                            "nullable": true
-                          }
-                        },
-                        "required": [
-                          "id",
-                          "title"
-                        ]
-                      }
-                    },
-                    "roles": {
-                      "type": "object",
-                      "required": [
-                        "base",
-                        "readonly"
-                      ],
-                      "properties": {
-                        "base": {
-                          "type": "object",
-                          "required": [
-                            "exists"
-                          ],
-                          "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "exists": {
-                              "type": "boolean"
-                            }
-                          }
-                        },
-                        "readonly": {
-                          "type": "object",
-                          "required": [
-                            "exists"
-                          ],
-                          "properties": {
-                            "name": {
-                              "type": "string",
-                              "minLength": 1
-                            },
-                            "exists": {
-                              "type": "boolean"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "spaces",
-                    "indices",
-                    "indexPatterns",
-                    "roles"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          }
-        },
-        "operationId": "get-institutions-id-state",
-        "security": [
-          {
-            "bearerAuth": []
-          }
-        ],
-        "description": "Get the current state of an institution (list spaces, indices, index patterns and roles)",
-        "x-internal": false
       }
     },
     "/logs": {

--- a/front/pages/myspace/institutions/_id/sushi.vue
+++ b/front/pages/myspace/institutions/_id/sushi.vue
@@ -280,6 +280,7 @@
           <v-spacer />
 
           <v-menu
+            v-if="canEdit"
             v-model="showSushiReadyPopup"
             :close-on-content-click="false"
             bottom
@@ -1005,10 +1006,10 @@ export default {
       this.loadingSushiReady = true;
       this.showSushiReadyPopup = false;
 
-      const sushiReadySince = this.institution?.sushiReadySince ? null : new Date();
+      const value = this.institution?.sushiReadySince ? null : new Date();
 
       try {
-        const data = await this.$axios.$put(`/institutions/${this.institution.id}`, { sushiReadySince });
+        const data = await this.$axios.$put(`/institutions/${this.institution.id}/sushiReadySince`, { value });
         this.$set(this.institution, 'sushiReadySince', data?.sushiReadySince);
       } catch (e) {
         this.$store.dispatch('snacks/error', this.$t('errors.generic'));


### PR DESCRIPTION
# API

## New routes

- `PUT /institution/:id/sushiReadySince`

## Deleted routes

- `GET /institution/:id/state`
  - Was unsused
  - Crashed when called because it was using some old way to get institutions
