### PR TITLE
feat: renamed SUSHI into COUNTER

### DIFF
--- a/api/locales/en.yml
+++ b/api/locales/en.yml
@@ -11,7 +11,7 @@ errors:
 
   harvest:
     noTarget: Please provide a target index, or associate a prefix to the institution [%s]
-    taskExists: "SUSHI item [%s] already have an associated task (status: [%s])"
+    taskExists: "COUNTER credentials [%s] already have an associated task (status: [%s])"
     invalidDate: The date [%s] is invalid
     invalidPeriod: The period [from %s to %s] is invalid
     failedToUpdateSupportedReports: Failed to update the list of supported reports
@@ -31,25 +31,25 @@ errors:
     noUserFound: No user found
 
   sushi-endpoint:
-    notFound: Endpoint not found
+    notFound: COUNTER API not found
 
     import:
-      alreadyExists: Endpoint [%s] already exists
+      alreadyExists: COUNTER API [%s] already exists
 
   sushi:
     unauthorized: You are not authorized to manage sushi credentials
     institutionNotValidated: "Cannot manage sushi credentials : institution is not validated"
-    notFound: SUSHI item not found
-    emptyEndpointResponse: SUSHI endpoint returned an empty response
-    invalidResponse: The SUSHI endpoint responded with invalid data
-    notJsonResponse: "The endpoint response is not in JSON format (type: %s)"
-    badStatus: The endpoint responded with %s %s
+    notFound: COUNTER credentials not found
+    emptyEndpointResponse: COUNTER API returned an empty response
+    invalidResponse: The COUNTER API responded with invalid data
+    notJsonResponse: "The API response is not in JSON format (type: %s)"
+    badStatus: The API responded with %s %s
     requestFailed: Request failed for an unknown reason
-    managementLocked: SUSHI credentials management is currently locked
+    managementLocked: COUNTER credentials management is currently locked
 
     import:
-      belongsToAnother: SUSHI item [%s] belongs to an other institution
-      alreadyExists: SUSHI item [%s] already exists
+      belongsToAnother: COUNTER credentials [%s] belongs to an other institution
+      alreadyExists: COUNTER credentials [%s] already exists
 
   task:
     notFound: Tâche introuvable

--- a/api/locales/en.yml
+++ b/api/locales/en.yml
@@ -31,19 +31,19 @@ errors:
     noUserFound: No user found
 
   sushi-endpoint:
-    notFound: COUNTER API not found
+    notFound: COUNTER endpoint not found
 
     import:
-      alreadyExists: COUNTER API [%s] already exists
+      alreadyExists: COUNTER endpoint [%s] already exists
 
   sushi:
     unauthorized: You are not authorized to manage sushi credentials
     institutionNotValidated: "Cannot manage sushi credentials : institution is not validated"
     notFound: COUNTER credentials not found
-    emptyEndpointResponse: COUNTER API returned an empty response
-    invalidResponse: The COUNTER API responded with invalid data
-    notJsonResponse: "The API response is not in JSON format (type: %s)"
-    badStatus: The API responded with %s %s
+    emptyEndpointResponse: COUNTER endpoint returned an empty response
+    invalidResponse: The COUNTER endpoint responded with invalid data
+    notJsonResponse: "The endpoint response is not in JSON format (type: %s)"
+    badStatus: The endpoint responded with %s %s
     requestFailed: Request failed for an unknown reason
     managementLocked: COUNTER credentials management is currently locked
 

--- a/api/locales/fr.yml
+++ b/api/locales/fr.yml
@@ -11,7 +11,7 @@ errors:
 
   harvest:
     noTarget: Veuillez spécifier un index cible, ou associer un préfixe à l'établissement [%s]
-    taskExists: "L'item SUSHI [%s] a déjà une tâche associée (statut: [%s])"
+    taskExists: "Les identifiants COUNTER [%s] ont déjà une tâche associée (statut: [%s])"
     invalidDate: La date [%s] est invalide
     invalidPeriod: La période [de %s à %s] est invalide
     failedToUpdateSupportedReports: La mise à jour de la liste des rapports disponibles a échoué
@@ -31,25 +31,25 @@ errors:
     noUserFound: Utilisateur introuvable
 
   sushi-endpoint:
-    notFound: Point d'accès introuvable
+    notFound: API COUNTER introuvable
 
     import:
-      alreadyExists: Le point d'accès [%s] existe déjà
+      alreadyExists: L'API COUNTER [%s] existe déjà
 
   sushi:
-    unauthorized: Vous n'êtes pas autorisé à gérer les identifiants SUSHI
-    institutionNotValidated: "Impossible de gérer les identifiants SUSHI : l'établissement n'est pas validé"
-    notFound: Item SUSHI introuvable
-    emptyEndpointResponse: Le point d'accès SUSHI a retourné une réponse vide
-    invalidResponse: Le point d'accès SUSHI a retourné des données invalides
+    unauthorized: Vous n'êtes pas autorisé à gérer les identifiants COUNTER
+    institutionNotValidated: "Impossible de gérer les identifiants COUNTER : l'établissement n'est pas validé"
+    notFound: Item COUNTER introuvable
+    emptyEndpointResponse: L'API COUNTER a retourné une réponse vide
+    invalidResponse: L'API COUNTER a retourné des données invalides
     notJsonResponse: "La réponse du point d'accès n'est pas au format JSON (type: %s)"
-    badStatus: Le point d'accès a répondu avec un code %s %s
+    badStatus: L'API a répondu avec un code %s %s
     requestFailed: La requête a échoué pour une raison indéterminée
-    managementLocked: La gestion des identifiants SUSHI est actuellement verrouillée
+    managementLocked: La gestion des identifiants COUNTER est actuellement verrouillée
 
     import:
-      belongsToAnother: L'item SUSHI [%s] appartient à un autre établissement
-      alreadyExists: L'item SUSHI [%s] existe déjà
+      belongsToAnother: Les identifiants COUNTER [%s] appartient à un autre établissement
+      alreadyExists: Les identifiants COUNTER [%s] existent déjà
 
   task:
     notFound: Tâche introuvable

--- a/api/locales/fr.yml
+++ b/api/locales/fr.yml
@@ -48,7 +48,7 @@ errors:
     managementLocked: La gestion des identifiants COUNTER est actuellement verrouillée
 
     import:
-      belongsToAnother: Les identifiants COUNTER [%s] appartient à un autre établissement
+      belongsToAnother: Les identifiants COUNTER [%s] appartiennent à un autre établissement
       alreadyExists: Les identifiants COUNTER [%s] existent déjà
 
   task:

--- a/api/locales/fr.yml
+++ b/api/locales/fr.yml
@@ -31,19 +31,19 @@ errors:
     noUserFound: Utilisateur introuvable
 
   sushi-endpoint:
-    notFound: API COUNTER introuvable
+    notFound: Point d'accès COUNTER introuvable
 
     import:
-      alreadyExists: L'API COUNTER [%s] existe déjà
+      alreadyExists: Le point d'accès COUNTER [%s] existe déjà
 
   sushi:
     unauthorized: Vous n'êtes pas autorisé à gérer les identifiants COUNTER
     institutionNotValidated: "Impossible de gérer les identifiants COUNTER : l'établissement n'est pas validé"
     notFound: Item COUNTER introuvable
-    emptyEndpointResponse: L'API COUNTER a retourné une réponse vide
-    invalidResponse: L'API COUNTER a retourné des données invalides
+    emptyEndpointResponse: Le point d'accès COUNTER a retourné une réponse vide
+    invalidResponse: Le point d'accès COUNTER a retourné des données invalides
     notJsonResponse: "La réponse du point d'accès n'est pas au format JSON (type: %s)"
-    badStatus: L'API a répondu avec un code %s %s
+    badStatus: Le point d'accès a répondu avec un code %s %s
     requestFailed: La requête a échoué pour une raison indéterminée
     managementLocked: La gestion des identifiants COUNTER est actuellement verrouillée
 

--- a/front/components/currentUser/institution/Card.vue
+++ b/front/components/currentUser/institution/Card.vue
@@ -46,6 +46,17 @@
       </template>
     </v-card-subtitle>
 
+    <div v-if="allowedActions.institution" class="px-4 mt-2">
+      <v-btn
+        :text="$t('institutions.modify')"
+        prepend-icon="mdi-pencil"
+        color="blue"
+        variant="flat"
+        block
+        @click="$emit('click:update', institution)"
+      />
+    </div>
+
     <div class="bg-primary">
       <div class="d-flex justify-space-evenly mt-2 py-2">
         <v-btn
@@ -65,7 +76,7 @@
         />
 
         <v-btn
-          :text="$t('menu.report')"
+          :text="$t('institutions.reports.reports')"
           :to="`/myspace/institutions/${institution.id}/reports`"
           :disabled="!allowedActions.reports"
           prepend-icon="mdi-file-chart-outline"
@@ -140,16 +151,6 @@
         </v-tabs-window-item>
       </v-tabs-window>
     </v-card-text>
-
-    <v-card-actions v-if="allowedActions.institution">
-      <v-btn
-        :text="$t('modify')"
-        prepend-icon="mdi-pencil"
-        color="blue"
-        block
-        @click="$emit('click:update', institution)"
-      />
-    </v-card-actions>
   </v-card>
 </template>
 

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -13,7 +13,7 @@ menu:
   myInstitution: My institution
   myInstitutions: My institutions
   institutions: Institutions
-  sushiEndpoints: COUNTER API
+  sushiEndpoints: COUNTER endpoints
   activity: Activity
   profile: Profile
   members: Members
@@ -151,7 +151,7 @@ activity:
     exports: Exports
     indices: Indices
     sushi: COUNTER credentials
-    endpoints: COUNTER API
+    endpoints: COUNTER endpoints
     reporting: Reporting
   actions:
     user/register: Registering
@@ -195,14 +195,14 @@ activity:
     reporting/history: Reporting task history consultation
 endpoints:
   endpoint: Endpoint
-  toolbarTitle: COUNTER API ({count})
-  pageDescription: Here you can manage the list of the available COUNTER API.
+  toolbarTitle: COUNTER endpoints ({count})
+  pageDescription: Here you can manage the list of the available COUNTER endpoints.
   pageDescription2: Only version 5 of the COUNTER protocol is supported.
   manageEndpoints: >
     Manage endpoint
     |Manage {count} endpoints
   unableToRetriveEndpoints: Unable to retrieve COUNTER APIS
-  soapWarning: The URL seems to point to an unsupported COUNTER API (version 4 or below)
+  soapWarning: The URL seems to point to an unsupported COUNTER endpoint (version 4 or below)
   sushiNotRootDetected: It seems that the COUNTER URL does not point to the root of the service. It should not contain /reports, /status ou /member.
   validated: Validated
   addEndpoint: Add an endpoint
@@ -637,7 +637,7 @@ sushi:
     noFilesAvailable: No files available
     nbFiles: 1 file|{count} files
 reports:
-  sushiReturnedErrors: The COUNTER API responded with errors.
+  sushiReturnedErrors: The COUNTER endpoint responded with errors.
   checkCredentials: Check credentials
   supportedReports: Supported reports
   supportedReportsOnPlatform: Reports supported by the publisher platform
@@ -688,14 +688,14 @@ contact:
   failed: Sending the contact form failed.
   requestInformation: Information request
   bugReport: Bug report
-  declareSushiEndpoint: Declare a COUNTER API
+  declareSushiEndpoint: Declare a COUNTER endpoint
   emailIsRequired: The email address is required
   emailMustBeValid: The email address must be valid
   contentIsRequired: A message is required
   subjectIsRequired: Subject is required
   sushiIsRequired: COUNTER credentials are required
   endpointVendor: Vendor name
-  endpointUrl: URL of the COUNTER API
+  endpointUrl: URL of the COUNTER endpoint
   pleaseEnterFullVendorName: Please enter the full name (possibly with its acronym)
   sushiDetails: Please provide credentials to be used to test this endpoint, admin team will use them to confirm that the endpoint is valid and COUNTER5 compliant.
   endpointDetails: If you have knowledge of other elements (required authentication keys, technical provider, etc.), please indicate them below.

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -279,6 +279,7 @@ institutions:
   joinInstitution: Would you join {institution} ?
   joinInstitutionEmail: A message will be sent to the correspondents of this institution to let them know.
   createMailContactList: Copy the emails of the correspondents
+  modify: Modify my institution
   reports:
     reports: Reports
   filters:
@@ -440,7 +441,7 @@ institutions:
     enterCustomerId: Please enter a Customer Id.
     enterAPIKey: Please enter an API Key.
     comment: Comment
-    credentials: Sushi credentials
+    credentials: COUNTER
     manageN: >
       Manage credentials
       |Manage {count} credentials

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -13,11 +13,10 @@ menu:
   myInstitution: My institution
   myInstitutions: My institutions
   institutions: Institutions
-  sushiEndpoints: SUSHI endpoints
+  sushiEndpoints: COUNTER API
   activity: Activity
   profile: Profile
   members: Members
-  sushi: Sushi
   users: Users
   logout: Logout
   contact: Contact
@@ -138,7 +137,6 @@ partners:
     ezcounter: ezCOUNTER
     ezreeport: ezREEPORT
     report: Reporting
-    sushi: SUSHI
 activity:
   action: Action
   user: User
@@ -152,8 +150,8 @@ activity:
     institutions: Institutions
     exports: Exports
     indices: Indices
-    sushi: SUSHI credentials
-    endpoints: SUSHI endpoints
+    sushi: COUNTER credentials
+    endpoints: COUNTER API
     reporting: Reporting
   actions:
     user/register: Registering
@@ -176,14 +174,14 @@ activity:
     indices/delete: Index deletion
     indices/search: Search
     indices/insert: Data load
-    sushi/create: SUSHI credentials creation
-    sushi/update: SUSHI credentials update
-    sushi/delete: SUSHI credentials deletion
-    sushi/delete-many: Bulk SUSHI credentials deletion
-    sushi/download-report: SUSHI report download
-    sushi/harvest: SUSHI harvest
-    sushi/import: SUSHI credentials import
-    sushi/check-connection: SUSHI connection test
+    sushi/create: COUNTER credentials creation
+    sushi/update: COUNTER credentials update
+    sushi/delete: COUNTER credentials deletion
+    sushi/delete-many: Bulk COUNTER credentials deletion
+    sushi/download-report: COUNTER report download
+    sushi/harvest: COUNTER harvest
+    sushi/import: COUNTER credentials import
+    sushi/check-connection: COUNTER connection test
     endpoint/create: Endpoint creation
     endpoint/update: Endpoint update
     endpoint/delete: Endpoint deletion
@@ -197,15 +195,15 @@ activity:
     reporting/history: Reporting task history consultation
 endpoints:
   endpoint: Endpoint
-  toolbarTitle: SUSHI endpoints ({count})
-  pageDescription: Here you can manage the list of the available SUSHI endpoints.
-  pageDescription2: Only version 5 of the SUSHI protocol is supported.
+  toolbarTitle: COUNTER API ({count})
+  pageDescription: Here you can manage the list of the available COUNTER API.
+  pageDescription2: Only version 5 of the COUNTER protocol is supported.
   manageEndpoints: >
     Manage endpoint
     |Manage {count} endpoints
-  unableToRetriveEndpoints: Unable to retrieve SUSHI endpoints
-  soapWarning: The URL seems to point to an unsupported SUSHI endpoint (version 4 or below)
-  sushiNotRootDetected: It seems that the SUSHI URL does not point to the root of the service. It should not contain /reports, /status ou /member.
+  unableToRetriveEndpoints: Unable to retrieve COUNTER APIS
+  soapWarning: The URL seems to point to an unsupported COUNTER API (version 4 or below)
+  sushiNotRootDetected: It seems that the COUNTER URL does not point to the root of the service. It should not contain /reports, /status ou /member.
   validated: Validated
   addEndpoint: Add an endpoint
   updateEndpoint: Update endpoint
@@ -229,7 +227,7 @@ endpoints:
   requireCustomerId: Customer ID is required
   requireRequestorId: Requestor ID is required
   requireApiKey: An API key is required
-  isSushiCompliant: The endpoint is SUSHI compliant
+  isSushiCompliant: The endpoint is COUNTER compliant
   harvestedReports: Harvested reports
   ignoredReportsDesc: The reports listed below will be considered as unsupported, even if they are present in the list provided by the endpoint.
   ignoredReports: Ignored reports
@@ -348,7 +346,7 @@ institutions:
       ezpaarse: Log processing with ezPAARSE
       ezmesure: Transfers into ezMESURE
       reporting: Periodic usage reports
-      sushi: SUSHI harvesting
+      sushi: COUNTER harvesting
     mustMatch: "Must match: {pattern}"
     searchOpenData: Search among known institutions
     searchOpenDataHint: Search an institution by name, location, UAI code, siret number...
@@ -408,13 +406,11 @@ institutions:
     featureLabels:
       institution: Institution card
       memberships: Members
-      sushi: SUSHI credentials
+      sushi: COUNTER credentials
   sushi:
-    title: SUSHI credentials ({count})
-    pageDescription:
-      Here you can enter the SUSHI credentials that will be used to
-      automatically harvest your COUNTER reports.
-    pageDescription2: Only version 5 of the SUSHI protocol is supported.
+    title: COUNTER credentials ({count})
+    pageDescription: Here you can enter the COUNTER credentials that will be used to automatically harvest your COUNTER reports.
+    pageDescription2: Only version 5 of the COUNTER protocol is supported.
     addCredentials: Add credentials
     updateCredentials: Update credentials
     unabletToRetriveSushiInformations: Unable to retrieve information from sushi platforms
@@ -544,7 +540,7 @@ tasks:
       invalid_json: The downloaded report is not in the good format (JSON), or has syntax issues.
       max_defferals_exceeded: After several attempts, the report was still not ready.
       unauthorized: Authentication to the endpoint failed. Check that your credentials are entered correctly.
-      invalid_report: The downloaded report is not valid, or include changes that are not SUSHI compliant.
+      invalid_report: The downloaded report is not valid, or include changes that are not COUNTER compliant.
       sushi:1000: The report could not be harvested because the endpoint is unreachable.
       sushi:1010: The endpoint is unable to provide the report because it's under heavy load.
       sushi:1020: The endpoint refuses to provide the report because the number of requests is too high.
@@ -592,7 +588,7 @@ sushi:
   latestImport: Latest import
   unableToUpdate: Unable to update credentials
   unableToGetLockStatus: Failed to retrieve credentials lock status
-  managementIsLocked: SUSHI credentials management is currently locked.
+  managementIsLocked: COUNTER credentials management is currently locked.
   nInstitutions: >
     1 institution use this endpoint
     |{count} institutions use this endpoint
@@ -606,7 +602,7 @@ sushi:
     1 credential show that endpoint is problematic
     |{count} credentials show that endpoint is problematic
   problematicEndpoint: Problematic endpoint
-  deleteNbCredentials: You are about to delete {number} SUSHI credentials.
+  deleteNbCredentials: You are about to delete {number} COUNTER credentials.
   scope: Scope
   unchangeableParam: Unchangeable parameter defined at the access point level.
   harvestState: Harvest state
@@ -627,7 +623,7 @@ sushi:
     ignored: Report not supported (ezMESURE finding)
   noMatrix:
     title: No harvested report for these credentials on this period
-    description: These credentials have not yet been harvested for this period. Please validate your SUSHI credentials to be harvested in the future by the administration team.
+    description: These credentials have not yet been harvested for this period. Please validate your COUNTER credentials to be harvested in the future by the administration team.
   paramScopes:
     all: All requests to the endpoint
     report_list: Report list
@@ -641,7 +637,7 @@ sushi:
     noFilesAvailable: No files available
     nbFiles: 1 file|{count} files
 reports:
-  sushiReturnedErrors: The SUSHI endpoint responded with errors.
+  sushiReturnedErrors: The COUNTER API responded with errors.
   checkCredentials: Check credentials
   supportedReports: Supported reports
   supportedReportsOnPlatform: Reports supported by the publisher platform
@@ -692,14 +688,14 @@ contact:
   failed: Sending the contact form failed.
   requestInformation: Information request
   bugReport: Bug report
-  declareSushiEndpoint: Declare a SUSHI endpoint
+  declareSushiEndpoint: Declare a COUNTER API
   emailIsRequired: The email address is required
   emailMustBeValid: The email address must be valid
   contentIsRequired: A message is required
   subjectIsRequired: Subject is required
-  sushiIsRequired: SUSHI credentials are required
+  sushiIsRequired: COUNTER credentials are required
   endpointVendor: Vendor name
-  endpointUrl: URL of the SUSHI endpoint
+  endpointUrl: URL of the COUNTER API
   pleaseEnterFullVendorName: Please enter the full name (possibly with its acronym)
   sushiDetails: Please provide credentials to be used to test this endpoint, admin team will use them to confirm that the endpoint is valid and COUNTER5 compliant.
   endpointDetails: If you have knowledge of other elements (required authentication keys, technical provider, etc.), please indicate them below.

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -201,7 +201,7 @@ endpoints:
   manageEndpoints: >
     Manage endpoint
     |Manage {count} endpoints
-  unableToRetriveEndpoints: Unable to retrieve COUNTER APIS
+  unableToRetriveEndpoints: Unable to retrieve COUNTER endpoints
   soapWarning: The URL seems to point to an unsupported COUNTER endpoint (version 4 or below)
   sushiNotRootDetected: It seems that the COUNTER URL does not point to the root of the service. It should not contain /reports, /status ou /member.
   validated: Validated

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -13,7 +13,7 @@ menu:
   myInstitution: Mon établissement
   myInstitutions: Mes établissements
   institutions: Établissements
-  sushiEndpoints: API COUNTER
+  sushiEndpoints: Points d'accès COUNTER
   activity: Activité
   profile: Profil
   members: Membres
@@ -152,7 +152,7 @@ activity:
     exports: Exports
     indices: Index
     sushi: Identifiants COUNTER
-    endpoints: API COUNTER
+    endpoints: Points d'accès COUNTER
     reporting: Reporting
   actions:
     user/register: Enregistrement
@@ -196,14 +196,14 @@ activity:
     reporting/history: Consultation de l'historique d'une tâche de reporting
 endpoints:
   endpoint: Point d'accès
-  toolbarTitle: API COUNTER ({count})
-  pageDescription: Gérez ici la liste des API COUNTER disponibles.
+  toolbarTitle: Point d'accès COUNTER ({count})
+  pageDescription: Gérez ici la liste des points d'accès COUNTER disponibles.
   pageDescription2: Seule la version 5 du protocole COUNTER est supportée.
   manageEndpoints: >
     Gérer le point d'accès
     |Gérer {count} points d'accès
-  unableToRetriveEndpoints: Impossible de récupérer les aAPI
-  soapWarning: L'URL semble pointer vers une API COUNTER non supporté (version 4 ou inférieure)
+  unableToRetriveEndpoints: Impossible de récupérer les point's d'accès
+  soapWarning: L'URL semble pointer vers un point d'accès COUNTER non supporté (version 4 ou inférieure)
   sushiNotRootDetected: L'URL COUNTER ne semble pas pointer vers la racine du service. Celle-ci ne devrait pas contenir /reports, /status ou /member.
   validated: Validé
   addEndpoint: Ajouter un point d'accès
@@ -651,7 +651,7 @@ sushi:
     noFilesAvailable: Aucun fichier disponible
     nbFiles: 1 fichier|{count} fichiers
 reports:
-  sushiReturnedErrors: L'API COUNTER a retourné des erreurs.
+  sushiReturnedErrors: Le point d'accès COUNTER a retourné des erreurs.
   checkCredentials: Vérifier les identifiants
   supportedReports: Rapports supportés
   supportedReportsOnPlatform: Rapports supportés par la plateforme éditeur
@@ -697,14 +697,14 @@ contact:
   failed: L'envoi du formulaire de contact a échoué.
   requestInformation: Demande d'information
   bugReport: Rapporter un bug
-  declareSushiEndpoint: Déclarer une API COUNTER
+  declareSushiEndpoint: Déclarer un point d'accès COUNTER
   emailIsRequired: L'adresse électronique est requise
   emailMustBeValid: L'adresse électronique doit être valide
   sushiIsRequired: Des identifiants COUNTER sont requis
   contentIsRequired: Un message est requis
   subjectIsRequired: L'objet est requis
   endpointVendor: Nom du fournisseur
-  endpointUrl: URL de l'API COUNTER
+  endpointUrl: URL du point d'accès COUNTER
   pleaseEnterFullVendorName: Veuillez rentrer le nom complet (accompagné éventuellement de son acronyme)
   sushiDetails: Merci de préciser des identifiants à utiliser pour tester ce point d'accès, l'équipe d'administration les utilisera pour confirmer que ce dernier est fonctionnel et compatible COUNTER5.
   endpointDetails: Si vous avez connaissance d'autres éléments (clés d'authentification requises, prestataire technique, etc.), veuillez les indiquer ci-dessous.

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -284,6 +284,7 @@ institutions:
   joinInstitution: Vous souhaitez rejoindre {institution} ?
   joinInstitutionEmail: Un email sera envoyé aux correspondants de cet établissement afin qu'ils puissent vous ajouter.
   createMailContactList: Copier les adresses mails des correspondants
+  modify: Modifier mon établissement
   reports:
     reports: Rapports
   filters:
@@ -441,7 +442,7 @@ institutions:
     enterCustomerId: Veuillez saisir un Customer Id.
     enterAPIKey: Veuillez saisir une Clé API.
     comment: Commentaire
-    credentials: ezCOUNTER
+    credentials: COUNTER
     manageN: >
       Gérer les identifiants
       |Gérer {count} identifiants

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -13,11 +13,10 @@ menu:
   myInstitution: Mon établissement
   myInstitutions: Mes établissements
   institutions: Établissements
-  sushiEndpoints: Points d'accès SUSHI
+  sushiEndpoints: API COUNTER
   activity: Activité
   profile: Profil
   members: Membres
-  sushi: Sushi
   users: Utilisateurs
   logout: Déconnexion
   contact: Contact
@@ -139,7 +138,6 @@ partners:
     ezcounter: ezCOUNTER
     ezreeport: ezREEPORT
     report: Reporting
-    sushi: SUSHI
 activity:
   action: Action
   user: Utilisateur
@@ -153,8 +151,8 @@ activity:
     institutions: Établissements
     exports: Exports
     indices: Index
-    sushi: Identifiants SUSHI
-    endpoints: Points d'accès SUSHI
+    sushi: Identifiants COUNTER
+    endpoints: API COUNTER
     reporting: Reporting
   actions:
     user/register: Enregistrement
@@ -177,14 +175,14 @@ activity:
     indices/delete: Suppression d'index
     indices/search: Recherche
     indices/insert: Chargement de données
-    sushi/create: Création d'identifiant SUSHI
-    sushi/update: Mise à jour d'identifiant SUSHI
-    sushi/delete: Suppression d'identifiant SUSHI
-    sushi/delete-many: Suppression par lot d'identifiants SUSHI
-    sushi/download-report: Téléchargement de rapport SUSHI
-    sushi/harvest: Moissonnage SUSHI
-    sushi/import: Import d'identifiants SUSHI
-    sushi/check-connection: Test de connexion SUSHI
+    sushi/create: Création d'identifiant COUNTER
+    sushi/update: Mise à jour d'identifiant COUNTER
+    sushi/delete: Suppression d'identifiant COUNTER
+    sushi/delete-many: Suppression par lot d'identifiants COUNTER
+    sushi/download-report: Téléchargement de rapport COUNTER
+    sushi/harvest: Moissonnage COUNTER
+    sushi/import: Import d'identifiants COUNTER
+    sushi/check-connection: Test de connexion COUNTER
     endpoint/create: Création de point d'accès
     endpoint/update: Mise à jour de point d'accès
     endpoint/delete: Suppression de point d'accès
@@ -198,15 +196,15 @@ activity:
     reporting/history: Consultation de l'historique d'une tâche de reporting
 endpoints:
   endpoint: Point d'accès
-  toolbarTitle: Points d'accès SUSHI ({count})
-  pageDescription: Gérez ici la liste des points d'accès SUSHI disponibles.
-  pageDescription2: Seule la version 5 du protocole SUSHI est supportée.
+  toolbarTitle: API COUNTER ({count})
+  pageDescription: Gérez ici la liste des API COUNTER disponibles.
+  pageDescription2: Seule la version 5 du protocole COUNTER est supportée.
   manageEndpoints: >
     Gérer le point d'accès
     |Gérer {count} points d'accès
-  unableToRetriveEndpoints: Impossible de récupérer les points d'accès
-  soapWarning: L'URL semble pointer vers un service SUSHI non supporté (version 4 ou inférieure)
-  sushiNotRootDetected: L'URL SUSHI ne semble pas pointer vers la racine du service. Celle-ci ne devrait pas contenir /reports, /status ou /member.
+  unableToRetriveEndpoints: Impossible de récupérer les aAPI
+  soapWarning: L'URL semble pointer vers une API COUNTER non supporté (version 4 ou inférieure)
+  sushiNotRootDetected: L'URL COUNTER ne semble pas pointer vers la racine du service. Celle-ci ne devrait pas contenir /reports, /status ou /member.
   validated: Validé
   addEndpoint: Ajouter un point d'accès
   updateEndpoint: Mettre à jour le point d'accès
@@ -230,7 +228,7 @@ endpoints:
   requireCustomerId: Un customer ID est nécessaire
   requireRequestorId: Un requestor ID est nécessaire
   requireApiKey: Une clé d'API est nécessaire
-  isSushiCompliant: Le point d'accès est conforme SUSHI
+  isSushiCompliant: Le point d'accès est conforme COUNTER
   harvestedReports: Rapports moissonnés
   ignoredReportsDesc: Les rapports saisis ci-dessous seront considérés comme non-supportés, même s'ils sont présents dans la liste fournie par le point d'accès.
   ignoredReports: Rapports ignorés
@@ -351,7 +349,7 @@ institutions:
       ezpaarse: Traitements des logs avec ezPAARSE
       ezmesure: Reversements dans ezMESURE
       reporting: Rapports d'usage périodiques
-      sushi: Moissonnage SUSHI
+      sushi: Moissonnage COUNTER
     mustMatch: 'Doit correspondre à : {pattern}'
     searchOpenData: Chercher parmi les établissements connus
     searchOpenDataHint: Chercher un établissement par nom, localité, code UAI, numéro de siret...
@@ -411,12 +409,12 @@ institutions:
     featureLabels:
       institution: Fiche établissement
       memberships: Membres
-      sushi: Identifiants SUSHI
-      reporting: Reporting
+      sushi: ezCOUNTER
+      reporting: ezREEPORT
   sushi:
-    title: Identifiants SUSHI ({count})
-    pageDescription: Entrez ici les identifiants SUSHI qui serviront à moissonner automatiquement vos rapports COUNTER.
-    pageDescription2: Seule la version 5 du protocole SUSHI est supportée.
+    title: Identifiants COUNTER ({count})
+    pageDescription: Entrez ici les identifiants COUNTER qui serviront à moissonner automatiquement vos rapports.
+    pageDescription2: Seule la version 5 du protocole COUNTER est supportée.
     addCredentials: Ajouter des identifiants
     updateCredentials: Mettre à jour des identifiants
     unabletToRetriveSushiInformations: Impossible de récupérer les informations des plateformes sushi
@@ -546,7 +544,7 @@ tasks:
       invalid_json: Le rapport téléchargé n'est pas au bon format (JSON), ou présente des problèmes de syntaxe.
       max_defferals_exceeded: Après plusieurs tentatives, le rapport n'était toujours pas prêt.
       unauthorized: L'identification auprès du point d'accès a échoué. Vérifiez que vos identifiants sont correctement saisis.
-      invalid_report: Le rapport téléchargé n'est pas valide, ou contient des modifications qui ne font pas partie du standard SUSHI.
+      invalid_report: Le rapport téléchargé n'est pas valide, ou contient des modifications qui ne font pas partie du standard COUNTER.
       sushi:1000: La rapport n'a pas pu être moissonné car le point d'accès n'est pas accessible.
       sushi:1010: Le point d'accès est dans l'incapacité de fournir le rapport en raison d'une forte charge.
       sushi:1020: Le point d'accès refuse de fournir le rapport en raison d'un nombre de requêtes trop élevé.
@@ -596,7 +594,7 @@ sushi:
   latestImport: Dernier import
   unableToUpdate: Impossible de modifier l'identifiant
   unableToGetLockStatus: Impossible de récupérer l'état de verrouillage des identifiants
-  managementIsLocked: La gestion des identifiants SUSHI est actuellement verrouillée.
+  managementIsLocked: La gestion des identifiants COUNTER est actuellement verrouillée.
   nInstitutions: >
     1 établissement utilise cet endpoint
     |{count} établissements utilisent cet endpoint
@@ -616,8 +614,8 @@ sushi:
     1 identifiant indique que le point d'accès est problématique
     |{count} identifiants indiquent que le point d'accès est problématique
   deleteNbCredentials: >
-    Vous allez supprimer {count} identifiant SUSHI.
-    |Vous allez supprimer {count} identifiants SUSHI.
+    Vous allez supprimer {count} identifiant COUNTER.
+    |Vous allez supprimer {count} identifiants COUNTER.
   problematicEndpoint: Point d'accès problématique
   scope: Périmètre
   unchangeableParam: Paramètre non modifiable défini au niveau du point d'accès.
@@ -639,7 +637,7 @@ sushi:
     ignored: Rapport non supporté (constat ezMESURE)
   noMatrix:
     title: Aucun rapport moissonné pour ces identifiants sur cette période
-    description: Ces identifiants n'ont pas encore été moissonnés pour cette période. Veuillez validez vos identifiants SUSHI pour être moissonné prochainement par l'équipe d'administration.
+    description: Ces identifiants n'ont pas encore été moissonnés pour cette période. Veuillez validez vos identifiants COUNTER pour être moissonné prochainement par l'équipe d'administration.
   paramScopes:
     all: Toutes les requêtes au point d'accès
     report_list: Listing des rapports
@@ -653,7 +651,7 @@ sushi:
     noFilesAvailable: Aucun fichier disponible
     nbFiles: 1 fichier|{count} fichiers
 reports:
-  sushiReturnedErrors: Le point d'accès SUSHI a retourné des erreurs.
+  sushiReturnedErrors: L'API COUNTER a retourné des erreurs.
   checkCredentials: Vérifier les identifiants
   supportedReports: Rapports supportés
   supportedReportsOnPlatform: Rapports supportés par la plateforme éditeur
@@ -699,14 +697,14 @@ contact:
   failed: L'envoi du formulaire de contact a échoué.
   requestInformation: Demande d'information
   bugReport: Rapporter un bug
-  declareSushiEndpoint: Déclarer un point d'accès SUSHI
+  declareSushiEndpoint: Déclarer une API COUNTER
   emailIsRequired: L'adresse électronique est requise
   emailMustBeValid: L'adresse électronique doit être valide
-  sushiIsRequired: Des identifiants SUSHI sont requis
+  sushiIsRequired: Des identifiants COUNTER sont requis
   contentIsRequired: Un message est requis
   subjectIsRequired: L'objet est requis
   endpointVendor: Nom du fournisseur
-  endpointUrl: URL du point d'accès SUSHI
+  endpointUrl: URL de l'API COUNTER
   pleaseEnterFullVendorName: Veuillez rentrer le nom complet (accompagné éventuellement de son acronyme)
   sushiDetails: Merci de préciser des identifiants à utiliser pour tester ce point d'accès, l'équipe d'administration les utilisera pour confirmer que ce dernier est fonctionnel et compatible COUNTER5.
   endpointDetails: Si vous avez connaissance d'autres éléments (clés d'authentification requises, prestataire technique, etc.), veuillez les indiquer ci-dessous.


### PR DESCRIPTION
## Why this change ?

Because from COUNTER version 5.1 and upwards, `SUSHI` term is dropped and we don't want to confuse users by mixing `COUNTER` and `SUSHI`.

From [COUNTER 5.1.0.1 Manifest](https://cop5.projectcounter.org/en/5.1.0.1/appendices/a-glossary-of-terms.html)
> SUSHI and COUNTER_SUSHI_API were references to SUSHI-Lite, the RESTful version of SUSHI that was described in an unpublished NISO Technical Report. **The preferred term is COUNTER API**.

From [COUNTER 5.1.0.1 OpenAPI](https://countermetrics.stoplight.io/docs/counter-sushi-api/au9uaf0yg84mo-counter-api) :
> This version of the **COUNTER API (formerly sushi)** applies to Release 5.1.0.1 of the COUNTER Code of Practice, which can be read online at https://cop5.countermetrics.org/.

## How

This PR doesn't change code, databases tables or i18n key to avoid big migrations. It only affects locale files by replacing `SUSHI` by `COUNTER`, `SUSHI endpoint` by `COUNTER endpoint` and so on.

![image](https://github.com/user-attachments/assets/72057ca9-13dd-4383-b775-02b537d875c2)
![image](https://github.com/user-attachments/assets/39de210b-7239-4ed5-be9c-58e8a8568d74)
