### PR TITLE
feat: loose array filters

### DIFF
--- a/api/lib/controllers/users/actions.js
+++ b/api/lib/controllers/users/actions.js
@@ -52,7 +52,9 @@ exports.list = async (ctx) => {
   const {
     source = 'fullName,username',
     roles,
+    'roles:loose': hasSomeRoles,
     permissions,
+    'permissions:loose': hasSomePermissions,
   } = ctx.query;
 
   const prismaQuery = standardQueryParams.getPrismaManyQuery(ctx);
@@ -60,8 +62,8 @@ exports.list = async (ctx) => {
   if (roles != null || permissions != null) {
     prismaQuery.where.memberships = {
       some: {
-        roles: arrayFilter(roles),
-        permissions: arrayFilter(permissions),
+        roles: arrayFilter(roles, hasSomeRoles),
+        permissions: arrayFilter(permissions, hasSomePermissions),
       },
     };
   }

--- a/api/lib/controllers/users/index.js
+++ b/api/lib/controllers/users/index.js
@@ -34,7 +34,9 @@ router.route({
     query: standardQueryParams.manyValidation.append({
       source: Joi.string().trim(),
       roles: stringOrArrayValidation,
+      'roles:loose': Joi.boolean().default(false),
       permissions: stringOrArrayValidation,
+      'permissions:loose': Joi.boolean().default(false),
     }),
   },
 });

--- a/front/components/filters/Select.vue
+++ b/front/components/filters/Select.vue
@@ -29,6 +29,15 @@
     <template v-if="$slots.selection" #selection="selection">
       <slot name="selection" v-bind="selection" />
     </template>
+
+    <template v-if="looseEnabled" #append>
+      <v-btn
+        v-tooltip="loose ? $t('looseFilter') : $t('strictFilter')"
+        :icon="loose ? 'mdi-approximately-equal' : 'mdi-equal'"
+        density="comfortable"
+        @click="emit('update:loose', !loose)"
+      />
+    </template>
   </v-autocomplete>
 </template>
 
@@ -46,15 +55,25 @@ const props = defineProps({
     type: Symbol,
     default: undefined,
   },
+  loose: {
+    type: Boolean,
+    default: undefined,
+  },
 });
 
 const emit = defineEmits({
   'update:modelValue': (v) => Array.isArray(v) || typeof v === 'string' || v === undefined,
+  'update:loose': (v) => v === true || v === false,
 });
 
 const { t } = useI18n();
 
 const search = ref('');
+
+const looseEnabled = computed(() => {
+  const { 'onUpdate:loose': looseListener } = getCurrentInstance()?.vnode.props ?? {};
+  return !!looseListener;
+});
 
 const value = computed({
   get: () => {

--- a/front/components/sushi/Filters.vue
+++ b/front/components/sushi/Filters.vue
@@ -41,6 +41,7 @@
         <v-col v-if="institution" cols="12">
           <FiltersSelect
             v-model="filters.packages"
+            v-model:loose="filters['packages:loose']"
             :items="availablePackages"
             :label="$t('institutions.sushi.packages')"
             :loading="loadingPackages && 'primary'"

--- a/front/components/sushiEndpoint/Filters.vue
+++ b/front/components/sushiEndpoint/Filters.vue
@@ -27,6 +27,7 @@
         <v-col cols="12">
           <FiltersSelect
             v-model="filters.tags"
+            v-model:loose="filters['tags:loose']"
             :items="availableTags"
             :label="$t('endpoints.tags')"
             :loading="loadingTags && 'primary'"
@@ -57,6 +58,7 @@
         <v-col cols="12">
           <FiltersSelect
             v-model="filters.counterVersions"
+            v-model:loose="filters['counterVersions:loose']"
             :items="SUPPORTED_COUNTER_VERSIONS"
             :label="$t('endpoints.counterVersion')"
             :return-object="false"

--- a/front/components/user/Filters.vue
+++ b/front/components/user/Filters.vue
@@ -35,6 +35,7 @@
         <v-col cols="12">
           <FiltersSelect
             v-model="filters.permissions"
+            v-model:loose="filters['permissions:loose']"
             :empty-symbol="emptySymbol"
             :items="permissionsItems"
             :label="$t('users.user.permissions')"
@@ -48,6 +49,7 @@
         <v-col cols="12">
           <FiltersSelect
             v-model="filters.roles"
+            v-model:loose="filters['roles:loose']"
             :empty-symbol="emptySymbol"
             :items="rolesItems"
             :label="$t('users.user.roles')"

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -986,3 +986,5 @@ enterKey: enter
 general: General
 enterValidUrl: Please enter a valid URL
 nbOthers: (+{count} others)
+looseFilter: Results will match one of the values
+strictFilter: Results will mach all the values

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -994,3 +994,5 @@ enterKey: entrée
 general: General
 enterValidUrl: Veuillez saisir une URL valide
 nbOthers: (+{count} autres)
+looseFilter: Les résultats correspondront à l'une des valeurs
+strictFilter: Les résultats correspondront à toutes les valeurs


### PR DESCRIPTION
# API

- [X] Change std-query behaviour
- [X] Change additional filters

"Loose" array filters uses `hasSome` instead of `hasEvery` when an additional parameter is supplied. Given a array filter named `key`, it'll check if `key:loose` is `truthy` to vhange behaviour.

# Front

- [X] Added button to change mode when using array filters

