### PR TITLE
feat: keeping COUNTER registry in endpoints and prefill informations

### DIFF
--- a/api/lib/controllers/sushi-endpoints/_registry/actions.js
+++ b/api/lib/controllers/sushi-endpoints/_registry/actions.js
@@ -1,0 +1,90 @@
+const counterRegistry = require('../../../services/counter-registry');
+
+exports.getAll = async (ctx) => {
+  const platforms = await counterRegistry.getAllPlatforms();
+
+  ctx.type = 'json';
+  ctx.status = 200;
+  ctx.body = platforms.map((p) => ({
+    id: p.id,
+    name: p.abbrev ? `${p.abbrev} (${p.name})` : `${p.name}`,
+    website: p.website,
+    counterVersions: Array.from(new Set(p.sushi_services.map((s) => s.counter_release))),
+  }));
+};
+
+exports.getOne = async (ctx) => {
+  const { id } = ctx.params;
+
+  const platform = await counterRegistry.getPlatform(id);
+  if (!platform) {
+    ctx.throw(404, ctx.$t('errors.sushi-endpoint.notFound'));
+  }
+
+  const endpoint = {
+    vendor: platform.name,
+    registryId: platform.id,
+    description: [],
+    counterVersions: new Set(),
+    technicalProvider: new Set(),
+    tags: new Set(),
+    requireRequestorId: true,
+    requireCustomerId: true,
+    requireApiKey: true,
+  };
+
+  const dataHosts = new Set();
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const service of platform.sushi_services) {
+    const url = counterRegistry.stripCounterVersionFromUrl(service.url, service.counter_release);
+
+    if (endpoint.sushiUrl && url !== endpoint.sushiUrl) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    endpoint.sushiUrl = url;
+    endpoint.counterVersions.add(service.counter_release);
+    dataHosts.add(service.data_host);
+    const description = [];
+
+    endpoint.requireRequestorId = service.requestor_id_required && endpoint.requireRequestorId;
+    endpoint.requireCustomerId = service.customer_id_required && endpoint.requireCustomerId;
+    endpoint.requireApiKey = service.api_key_required && endpoint.requireApiKey;
+
+    if (service.credentials_auto_expire) {
+      let autoExpireText = ctx.$t('sushi-endpoint.credentialsAutoExpire');
+      if (service.credentials_auto_expire) { autoExpireText += `: ${service.credentials_auto_expire}`; }
+      endpoint.tags.add('Expire');
+      description.push(autoExpireText);
+    }
+    if (service.platform_specific_info) {
+      description.push(service.platform_specific_info);
+    }
+
+    if (description.length > 0) {
+      endpoint.description.push(`COUNTER ${service.counter_release}:`, ...description);
+    }
+  }
+
+  await Promise.all(
+    Array.from(dataHosts).map(async (hostUrl) => {
+      const hostId = /usage-data-host\/(.+)\/?$/.exec(hostUrl)?.[1];
+      if (!hostId) { return; }
+
+      const dataHost = await counterRegistry.getDataHost(hostId);
+      endpoint.technicalProvider.add(dataHost.name);
+    }),
+  );
+
+  ctx.type = 'json';
+  ctx.status = 200;
+  ctx.body = {
+    ...endpoint,
+    description: endpoint.description.join('\n'),
+    counterVersions: Array.from(endpoint.counterVersions),
+    technicalProvider: Array.from(endpoint.technicalProvider).join(', '),
+    tags: Array.from(endpoint.tags),
+  };
+};

--- a/api/lib/controllers/sushi-endpoints/_registry/index.js
+++ b/api/lib/controllers/sushi-endpoints/_registry/index.js
@@ -1,0 +1,44 @@
+const router = require('koa-joi-router')();
+const { Joi } = require('koa-joi-router');
+
+const {
+  requireJwt,
+  requireUser,
+  requireTermsOfUse,
+  requireAdmin,
+} = require('../../../services/auth');
+
+const {
+  getAll,
+  getOne,
+} = require('./actions');
+
+router.use(
+  requireJwt,
+  requireUser,
+  requireTermsOfUse,
+  requireAdmin,
+);
+
+router.route({
+  method: 'GET',
+  path: '/',
+  handler: [
+    getAll,
+  ],
+});
+
+router.route({
+  method: 'GET',
+  path: '/:id',
+  handler: [
+    getOne,
+  ],
+  validate: {
+    params: {
+      id: Joi.string(),
+    },
+  },
+});
+
+module.exports = router;

--- a/api/lib/controllers/sushi-endpoints/index.js
+++ b/api/lib/controllers/sushi-endpoints/index.js
@@ -24,6 +24,10 @@ const {
   importEndpoints,
 } = require('./actions');
 
+const registry = require('./_registry');
+
+router.use(registry.prefix('/_registry').middleware());
+
 router.use(
   requireJwt,
   requireUser,

--- a/api/lib/entities/sushi-endpoints.dto.js
+++ b/api/lib/entities/sushi-endpoints.dto.js
@@ -20,6 +20,7 @@ const schema = {
   vendor: Joi.string().min(1),
   description: Joi.string().allow('').empty(null),
   counterVersions: Joi.array().items(Joi.string().regex(/^[0-9]+(\.[0-9]+(\.[0-9]+(\.[0-9]+)?)?)?$/)).min(1),
+  registryId: Joi.string().min(1),
   technicalProvider: Joi.string().allow('').empty(null),
 
   active: Joi.boolean(),

--- a/api/lib/services/counter-registry.js
+++ b/api/lib/services/counter-registry.js
@@ -1,0 +1,94 @@
+const { isValid, isBefore, addHours } = require('date-fns');
+
+const registry = require('axios').create({
+  baseURL: 'https://registry.countermetrics.org/api/v1',
+});
+
+/** @type {{ cachedAt: Date, platforms: object[] } | undefined} */
+let platformsCache;
+/** @type {Map<string, { cachedAt: Date, dataHost: object }>} */
+const dataHostCache = new Map();
+
+/**
+ * Check if cache is invalid, cache lasts 1 hour
+ *
+ * @param {Date | undefined} cachedAt
+ *
+ * @returns {boolean}
+ */
+const isCacheInvalid = (cachedAt) => !cachedAt
+  || !isValid(cachedAt)
+  || isBefore(addHours(cachedAt, 1), new Date());
+
+/**
+ * Get all platforms from counter registry, and cache them for 1 hour
+ *
+ * @returns {Promise<object[]>}
+ */
+async function getAllPlatforms() {
+  if (isCacheInvalid(platformsCache?.cachedAt)) {
+    const { data } = await registry.get('/platform');
+    platformsCache = {
+      platforms: data,
+      cachedAt: new Date(),
+    };
+  }
+
+  return platformsCache.platforms;
+}
+
+/**
+ * Get specific platform from counter registry
+ *
+ * We don't use cache to get newest data
+ *
+ * @param {string} id Id of the platform
+ *
+ * @returns {Promise<object>}
+ */
+async function getPlatform(id) {
+  const { data } = await registry.get(`/platform/${id}`);
+  return data;
+}
+
+/**
+ * Get specific data host, and cache them for 1 hour
+ *
+ * @param {string} id Id of the data host
+ *
+ * @returns {Promise<object>}
+ */
+async function getDataHost(id) {
+  let { dataHost, cachedAt } = dataHostCache.get(id) ?? {};
+  if (isCacheInvalid(cachedAt)) {
+    ({ data: dataHost } = await registry.get(`/usage-data-host/${id}`));
+    cachedAt = new Date();
+
+    dataHostCache.set(id, { dataHost, cachedAt });
+  }
+  return dataHost;
+}
+
+/**
+ * Strip known counter version from url
+ *
+ * @param {string} url The url of the endpoint
+ * @param {string} version The version of the endpoint
+ *
+ * @returns {string} URL without known counter version
+ */
+function stripCounterVersionFromUrl(url, version) {
+  let result = url;
+  if (version.startsWith('5.1')) {
+    result = url.replace(/\/r51\/?$/, '/');
+  }
+
+  return result.replace(/\/$/, '');
+}
+
+module.exports = {
+  getAllPlatforms,
+  getPlatform,
+  getDataHost,
+  stripCounterVersionFromUrl,
+};

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -433,6 +433,8 @@ model SushiEndpoint {
   harvestDateFormat         String?
   /// Report used when testing endpoint
   testedReport              String?
+  /// Id of platform in https://registry.countermetrics.org
+  registryId                String?
   /// SUSHI credentials associated with the endpoint
   credentials               SushiCredentials[]
   /// Additionnal default parameters. Each param has a name, a value, and a scope.

--- a/front/components/sushiEndpoint/Details.vue
+++ b/front/components/sushiEndpoint/Details.vue
@@ -61,8 +61,15 @@ const fields = computed(() => [
   { value: props.modelValue.sushiUrl || '', label: t('endpoints.url'), cols: 8 },
   { value: props.modelValue.technicalProvider || '-', label: t('endpoints.technicalProvider'), cols: 4 },
 
-  { value: props.modelValue.requireCustomerId ? t('yes') : t('no'), label: t('institutions.sushi.requestorId'), cols: 4 },
-  { value: props.modelValue.requireRequestorId ? t('yes') : t('no'), label: t('institutions.sushi.customerId'), cols: 4 },
-  { value: props.modelValue.requireApiKey ? t('yes') : t('no'), label: t('institutions.sushi.apiKey'), cols: 4 },
-]);
+  { value: props.modelValue.requireCustomerId ? t('yes') : t('no'), label: t('endpoints.requireRequestorId'), cols: 4 },
+  { value: props.modelValue.requireRequestorId ? t('yes') : t('no'), label: t('endpoints.requireCustomerId'), cols: 4 },
+  { value: props.modelValue.requireApiKey ? t('yes') : t('no'), label: t('endpoints.requireApiKey'), cols: 4 },
+
+  {
+    value: `https://registry.countermetrics.org/platform/${props.modelValue.registryId}`,
+    label: t('endpoints.registryUrl'),
+    cols: 12,
+    hide: !props.modelValue.registryId,
+  },
+].filter((v) => v.hide !== true));
 </script>

--- a/front/components/sushiEndpoint/Form.vue
+++ b/front/components/sushiEndpoint/Form.vue
@@ -5,6 +5,15 @@
     prepend-icon="mdi-server-plus"
   >
     <template #text>
+      <v-row v-if="!isEditing">
+        <v-col>
+          <SushiEndpointRegistrySearch
+            v-model="registryEndpoint"
+            @update:endpoint="applyRegistryEndpoint($event)"
+          />
+        </v-col>
+      </v-row>
+
       <v-row>
         <v-col>
           <v-form
@@ -128,6 +137,30 @@
                         />
                       </template>
                     </v-combobox>
+                  </v-col>
+
+                  <v-col cols="12">
+                    <v-text-field
+                      v-model="endpoint.registryId"
+                      :label="$t('endpoints.registryId')"
+                      :hint="$t('endpoints.registryIdHint')"
+                      prepend-icon="mdi-identifier"
+                      variant="underlined"
+                      hide-details="auto"
+                      @update:model-value="extractIdFromUrl($event)"
+                    >
+                      <template v-if="endpoint.registryId" #append>
+                        <v-btn
+                          icon="mdi-open-in-new"
+                          :href="`https://registry.countermetrics.org/platform/${endpoint.registryId}`"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          variant="text"
+                          density="comfortable"
+                          size="small"
+                        />
+                      </template>
+                    </v-text-field>
                   </v-col>
 
                   <v-col cols="12">
@@ -314,7 +347,7 @@
           <v-btn
             :disabled="!valid"
             :text="$t('endpoints.checkEndpoint')"
-            color="primary"
+            color="accent"
             variant="tonal"
             v-bind="menu"
           />
@@ -378,6 +411,7 @@ const saving = ref(false);
 const valid = ref(false);
 const isConnectionMenuOpen = ref(false);
 const loadingTags = ref(false);
+const registryEndpoint = ref();
 const endpoint = ref({ ...(props.modelValue ?? { counterVersions: ['5'] }) });
 
 /** @type {Ref<Object | null>} */
@@ -470,6 +504,25 @@ async function save() {
   }
 
   saving.value = false;
+}
+
+function applyRegistryEndpoint(e) {
+  if (!e) {
+    endpoint.value.registryId = '';
+    return;
+  }
+  endpoint.value = e;
+}
+
+function extractIdFromUrl(url) {
+  if (!url.trim().startsWith('https://registry.countermetrics.org/')) {
+    return;
+  }
+
+  const id = /\/platform\/(.+)\/?$/.exec(url)?.[1];
+  if (id) {
+    endpoint.value.registryId = id;
+  }
 }
 
 onMounted(() => {

--- a/front/components/sushiEndpoint/registry/Search.vue
+++ b/front/components/sushiEndpoint/registry/Search.vue
@@ -1,0 +1,82 @@
+<template>
+  <v-autocomplete
+    v-model="selected"
+    :label="$t('endpoints.searchRegistryData')"
+    :items="items ?? []"
+    :loading="(status === 'pending' || endpointLoading) && 'primary'"
+    :error="!!error"
+    :error-messages="error ? [error.message] : []"
+    no-data-text="endpoints.searchRegistryDataHint"
+    item-value="id"
+    item-title="name"
+    prepend-icon="mdi-database-search"
+    hide-details="auto"
+    clearable
+    return-object
+    @click:clear="selected = null"
+  >
+    <template #item="{ item: { raw: item }, props: listItem }">
+      <v-list-item
+        :title="item.vendor"
+        :subtitle="item.website"
+        lines="two"
+        v-bind="listItem"
+      >
+        <template #append>
+          <SushiEndpointVersionsChip :model-value="item" end />
+        </template>
+      </v-list-item>
+    </template>
+  </v-autocomplete>
+</template>
+
+<script setup>
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    default: () => null,
+  },
+});
+
+const emit = defineEmits({
+  'update:modelValue': (value) => typeof value === 'object',
+  'update:endpoint': (value) => typeof value === 'object',
+});
+
+const { t } = useI18n();
+const snacks = useSnacksStore();
+
+const endpointLoading = ref(false);
+
+const {
+  data: items,
+  status,
+  error,
+} = await useFetch(
+  '/api/sushi-endpoints/_registry/',
+  { lazy: true },
+);
+
+async function fetchEndpoint(id) {
+  endpointLoading.value = true;
+  try {
+    const endpoint = await $fetch(`/api/sushi-endpoints/_registry/${id}`);
+    emit('update:endpoint', endpoint);
+  } catch {
+    snacks.error(t('errors.generic'));
+  }
+  endpointLoading.value = false;
+}
+
+const selected = computed({
+  get: () => props.modelValue,
+  set: (v) => {
+    if (v) {
+      fetchEndpoint(v.id);
+    } else {
+      emit('update:endpoint', undefined);
+    }
+    emit('update:modelValue', v);
+  },
+});
+</script>

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -253,6 +253,7 @@ endpoints:
   searchRegistryDataHint: Search for a platform by name
   registryId: Platform ID in the COUNTER registry
   registryIdHint: You can directly paste the URL of the COUNTER registry
+  registryUrl: Link to the COUNTER registry
 institutions:
   toolbarTitle: Institutions ({count})
   title: Institution

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -52,7 +52,7 @@ myspace:
   infos: My informations
   repos: My repositories
   spaces: My spaces
-  roles: 'My roles:'
+  roles: "My roles:"
 files:
   title: My Deposits
   manageN: >
@@ -65,9 +65,9 @@ files:
   modified: Modified
   size: Size
   category:
-    pending: 'Pending'
-    loading: 'Loading'
-    finished: 'Finished'
+    pending: "Pending"
+    loading: "Loading"
+    finished: "Finished"
   letAdmin: Transfer to admin team
   letAdminDesc: Please note that the upload is not immediate, and will be done as soon as possible
   selectIndex: Select an index
@@ -83,7 +83,7 @@ files:
   validatingFile: Validation of the file...
   isWaiting: Waiting
   isNotCSV: This file is not a CSV
-  markFieldIncorrectlyFormatted: 'Row #${lineNumber}: A field in quotes is formatted incorrectly.'
+  markFieldIncorrectlyFormatted: "Row #${lineNumber}: A field in quotes is formatted incorrectly."
   missingField: '"{missingField}" is missing'
   fieldIsEmpty: 'Line #{lineNumber}: "{field}" is blank.'
   invalidField: 'Line #{lineNumber}: "{field}" is not valid, has the file been modified ?'
@@ -102,15 +102,17 @@ kibana:
     text: Don't remember your password? Click on {reset} to receive a reset email.
     reset: reset
   whatDoesUsername:
-    text: This username allows you to connect to the Kibana interface in order to
+    text:
+      This username allows you to connect to the Kibana interface in order to
       access your dashboards. To change your password, go to your {accountLink}.
     accountLink: Kibana account
 token:
   title: Authentication token
   whatDoesToken:
-    text: 'This token is required to use the ezMESURE API. To use it, add the following
-      header to your HTTP requests: {header}'
-    header: 'Authorization: Bearer [insert the token here]'
+    text:
+      "This token is required to use the ezMESURE API. To use it, add the following
+      header to your HTTP requests: {header}"
+    header: "Authorization: Bearer [insert the token here]"
   token: Token
   unableToRetrieveToken: Unable to retrieve authentication token
   copyFailed: The copy of the token failed
@@ -247,6 +249,10 @@ endpoints:
   checkEndpoint: Test endpoint
   filters:
     title: Filter endpoints
+  searchRegistryData: Search in the COUNTER registry
+  searchRegistryDataHint: Search for a platform by name
+  registryId: Platform ID in the COUNTER registry
+  registryIdHint: You can directly paste the URL of the COUNTER registry
 institutions:
   toolbarTitle: Institutions ({count})
   title: Institution
@@ -291,7 +297,8 @@ institutions:
     indexCount: Indexed consultation events
     indexPrefix: Allocated prefix for indices
     namespace: Institution namespace
-    namespaceHint: Prefix added to entities related to the institution (repositories,
+    namespaceHint:
+      Prefix added to entities related to the institution (repositories,
       Kibana spaces)
     role: Associated role
     uai: RAU
@@ -314,8 +321,8 @@ institutions:
     automations: Automations
     monitor: Monitoring
     dropImageHere: Drop your image here
-    invalidImageFile: 'Invalid image file. Accepted file types: JPEG, PNG, SVG'
-    imageTooLarge: 'Image is too large. Maximum allowed size: 2mb'
+    invalidImageFile: "Invalid image file. Accepted file types: JPEG, PNG, SVG"
+    imageTooLarge: "Image is too large. Maximum allowed size: 2mb"
     noDataFound: Your institution's information could not be retrieved.
     dataSent: Institution informations transmitted
     updated: Institution updated
@@ -340,7 +347,7 @@ institutions:
       ezmesure: Transfers into ezMESURE
       reporting: Periodic usage reports
       sushi: SUSHI harvesting
-    mustMatch: 'Must match: {pattern}'
+    mustMatch: "Must match: {pattern}"
     searchOpenData: Search among known institutions
     searchOpenDataHint: Search an institution by name, location, UAI code, siret number...
     searchEmpty: No institution matches the query.
@@ -373,7 +380,7 @@ institutions:
     updated: Member updated
     email: Email address *
     emailExample: e.g. john{'@'}doe.fr
-    thisMemberIs: 'This member is :'
+    thisMemberIs: "This member is :"
     enterValidEmail: Please enter a valid email.
     members: Members
     addMember: Add a member
@@ -402,7 +409,8 @@ institutions:
       sushi: SUSHI credentials
   sushi:
     title: SUSHI credentials ({count})
-    pageDescription: Here you can enter the SUSHI credentials that will be used to
+    pageDescription:
+      Here you can enter the SUSHI credentials that will be used to
       automatically harvest your COUNTER reports.
     pageDescription2: Only version 5 of the SUSHI protocol is supported.
     addCredentials: Add credentials
@@ -412,7 +420,8 @@ institutions:
     tags: Tags
     packages: Packages
     packagesHint: Profiles, accounts, funds, antennas, etc. that include the credentials.
-    packagesDescription: Profiles, accounts, funds, antennas, etc. that include the
+    packagesDescription:
+      Profiles, accounts, funds, antennas, etc. that include the
       credentials. The packages will be usable in your dashboards, using the X_Package
       field
     unableToRetriveSushiData: Unable to retrieve sushi information
@@ -451,7 +460,7 @@ institutions:
     invalidCredentialsShort: Invalid
     connectionSuccessful:
       title: Successful connection
-      desc: 'A test report has been successfuly downloaded, or generated errors that are not related to authentication (ex: unavailable period).'
+      desc: "A test report has been successfuly downloaded, or generated errors that are not related to authentication (ex: unavailable period)."
     connectionFailed:
       title: Connection failed
       desc: An error occurred when communicating with the endpoint. The team is in contact with the publisher to find out why.
@@ -556,17 +565,17 @@ tasks:
     terminatedIn: Terminated in {duration}
     deletedItems: "{n} deleted documents"
     processedItems: "{n} processed items"
-    progress: 'Progress: {progress}%'
+    progress: "Progress: {progress}%"
     labels:
       download: Report download
       validation: Report validation
       index: Index preparation
       insert: Insert in Elasticsearch
   params:
-    reportType: 'Report type:'
-    sessionId: 'Session identifier:'
-    period: 'Period:'
-    index: 'Indice:'
+    reportType: "Report type:"
+    sessionId: "Session identifier:"
+    period: "Period:"
+    index: "Indice:"
 sushi:
   filters:
     title: Filters credentials
@@ -609,7 +618,7 @@ sushi:
   insertedItems: "{count} report items have been inserted."
   updatedItems: "{count} report items have been updated."
   failedItems: "{count} report items could not be retrieved."
-  messagesFromEndpoint: 'Messages from the endpoint:'
+  messagesFromEndpoint: "Messages from the endpoint:"
   checkBeforeSave: Check credentials before saving
   matrix:
     unsupported: Report not supported (editor declaration)
@@ -634,7 +643,8 @@ reports:
   checkCredentials: Check credentials
   supportedReports: Supported reports
   supportedReportsOnPlatform: Reports supported by the publisher platform
-  supportedReportsUnavailable: The list of supported reports is not available for
+  supportedReportsUnavailable:
+    The list of supported reports is not available for
     this publisher platform.
   failedToFetchReports: Failed to fetch the list of available reports
   onlyShowMasterReports: Only show master reports
@@ -660,7 +670,8 @@ password:
   repeatPassword: Repeat password
   passwordIsRequired: Password required
   backToLogin: Back to login
-  enterUser: Please enter your username so we can send you an email to retrieve your
+  enterUser:
+    Please enter your username so we can send you an email to retrieve your
     password.
   checkYourEmail: Check your email for a link to reset your password.
   waitFewMinutes: If it doesn’t appear within a few minutes, check your spam folder
@@ -692,8 +703,8 @@ contact:
   endpointDetails: If you have knowledge of other elements (required authentication keys, technical provider, etc.), please indicate them below.
   additionalInformation: Additional information
 errors:
-  '404': La page demandée n'a pas été trouvée
-  '500': An internal error occurred
+  "404": La page demandée n'a pas été trouvée
+  "500": An internal error occurred
   generic: An unexpected error has occurred
 account:
   title: Account activation
@@ -842,12 +853,15 @@ sync:
     completed: Synchronized
     error: Error occurred during synchronization
   description:
-    notSynced: The data of ezMESURE are not yet synchronized, you may encounter some
+    notSynced:
+      The data of ezMESURE are not yet synchronized, you may encounter some
       incoherences between ezMESURE's interface and the different services linked
       to ezMESURE. Just click on the button above to synchronize.
-    completed: The data of ezMESURE have been successfully synchronized with the different
+    completed:
+      The data of ezMESURE have been successfully synchronized with the different
       services linked to ezMESURE.
-    error: An error occurred during the synchronization of ezMESURE data with the
+    error:
+      An error occurred during the synchronization of ezMESURE data with the
       different services linked to ezMESURE. Please check your instance logs for more
       information.
   start: Launch synchronization
@@ -926,15 +940,15 @@ invalidDate: Invalid date
 invalidFormat: Invalid format
 areYouSure: Are you sure ?
 fieldIsRequired: This field is required
-fieldMustMatch: 'This field must match : {pattern}'
-maxLength: 'Maximum length: {n} characters'
+fieldMustMatch: "This field must match : {pattern}"
+maxLength: "Maximum length: {n} characters"
 open: Open
 send: Send
-'yes': 'Yes'
-'no': 'No'
+"yes": "Yes"
+"no": "No"
 validate: Validate
 invalidate: Invalidate
-reason: 'Reason: {reason}'
+reason: "Reason: {reason}"
 groupBy: Group by
 indeterminate: indeterminate
 noMatchFor: No results matching "{search}". Press {key} to add it.

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -254,6 +254,7 @@ endpoints:
   searchRegistryDataHint: Chercher une plateforme par nom
   registryId: ID de la plateforme dans le registre COUNTER
   registryIdHint: Vous pouvez directement coller l'URL du registre COUNTER
+  registryUrl: Lien vers le registre COUNTER
   filters:
     title: Filtrer les points d'accès
 institutions:

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -250,6 +250,10 @@ endpoints:
   disabledUntil: Désactivé jusqu'au
   disabledUntilDesc: Ce point d'accès est désactivé, ce qui signifie que toutes les tâches de moissonnage de ce point d'accès seront suspendues jusqu'a cette date.
   checkEndpoint: Tester le point d'accès
+  searchRegistryData: Rechercher dans le registre COUNTER
+  searchRegistryDataHint: Chercher une plateforme par nom
+  registryId: ID de la plateforme dans le registre COUNTER
+  registryIdHint: Vous pouvez directement coller l'URL du registre COUNTER
   filters:
     title: Filtrer les points d'accès
 institutions:


### PR DESCRIPTION
# API

- [X] Add wrapper around COUNTER registry
- [X] Cache COUNTER responses
- [X] Add routes to query registry

## New routes

- `GET /sushi-endpoints/_registry`
- `GET /sushi-endpoints/_registry/:id`

# Front

- [X] Add search bar
- [X] Prefill informations
- [X] Add link to COUNTER Registry

![image](https://github.com/user-attachments/assets/06377d6e-c91d-41da-b7de-f303d785f0d8)
![image](https://github.com/user-attachments/assets/9f6f8f82-f384-491d-b621-1645ed03bd2b)
