### PR TITLE
Feat/bulk retries

### DIFF
--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -59,6 +59,13 @@
   "storage": {
     "path": "EZMESURE_STORAGE_PATH"
   },
+  "ezpaarse": {
+    "upload": {
+      "bulkSize": "EZMESURE_EZPAARSE_UPLOAD_BULK_SIZE",
+      "bulkMaxTries": "EZMESURE_EZPAARSE_UPLOAD_BULK_MAX_TRIES",
+      "bulkBaseRetryDelay": "EZMESURE_EZPAARSE_UPLOAD_BULK_BASE_RETRY_DELAY"
+    }
+  },
   "jobs": {
     "harvest": {
       "concurrency": "EZMESURE_HARVEST_CONCURRENCY",

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -74,6 +74,13 @@ module.exports = {
   storage: {
     path: path.resolve(__dirname, '../storage'),
   },
+  ezpaarse: {
+    upload: {
+      bulkSize: 2000,
+      bulkMaxTries: 5,
+      bulkBaseRetryDelay: 1000,
+    },
+  },
   jobs: {
     harvest: {
       concurrency: 1,

--- a/api/lib/controllers/logs/upload.js
+++ b/api/lib/controllers/logs/upload.js
@@ -315,7 +315,7 @@ module.exports = async function upload(ctx) {
       }
       return ctx.throw(e.type === 'validation' ? 400 : 500, e.message);
     }
-    return appLogger.info(`Insert into [${index}]`, ctx.body);
+    return appLogger.info(`[ec-upload] Insert into [${index}]`, ctx.body);
   }
 
   let total = 0;
@@ -377,5 +377,5 @@ module.exports = async function upload(ctx) {
     failed,
     errors,
   };
-  return appLogger.info(`Insert into [${index}]`, ctx.body);
+  return appLogger.info(`[ec-upload] Insert into [${index}]`, ctx.body);
 };


### PR DESCRIPTION
# Changes

- Adds a retry strategy to bulk requests, in order to make EC uploads more robust in case of temporary communication issues with the Elasticsearch cluster
- Adds some logging 
- Encapsulate thrown Elasticsearch error so that we can get a usable stacktrace