### PR TITLE
feat: add COUNTER 5.1 to supported reports

### DIFF
--- a/api/lib/services/sushi.js
+++ b/api/lib/services/sushi.js
@@ -157,6 +157,34 @@ const DEFAULT_REPORT_TYPE = 'tr';
 // https://app.swaggerhub.com/apis/COUNTER/counter-sushi_5_0_api/
 
 /**
+ * Get SUSHI URL for a given COUNTER version
+ *
+ * Some endpoints uses the (non standard) prefix `/r5` for COUNTER 5 while also using `/r51`
+ * for COUNTER 5.1. This methods removes the suffix `/r5` before adding the standard if
+ * using COUNTER 5.1
+ * It also remove the trailing `/`
+ *
+ * @param {import('@prisma/client').SushiEndpoint} endpoint - The endpoint
+ * @param {string} version - The COUNTER version
+ * @returns
+ */
+function getSushiURL({ sushiUrl }, version = '5') {
+  const versionPrefixRegex = /(\/?r51?)?\/*$/;
+  const baseUrl = sushiUrl.trim().replace(versionPrefixRegex, '');
+  const versionPrefix = versionPrefixRegex.exec(sushiUrl)?.[1];
+
+  switch (version) {
+    case '5':
+      return `${baseUrl}${versionPrefix || ''}`;
+    case '5.1':
+      return `${baseUrl}/r51`;
+
+    default:
+      throw new Error(`Unsupported COUNTER version: ${version}`);
+  }
+}
+
+/**
  * Get query parameters of a given SUSHI item
  * @param {SushiCredentials} sushiItem - The SUSHI item
  * @param {Array<string>} scopes - The scopes of the request
@@ -188,14 +216,12 @@ function getSushiParams(sushiItem, scopes = []) {
 /**
  * Get the list of available reports for a given SUSHI item
  * @param {SushiCredentials} sushi - The SUSHI item
+ * @param {string} [version] - The COUNTER version
  * @returns {Promise<any>} The endpoint response
  */
-async function getAvailableReports(sushi) {
-  const {
-    sushiUrl,
-  } = sushi?.endpoint || {};
+async function getAvailableReports(sushi, version = '5') {
+  const baseUrl = getSushiURL(sushi?.endpoint || {}, version);
 
-  const baseUrl = sushiUrl.trim().replace(/\/+$/, '');
   const allowedScopes = [undefined, 'all', 'report_list'];
   const params = getSushiParams(sushi, allowedScopes);
 

--- a/api/lib/services/sushi.js
+++ b/api/lib/services/sushi.js
@@ -165,7 +165,7 @@ const DEFAULT_REPORT_TYPE = 'tr';
  * It also remove the trailing `/`
  *
  * @param {import('@prisma/client').SushiEndpoint} endpoint - The endpoint
- * @param {string} version - The COUNTER version
+ * @param {string} [version=5] - The COUNTER version
  * @returns
  */
 function getSushiURL({ sushiUrl }, version = '5') {
@@ -216,7 +216,7 @@ function getSushiParams(sushiItem, scopes = []) {
 /**
  * Get the list of available reports for a given SUSHI item
  * @param {SushiCredentials} sushi - The SUSHI item
- * @param {string} [version] - The COUNTER version
+ * @param {string} [version=5] - The COUNTER version
  * @returns {Promise<any>} The endpoint response
  */
 async function getAvailableReports(sushi, version = '5') {

--- a/front/components/sushi/Reports.vue
+++ b/front/components/sushi/Reports.vue
@@ -80,10 +80,12 @@
               >
                 <td>{{ report.Report_Name }}</td>
                 <td>{{ report.Report_ID }}</td>
-                <td v-if="report.First_Month_Available || report.Last_Month_Available">
-                  {{ report.First_Month_Available ?? $t('unknown') }}
-                  ~
-                  {{ report.Last_Month_Available ?? $t('unknown') }}
+                <td>
+                  <span v-if="report.First_Month_Available || report.Last_Month_Available">
+                    {{ report.First_Month_Available ?? $t('unknown') }}
+                    ~
+                    {{ report.Last_Month_Available ?? $t('unknown') }}
+                  </span>
                 </td>
               </tr>
             </tbody>

--- a/front/components/sushi/Reports.vue
+++ b/front/components/sushi/Reports.vue
@@ -5,7 +5,7 @@
     prepend-icon="mdi-file-search"
   >
     <template v-if="showSushi" #subtitle>
-      <SushiSubtitle :model-value="modelValue" />
+      <SushiSubtitle :model-value="sushi" />
     </template>
 
     <template #append>
@@ -20,7 +20,27 @@
       />
     </template>
 
-    <template #text>
+    <v-tabs
+      v-if="versions.length > 0"
+      v-model="currentVersion"
+      bg-color="primary"
+      class="px-2"
+    >
+      <v-tab
+        v-for="version in versions"
+        :key="version"
+        :value="version"
+      >
+        COUNTER
+        <v-badge
+          :content="version"
+          :color="counterVersionsColors.get(version) || 'secondary'"
+          inline
+        />
+      </v-tab>
+    </v-tabs>
+
+    <v-card-text>
       <v-row v-if="exceptions.length > 0">
         <v-col>
           <v-alert
@@ -41,13 +61,16 @@
         </v-col>
       </v-row>
 
-      <v-row>
+      <v-row v-if="filteredReports.length > 0">
         <v-col>
           <v-table>
             <thead>
               <tr>
                 <th>{{ $t('name') }}</th>
                 <th>{{ $t('identifier') }}</th>
+                <th v-if="currentVersion !== '5'">
+                  {{ $t('reports.availablePeriod') }}
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -57,12 +80,27 @@
               >
                 <td>{{ report.Report_Name }}</td>
                 <td>{{ report.Report_ID }}</td>
+                <td v-if="report.First_Month_Available || report.Last_Month_Available">
+                  {{ report.First_Month_Available ?? $t('unknown') }}
+                  ~
+                  {{ report.Last_Month_Available ?? $t('unknown') }}
+                </td>
               </tr>
             </tbody>
           </v-table>
         </v-col>
       </v-row>
-    </template>
+
+      <v-row v-else-if="status !== 'pending'">
+        <v-col>
+          <v-empty-state
+            icon="mdi-file-hidden"
+            :title="$t('reports.failedToFetchReports')"
+            :text="$t('reports.supportedReportsUnavailable')"
+          />
+        </v-col>
+      </v-row>
+    </v-card-text>
 
     <template #actions>
       <v-switch
@@ -93,9 +131,12 @@ const props = defineProps({
 });
 
 const showOnlyMaster = ref(true);
+const currentVersion = ref('5');
+
+const { t } = useI18n();
 
 const {
-  data: reports,
+  data: reportsPerVersion,
   error,
   refresh,
   status,
@@ -103,32 +144,36 @@ const {
   lazy: true,
 });
 
+const versions = computed(() => Object.keys(reportsPerVersion.value ?? {}));
+const reports = computed(() => reportsPerVersion.value?.[currentVersion.value]?.data ?? []);
+
 const exceptions = computed(() => {
-  if (!error.value) {
+  if (status.value === 'pending') {
     return [];
   }
 
-  let rawExceptions = error.value?.data?.exceptions;
-  if (!Array.isArray(rawExceptions)) {
-    rawExceptions = [{ Message: data?.error }];
+  const rawExceptions = reportsPerVersion.value?.[currentVersion.value]?.exceptions ?? [];
+  if (reportsPerVersion.value?.[currentVersion.value]?.error) {
+    rawExceptions.push({ Message: reportsPerVersion.value[currentVersion.value].error });
+  }
+  if (error.value) {
+    rawExceptions.push({ Message: error.value?.data?.error || t('errors.generic') });
   }
 
-  return rawExceptions.map(
-    (exception) => {
-      if (!exception) {
-        return undefined;
-      }
+  return rawExceptions.map((exception) => {
+    if (!exception) {
+      return undefined;
+    }
 
-      let message = exception.Message;
-      if (exception.Code) {
-        message = `[#${exception.Code}] ${message}`;
-      }
-      if (exception.Severity) {
-        message = `[${exception.Severity}] ${message}`;
-      }
-      return message;
-    },
-  ).filter((message) => !!message);
+    let message = exception.Message;
+    if (exception.Code) {
+      message = `[#${exception.Code}] ${message}`;
+    }
+    if (exception.Severity) {
+      message = `[${exception.Severity}] ${message}`;
+    }
+    return message;
+  }).filter((message) => !!message);
 });
 
 const filteredReports = computed(() => {

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -640,11 +640,10 @@ reports:
   checkCredentials: Check credentials
   supportedReports: Supported reports
   supportedReportsOnPlatform: Reports supported by the publisher platform
-  supportedReportsUnavailable:
-    The list of supported reports is not available for
-    this publisher platform.
+  supportedReportsUnavailable: The list of supported reports is not available for this publisher platform.
   failedToFetchReports: Failed to fetch the list of available reports
   onlyShowMasterReports: Only show master reports
+  availablePeriod: Available period
 identifier: Identifier
 authenticate:
   restrictedAccess: Restricted Access
@@ -986,3 +985,4 @@ enterKey: enter
 general: General
 enterValidUrl: Please enter a valid URL
 nbOthers: (+{count} others)
+unknown: Unknown

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -654,6 +654,7 @@ reports:
   supportedReportsUnavailable: La liste des rapports supportés n'est pas disponible pour cette plateforme éditeur.
   failedToFetchReports: Impossible de récupérer la liste des rapports disponibles
   onlyShowMasterReports: Afficher uniquement les rapports maîtres
+  availablePeriod: Période disponible
 identifier: Identifiant
 authenticate:
   restrictedAccess: Accès restreint
@@ -994,3 +995,4 @@ enterKey: entrée
 general: General
 enterValidUrl: Veuillez saisir une URL valide
 nbOthers: (+{count} autres)
+unknown: Inconnu


### PR DESCRIPTION
# API

- [X] Added method to get SUSHI url by version
- [X] Available reports of a sushi now use all COUNTER versions

# Front

- [X] Available reports of a sushi now use all COUNTER versions

![image](https://github.com/user-attachments/assets/c06feb7a-dac4-4bd6-9cd1-a2c1ed245454)

