### PR TITLE
Feature/password reset

### DIFF
--- a/api/lib/controllers/auth/auth.js
+++ b/api/lib/controllers/auth/auth.js
@@ -273,7 +273,7 @@ exports.resetPassword = async (ctx) => {
     const tokenIsValid = isBefore(parseISO(user?.metadata?.passwordDate), parseISO(createdAt));
 
     if (!tokenIsValid) {
-      ctx.throw(404, ctx.$t('errors.password.expires'));
+      ctx.throw(400, ctx.$t('errors.password.expires'));
       return;
     }
   }

--- a/api/lib/controllers/auth/auth.js
+++ b/api/lib/controllers/auth/auth.js
@@ -15,6 +15,8 @@ const { sendPasswordRecovery, sendWelcomeMail, sendNewUserToContacts } = require
 const secret = config.get('auth.secret');
 const cookie = config.get('auth.cookie');
 
+const resetPasswordSecret = `${secret}_password_reset`;
+
 const standardMembershipsQueryParams = prepareStandardQueryParams({
   schema: membershipSchema,
   includableFields: includableMembershipFields,
@@ -247,7 +249,7 @@ exports.getResetToken = async (ctx) => {
     username: user.username,
     createdAt: currentDate,
     expiresAt,
-  }, secret);
+  }, resetPasswordSecret);
 
   const diffInHours = config.get('passwordResetValidity');
   await sendPasswordRecovery(user, {
@@ -260,9 +262,20 @@ exports.getResetToken = async (ctx) => {
 };
 
 exports.resetPassword = async (ctx) => {
-  const { password } = ctx.request.body;
-  const { username } = ctx.state.user;
-  const { createdAt } = ctx.state.jwtdata;
+  const { password, token } = ctx.request.body;
+
+  const { valid, data } = await new Promise((resolve) => {
+    jwt.verify(token, resetPasswordSecret, (err, decoded) => {
+      resolve({ valid: !err, data: decoded });
+    });
+  });
+
+  if (!valid || !data?.username || !data?.createdAt) {
+    ctx.throw(400, ctx.$t('errors.password.invalidToken'));
+    return;
+  }
+
+  const { username, createdAt } = data;
 
   const usersService = new UsersService();
   const user = await usersService.findUnique({ where: { username } });

--- a/api/lib/controllers/auth/index.js
+++ b/api/lib/controllers/auth/index.js
@@ -32,8 +32,6 @@ router.route({
   },
 });
 
-router.use(requireJwt, requireUser);
-
 router.route({
   method: 'POST',
   path: '/password/_reset',
@@ -45,9 +43,12 @@ router.route({
     type: 'json',
     body: Joi.object({
       password: Joi.string().trim().min(6).required(),
+      token: Joi.string().trim().required(),
     }),
   },
 });
+
+router.use(requireJwt, requireUser);
 
 router.route({
   method: 'POST',

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -679,6 +679,7 @@ password:
   waitFewMinutes: If it doesn’t appear within a few minutes, check your spam folder
   notEqual: Passwords don't match
   updated: Password updated
+  youCanNowLogin: You can now log in with your new credentials.
   pattern: Minimum 6 characters
   length: The password must be at least 6 characters long
   update: Update your password

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -686,6 +686,7 @@ password:
   waitFewMinutes: S'il n'apparaît pas dans les minutes qui suivent, vérifiez votre dossier spam.
   notEqual: Les mots de passes ne correspondent pas
   updated: Mot de passe mis à jour
+  youCanNowLogin: Vous pouvez maintenant vous connecter avec vos nouveaux identifiants.
   pattern: Minimum 6 caractères
   length: Le mot de passe doit contenir au moins 6 caractères
   update: Mettre à jour votre mot de passe

--- a/front/pages/password/new.vue
+++ b/front/pages/password/new.vue
@@ -24,6 +24,28 @@
               </v-col>
             </v-row>
 
+            <v-expand-transition>
+              <v-row v-if="success">
+                <v-col>
+                  <v-alert
+                    :title="$t('password.updated')"
+                    :text="$t('password.youCanNowLogin')"
+                    type="success"
+                    density="compact"
+                  >
+                    <template #append>
+                      <v-btn
+                        :text="$t('authenticate.logIn')"
+                        prepend-icon="mdi-arrow-left"
+                        to="/authenticate"
+                        variant="tonal"
+                      />
+                    </template>
+                  </v-alert>
+                </v-col>
+              </v-row>
+            </v-expand-transition>
+
             <v-form v-model="valid" @submit.prevent="replacePassword()">
               <v-row>
                 <v-col>
@@ -97,6 +119,7 @@ if (!currentRoute.value.query?.token) {
 
 const valid = ref(false);
 const loading = ref(false);
+const success = ref(false);
 const password = ref('');
 const passwordRepeat = ref('');
 const showPassword = ref(false);

--- a/front/pages/password/new.vue
+++ b/front/pages/password/new.vue
@@ -58,7 +58,6 @@
                       (v) => !!v || $t('password.passwordIsRequired'),
                       (v) => v.length >= 6 || $t('password.length'),
                       () => passwordRepeat === password || $t('password.notEqual'),
-                      (v) => v >= 6 || $t('password.length'),
                     ]"
                     prepend-icon="mdi-lock"
                     variant="underlined"

--- a/front/pages/password/new.vue
+++ b/front/pages/password/new.vue
@@ -140,15 +140,10 @@ async function replacePassword() {
 
     success.value = true;
   } catch (err) {
-    if (!(err instanceof Error)) {
-      errorMessage.value = t('authenticate.failed');
-      return;
-    }
-
-    if (err.statusCode >= 400 && err.statusCode < 500) {
-      errorMessage.value = t('authenticate.loginFailed');
+    if (err?.data?.error) {
+      errorMessage.value = err?.data?.error;
     } else {
-      errorMessage.value = t('authenticate.failed');
+      errorMessage.value = t('anErrorOccurred');
     }
   }
   loading.value = false;

--- a/front/pages/password/new.vue
+++ b/front/pages/password/new.vue
@@ -132,9 +132,7 @@ async function replacePassword() {
       method: 'POST',
       body: {
         password: password.value,
-      },
-      headers: {
-        Authorization: `Bearer ${currentRoute.value.query?.token}`,
+        token: currentRoute.value.query?.token,
       },
     });
 

--- a/front/pages/password/new.vue
+++ b/front/pages/password/new.vue
@@ -34,7 +34,7 @@
                     :hint="$t('password.pattern')"
                     :rules="[
                       (v) => !!v || $t('password.passwordIsRequired'),
-                      (v) => v >= 6 || $t('password.length'),
+                      (v) => v.length >= 6 || $t('password.length'),
                     ]"
                     :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
                     prepend-icon="mdi-lock"
@@ -56,6 +56,7 @@
                     :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
                     :rules="[
                       (v) => !!v || $t('password.passwordIsRequired'),
+                      (v) => v.length >= 6 || $t('password.length'),
                       () => passwordRepeat === password || $t('password.notEqual'),
                       (v) => v >= 6 || $t('password.length'),
                     ]"


### PR DESCRIPTION
# Changes

## Front
In the password reset page
- Fix password length behind always considered shorter than 6
- Display the error message returned by the server (if any) when password reset fails
- Add a success message with a link to the login page when password has been reset successfuly
- Put the JWT token in the request body

## API
- Use a dedicated JWT secret for password reset
- Get the password reset token from the request body instead of relying on the auth middleware, preventing conflicts with the regular auth token
- Throw 400 instead of 404 when the password reset token is expired