### PR TITLE
feat(front): restrict to one package

### DIFF
--- a/front/components/sushi/Form.vue
+++ b/front/components/sushi/Form.vue
@@ -94,6 +94,7 @@
                       :hint="$t('institutions.sushi.packagesDescription')"
                       :items="availablePackages"
                       :loading="loadingPackages && 'primary'"
+                      :rules="[(v) => v.length <= 1 || $t('institutions.sushi.onlyOnePackage')]"
                       prepend-icon="mdi-tag"
                       variant="underlined"
                       multiple

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -410,13 +410,11 @@ institutions:
     unabletToRetriveSushiInformations: Unable to retrieve information from sushi platforms
     label: Label
     tags: Tags
-    packages: Packages
-    packagesHint: Profiles, accounts, funds, antennas, etc. that include the credentials.
-    packagesDescription:
-      Profiles, accounts, funds, antennas, etc. that include the
-      credentials. The packages will be usable in your dashboards, using the X_Package
-      field
+    packages: Package
+    packagesHint: Profile, account, fund, antenna, etc. that include the credentials.
+    packagesDescription: Profile, account, fund, antenna, etc. that include the credentials. The package will be usable in your dashboards, using the X_Package field
     unableToRetriveSushiData: Unable to retrieve sushi information
+    onlyOnePackage: You must choose one package.
     endpoint: Endpoint
     requestorId: Requestor ID
     customerId: Customer ID

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -415,7 +415,7 @@ institutions:
     tags: Étiquettes
     packages: Package
     packagesHint: Profil, compte, fond, antenne, etc. dont font partie les identifiants.
-    packagesDescription: Profil, compte, fond, antenne, etc. dont font partie les identifiants. Le package peut être utilisés dans vos tableaux de bord, à travers le champ X_Package.
+    packagesDescription: Profil, compte, fond, antenne, etc. dont font partie les identifiants. Le package peut être utilisé dans vos tableaux de bord, à travers le champ X_Package.
     unableToRetriveSushiData: Impossible de récupérer les informations sushi
     onlyOnePackage: Vous devez choisir un seul package.
     endpoint: Point d'accès

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -413,10 +413,11 @@ institutions:
     unabletToRetriveSushiInformations: Impossible de récupérer les informations des plateformes sushi
     label: Libellé
     tags: Étiquettes
-    packages: Packages
-    packagesHint: Profils, comptes, fonds, antennes, etc. dont font partie les identifiants.
-    packagesDescription: Profils, comptes, fonds, antennes, etc. dont font partie les identifiants. Les packages peuvent être utilisés dans vos tableaux de bord, à travers le champ X_Package.
+    packages: Package
+    packagesHint: Profil, compte, fond, antenne, etc. dont font partie les identifiants.
+    packagesDescription: Profil, compte, fond, antenne, etc. dont font partie les identifiants. Le package peut être utilisés dans vos tableaux de bord, à travers le champ X_Package.
     unableToRetriveSushiData: Impossible de récupérer les informations sushi
+    onlyOnePackage: Vous devez choisir un seul package.
     endpoint: Point d'accès
     requestorId: Requestor ID
     customerId: Customer ID


### PR DESCRIPTION
by using rules while still keeping the field as multiple to allow users easily removes packages, it also doesn't change the datatype to make it simpler, once all packages will be cleaner, we can make it a simple string instead of an array
