### PR TITLE
fix(api): remove "delayed" from the end statuses

### DIFF
--- a/api/lib/entities/harvest-job.service.js
+++ b/api/lib/entities/harvest-job.service.js
@@ -22,7 +22,10 @@ module.exports = class HarvestJobsService extends BasePrismaService {
   static $transaction = super.$transaction;
 
   /** @type {HarvestJobStatus[]} */
-  static endStatuses = ['finished', 'failed', 'cancelled', 'delayed'];
+  static endStatuses = ['finished', 'failed', 'cancelled', 'interrupted'];
+
+  /** @type {HarvestJobStatus} */
+  static delayedStatus = 'delayed';
 
   /**
    * Returns whether the job is terminated or not by checking its status
@@ -30,6 +33,14 @@ module.exports = class HarvestJobsService extends BasePrismaService {
    */
   static isDone(job) {
     return this.endStatuses.includes(job?.status);
+  }
+
+  /**
+   * Returns whether the job has been delayed
+   * @param {HarvestJob} job - The job to check
+   */
+  static isDelayed(job) {
+    return job?.status === this.delayedStatus;
   }
 
   /**

--- a/api/lib/services/jobs.js
+++ b/api/lib/services/jobs.js
@@ -24,7 +24,9 @@ async function checkTask(taskId, jobId) {
 
   const task = await harvestJobService.findUnique({ where: { id: taskId } });
 
-  if (!task || HarvestJobService.isDone(task)) { return; }
+  if (!task) { return; }
+  if (HarvestJobService.isDone(task)) { return; }
+  if (HarvestJobService.isDelayed(task)) { return; }
 
   appLogger.verbose(`${logPrefix} Job [${jobId}] stopped unexpectedly, setting task from status [${task.status}] to [failed]...`);
 


### PR DESCRIPTION
Removes `delayed` from the possible end statuses of harvest jobs, as a delayed job is not really terminated. That way, harvest sessions won't be considered finished if they still have delayed jobs (and no mail will be sent).