### PR TITLE
feat: added way to show and delete harvested reports that are unsupported

### DIFF
--- a/api/lib/controllers/harvests/actions.js
+++ b/api/lib/controllers/harvests/actions.js
@@ -47,3 +47,33 @@ exports.getHarvests = async (ctx) => {
   ctx.set('X-Total-Count', await harvestsService.count({ where: prismaQuery.where }));
   ctx.body = await harvestsService.findMany(prismaQuery);
 };
+
+exports.deleteHarvestsByQuery = async (ctx) => {
+  const {
+    credentialsId,
+    reportId,
+    period,
+    status,
+  } = ctx.request.body;
+
+  /** @type {HarvestFindManyArgs} */
+  const prismaQuery = {
+    where: {
+      credentialsId,
+      reportId,
+      period: {
+        gte: period.from,
+        lte: period.to,
+      },
+      status,
+    },
+  };
+
+  const harvestsService = new HarvestsService();
+
+  const deleted = await harvestsService.deleteMany(prismaQuery);
+
+  ctx.type = 'json';
+  ctx.status = 200;
+  ctx.body = { deleted };
+};

--- a/api/lib/controllers/harvests/index.js
+++ b/api/lib/controllers/harvests/index.js
@@ -12,6 +12,7 @@ const { stringOrArrayValidation } = require('../../services/std-query');
 const {
   standardQueryParams,
   getHarvests,
+  deleteHarvestsByQuery,
 } = require('./actions');
 
 router.use(
@@ -35,6 +36,26 @@ router.route({
       institutionId: stringOrArrayValidation,
       tags: stringOrArrayValidation,
       packages: stringOrArrayValidation,
+    }),
+  },
+});
+
+router.route({
+  method: 'DELETE',
+  path: '/_by-query',
+  handler: [
+    deleteHarvestsByQuery,
+  ],
+  validate: {
+    type: 'json',
+    body: Joi.object({
+      credentialsId: Joi.string().trim().required(),
+      reportId: Joi.string().trim().required(),
+      period: Joi.object({
+        from: Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+        to: Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+      }).required(),
+      status: Joi.string().trim(),
     }),
   },
 });

--- a/api/lib/entities/harvest.service.js
+++ b/api/lib/entities/harvest.service.js
@@ -10,6 +10,7 @@ const BasePrismaService = require('./base-prisma.service');
 /** @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs */
+/** @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs */
 /* eslint-enable max-len */
 
 module.exports = class HarvestsService extends BasePrismaService {
@@ -62,5 +63,13 @@ module.exports = class HarvestsService extends BasePrismaService {
    */
   upsert(params) {
     return harvestPrisma.upsert(params, this.prisma);
+  }
+
+  /**
+   * @param {HarvestDeleteManyArgs} params
+   * @returns {Promise<number>}
+   */
+  deleteMany(params) {
+    return harvestPrisma.removeMany(params, this.prisma);
   }
 };

--- a/api/lib/services/prisma/harvest.js
+++ b/api/lib/services/prisma/harvest.js
@@ -10,6 +10,7 @@ const { client: prisma } = require('./index');
 /** @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs */
 /** @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs */
+/** @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs */
 /* eslint-enable max-len */
 
 /**
@@ -66,6 +67,16 @@ function upsert(params, tx = prisma) {
   return tx.harvest.upsert(params);
 }
 
+/**
+ * @param {HarvestDeleteManyArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<number>}
+ */
+async function removeMany(params, tx = prisma) {
+  const { count: c } = await tx.harvest.deleteMany(params);
+  return c;
+}
+
 module.exports = {
   create,
   findMany,
@@ -73,4 +84,5 @@ module.exports = {
   count,
   update,
   upsert,
+  removeMany,
 };

--- a/front/components/harvestDashboard/UnsupportedButHarvested.vue
+++ b/front/components/harvestDashboard/UnsupportedButHarvested.vue
@@ -1,0 +1,358 @@
+<template>
+  <div>
+    <v-progress-linear
+      v-if="status === 'pending'"
+      color="primary"
+      indeterminate
+    />
+
+    <v-alert
+      v-if="error"
+      :text="$t('harvest.dashboard.unsupportedButHarvested.error', { error: error.message })"
+      type="error"
+    />
+
+    <v-empty-state
+      v-if="unsupportedButHarvested.length <= 0"
+      :title="$t('harvest.dashboard.unsupportedButHarvested.empty')"
+      icon="mdi-check"
+      color="green"
+    />
+
+    <v-data-table
+      v-else
+      :items="unsupportedButHarvested"
+      :headers="headers"
+      :sort-by="[{ key: 'severity', order: 'desc' }]"
+    >
+      <template #[`item.severity`]="{ item }">
+        <v-icon v-if="item.severity === 'low'" color="info" icon="mdi-information-outline" />
+        <v-icon v-else-if="item.severity === 'medium'" color="warning" icon="mdi-alert-outline" />
+        <v-icon v-else color="error" icon="mdi-alert-outline" />
+      </template>
+
+      <template #[`item.endpoint.vendor`]="{ item, value }">
+        <nuxt-link :to="`/admin/endpoints/${item.endpoint.id}`">
+          {{ value }}
+        </nuxt-link>
+      </template>
+
+      <template #[`item.institution.name`]="{ item, value }">
+        <nuxt-link :to="`/admin/institutions/${item.institution.id}/sushi`">
+          {{ value }}
+        </nuxt-link>
+      </template>
+
+      <template #[`item.status.key`]="{ item, value }">
+        <v-chip
+          :text="t(`tasks.status.${value}`)"
+          :prepend-icon="item.status.icon"
+          :color="item.status.color"
+          density="comfortable"
+          variant="outlined"
+        />
+      </template>
+
+      <template #[`item.period`]="{ item }">
+        {{ item.beginDate }} - {{ item.endDate }}
+      </template>
+
+      <template #[`item.actions`]="{ item }">
+        <v-btn
+          v-tooltip:top="$t('sushi.harvestState')"
+          :disabled="!!lockActions"
+          :loading="matrixLoading === item.id"
+          icon="mdi-table-headers-eye"
+          color="grey-darken-1"
+          variant="text"
+          density="comfortable"
+          @click="openHarvestMatrix(item)"
+        />
+        <v-btn
+          v-tooltip:top="$t('delete')"
+          :disabled="!!lockActions"
+          icon="mdi-delete"
+          color="red"
+          variant="text"
+          density="comfortable"
+          @click="deleteHarvestedPeriod(item)"
+        />
+      </template>
+    </v-data-table>
+
+    <SushiHarvestMatrixDialog ref="harvestMatrixRef" />
+  </div>
+</template>
+
+<script setup>
+const PENDING_STATUS = new Set(['running', 'waiting', 'delayed']);
+
+const SEVERITY_PER_STATUS = new Map([
+  ['finished', 'low'],
+  ['missing', 'medium'],
+  // will defaults to "high"
+]);
+
+const props = defineProps({
+  defineRefresh: {
+    type: Function,
+    default: () => {},
+  },
+});
+
+const { t } = useI18n();
+const { openConfirm } = useDialogStore();
+const snacks = useSnacksStore();
+
+const lockActions = ref(false);
+const matrixLoading = ref('');
+
+const harvestMatrixRef = useTemplateRef('harvestMatrixRef');
+
+const {
+  status,
+  data: harvests,
+  error,
+  refresh,
+} = await useFetch('/api/harvests', {
+  lazy: true,
+  query: {
+    size: 0,
+    include: ['credentials'],
+  },
+});
+
+// Allow parent component to refresh
+props.defineRefresh({
+  execute: refresh,
+  status,
+});
+
+/** Key to cache credentials data */
+const credentialsIds = computed(() => Array.from(new Set(harvests.value?.map((h) => h.credentialsId))).join(','));
+
+/** Credentials concerned by harvests grouped by id */
+const credentials = computedAsync(async () => {
+  if (!credentialsIds.value) {
+    return undefined;
+  }
+
+  try {
+    const values = await $fetch('/api/sushi', {
+      query: {
+        size: 0,
+        id: credentialsIds.value.split(','),
+      },
+    });
+
+    return new Map(values.map((c) => [c.id, c]));
+  } catch (err) {
+    snacks.error(t('anErrorOccurred'), err);
+    return new Map();
+  }
+});
+
+/** Key to cache endpoint data */
+const endpointsIds = computed(() => Array.from(new Set(Array.from(credentials.value.values())?.map((c) => c.endpointId))).join(','));
+
+/** Endpoints concerned by harvests grouped by id */
+const endpoints = computedAsync(async () => {
+  if (!endpointsIds.value) {
+    return undefined;
+  }
+
+  try {
+    const values = await $fetch('/api/sushi-endpoints', {
+      query: {
+        size: 0,
+        id: endpointsIds.value.split(','),
+      },
+    });
+
+    return new Map(values.map((e) => [e.id, e]));
+  } catch (err) {
+    snacks.error(t('anErrorOccurred'), err);
+    return new Map();
+  }
+});
+
+/** Key to cache institution data */
+const institutionsIds = computed(() => Array.from(new Set(Array.from(credentials.value.values())?.map((c) => c.institutionId))).join(','));
+
+/** Institutions concerned by harvests grouped by id */
+const institutions = computedAsync(async () => {
+  if (!institutionsIds.value) {
+    return undefined;
+  }
+
+  try {
+    const values = await $fetch('/api/institutions', {
+      query: {
+        size: 0,
+        id: institutionsIds.value.split(','),
+      },
+    });
+
+    return new Map(values.map((e) => [e.id, e]));
+  } catch (err) {
+    snacks.error(t('anErrorOccurred'), err);
+    return new Map();
+  }
+});
+
+const unsupportedButHarvested = computed(() => {
+  if (!harvests.value || !endpoints.value || !institutions.value) {
+    return [];
+  }
+
+  const map = new Map();
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const harvest of harvests.value) {
+    // Ignore pending harvests
+    if (PENDING_STATUS.has(harvest.status)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const creds = credentials.value?.get(harvest.credentialsId);
+    const endpoint = endpoints.value.get(creds.endpointId);
+    // Ignore supported harvests
+    if (!endpoint || endpoint.supportedData?.[harvest.reportId]?.supported?.value) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const key = `${harvest.credentialsId}:${harvest.reportId}:${harvest.status}`;
+
+    const group = map.get(key) ?? {
+      id: key,
+
+      reportId: harvest.reportId,
+      status: {
+        ...harvestStatus.get(harvest.status),
+        key: harvest.status,
+      },
+      severity: SEVERITY_PER_STATUS.get(harvest.status) || 'high',
+
+      beginDate: harvest.period,
+      endDate: harvest.period,
+
+      credentials: creds,
+      endpoint,
+      institution: institutions.value.get(creds.institutionId),
+    };
+
+    // TODO: what if missing one ?
+    if (group.beginDate >= harvest.period) {
+      group.beginDate = harvest.period;
+    }
+    if (group.endDate <= harvest.period) {
+      group.endDate = harvest.period;
+    }
+
+    map.set(key, group);
+  }
+
+  return Array.from(map.values());
+});
+
+const headers = computed(() => [
+  {
+    title: t('harvest.dashboard.unsupportedButHarvested.severity'),
+    value: 'severity',
+    align: 'center',
+    sortable: true,
+  },
+  {
+    title: t('institutions.sushi.endpoint'),
+    value: 'endpoint.vendor',
+    sortable: true,
+  },
+  {
+    title: t('institutions.title'),
+    value: 'institution.name',
+    sortable: true,
+  },
+  {
+    title: t('harvest.jobs.period'),
+    value: 'period',
+    align: 'center',
+  },
+  {
+    title: t('harvest.jobs.reportType'),
+    value: 'reportId',
+    align: 'center',
+    sortable: true,
+    cellProps: {
+      class: ['text-uppercase'],
+    },
+  },
+  {
+    title: t('status'),
+    value: 'status.key',
+    align: 'center',
+    sortable: true,
+  },
+  {
+    title: t('actions'),
+    value: 'actions',
+  },
+]);
+
+async function openHarvestMatrix(item) {
+  if (!harvestMatrixRef.value) {
+    return;
+  }
+
+  matrixLoading.value = item.id;
+
+  try {
+    const sushiItem = await $fetch(`/api/sushi/${item.credentials.id}`, {
+      include: ['endpoint', 'harvests'],
+    });
+
+    harvestMatrixRef.value.open(sushiItem, { period: item.beginDate });
+  } catch (err) {
+    snacks.error(t('anErrorOccurred'), err);
+  }
+
+  matrixLoading.value = '';
+}
+
+function deleteHarvestedPeriod(item) {
+  openConfirm({
+    text: t('harvest.dashboard.unsupportedButHarvested.deletePeriod', {
+      reportId: item.reportId.toUpperCase(),
+      institutionName: item.institution.name,
+      beginDate: item.beginDate,
+      endDate: item.endDate,
+    }),
+    agreeText: t('delete'),
+    agreeIcon: 'mdi-delete',
+    onAgree: async () => {
+      lockActions.value = true;
+
+      try {
+        await $fetch('/api/harvests/_by-query', {
+          method: 'DELETE',
+          body: {
+            credentialsId: item.credentials.id,
+            reportId: item.reportId,
+            period: {
+              from: item.beginDate,
+              to: item.endDate,
+            },
+            status: item.status.key,
+          },
+        });
+        refresh();
+      } catch (err) {
+        snacks.error(t('anErrorOccurred'), err);
+      }
+
+      lockActions.value = false;
+    },
+  });
+}
+</script>

--- a/front/components/skeleton/AdminMenu.vue
+++ b/front/components/skeleton/AdminMenu.vue
@@ -48,11 +48,29 @@
         to="/admin/custom-fields"
         prepend-icon="mdi-tag-outline"
       />
-      <v-list-item
-        :title="$t('menu.harvest')"
-        to="/admin/harvests"
-        prepend-icon="mdi-tractor"
-      />
+
+      <v-list-group value="harvests">
+        <template #activator="{ props }">
+          <v-list-item
+            :title="$t('menu.harvest.title')"
+            prepend-icon="mdi-tractor"
+            v-bind="props"
+          />
+        </template>
+
+        <v-list-item
+          :title="$t('menu.harvest.tabs.sessions')"
+          to="/admin/harvests"
+          prepend-icon="mdi-file-tree"
+          exact
+        />
+
+        <v-list-item
+          :title="$t('menu.harvest.tabs.dashboard')"
+          to="/admin/harvests/dashboard"
+          prepend-icon="mdi-view-dashboard"
+        />
+      </v-list-group>
 
       <v-list-group value="ezREEPORT">
         <template #activator="{ props }">

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -26,7 +26,11 @@ menu:
   repositories: Repositories
   repositoryAliases: Repository aliases
   spaces: Spaces
-  harvest: Harvest
+  harvest:
+    title: Harvest
+    tabs:
+      sessions: Sessions
+      dashboard: Dashboard
   sync: Synchronisation
   customFields: Custom fields
 home:
@@ -858,7 +862,7 @@ spaces:
   filters:
     title: Filter spaces
 harvest:
-  toolbarTitle: Harvests ({count})
+  toolbarTitle: Sessions ({count})
   sessions:
     pendingSession: Pending harvest...
     startedAt: Harvest started {date}
@@ -898,6 +902,14 @@ harvest:
     unableToRetriveMeta: Unable to retrieve information about harvesting tasks
     unableToStop: Unable to stop the harvesting task
     unableToDelete: Unable to delete the harvesting task
+  dashboard:
+    title: Dashboard
+    unsupportedButHarvested:
+      title: Unsupported reports but still harvested
+      severity: Severity
+      error: An error occurred while searching for harvested but unsupported reports
+      empty: No unsupported reports have been harvested!
+      deletePeriod: "You'll delete the harvested report \"{reportId}\" of the matrix from \"{institutionName}\" for the period \"{beginDate} - {endDate}\". This won't delete the data. This action is irreversible."
 elasticRoles:
   toolbarTitle: Elastic Roles ({count})
   newRole: New role

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -26,7 +26,11 @@ menu:
   repositories: Entrepôts
   repositoryAliases: Alias d'entrepôts
   spaces: Espaces
-  harvest: Moissonnage
+  harvest:
+    title: Moissonnage
+    tabs:
+      sessions: Sessions
+      dashboard: Tableau de bord
   sync: Synchronisation
   customFields: Champs personnalisés
 home:
@@ -872,7 +876,7 @@ spaces:
   filters:
     title: Filtrer les espaces
 harvest:
-  toolbarTitle: Moissonnage ({count})
+  toolbarTitle: Sessions ({count})
   sessions:
     pendingSession: Moissonnage en attente...
     startedAt: Moissonnage lancé le {date}
@@ -913,6 +917,14 @@ harvest:
       de moissonnage
     unableToStop: Impossible de stopper la tâche de moissonnage
     unableToDelete: Impossible de supprimer la tâche de moissonnage
+  dashboard:
+    title: Tableau de bord
+    unsupportedButHarvested:
+      title: Rapports moissonnés mais non supportés
+      severity: Sévérité
+      error: Une erreur est survenue lors de la recherche des rapports moissonnées mais non supportés
+      empty: Aucun rapport non supporté n'a été moissonné !
+      deletePeriod: "Vous allez supprimer le rapport moissonné \"{reportId}\" de la matrice de \"{institutionName}\" pour la période \"{beginDate} - {endDate}\". Cela n’entraînera pas la suppression des données. Cette action est irréversible."
 elasticRoles:
   toolbarTitle: Rôles Elastic ({count})
   newRole: Nouveau rôle

--- a/front/pages/admin/custom-fields.vue
+++ b/front/pages/admin/custom-fields.vue
@@ -66,7 +66,7 @@
           variant="text"
           density="comfortable"
           color="blue"
-          @click="customFieldFormDialogRef.open(item)"
+          @click="customFieldFormDialogRef?.open(item)"
         />
         <v-btn
           v-tooltip:top="$t('delete')"

--- a/front/pages/admin/harvests/dashboard.vue
+++ b/front/pages/admin/harvests/dashboard.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <SkeletonPageBar
+      :title="`${$t('menu.harvest.title')} / ${$t('harvest.dashboard.title')}`"
+      icons
+    />
+
+    <v-container>
+      <v-expansion-panels>
+        <v-expansion-panel>
+          <template #title>
+            <v-icon icon="mdi-file-alert" start />
+
+            {{ $t('harvest.dashboard.unsupportedButHarvested.title') }}
+
+            <v-spacer />
+
+            <v-btn
+              v-if="panelsRefresh.unsupportedButHarvested"
+              :loading="panelsRefresh.unsupportedButHarvested.status === 'pending'"
+              icon="mdi-reload"
+              variant="tonal"
+              color="primary"
+              density="comfortable"
+              class="mr-2"
+              @click.stop="() => panelsRefresh.unsupportedButHarvested.execute()"
+            />
+          </template>
+
+          <template #text>
+            <HarvestDashboardUnsupportedButHarvested
+              :define-refresh="(def) => panelsRefresh.unsupportedButHarvested = def"
+            />
+          </template>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </v-container>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({
+  layout: 'admin',
+  middleware: ['sidebase-auth', 'terms', 'admin'],
+});
+
+const { t } = useI18n();
+
+const panelsRefresh = ref({});
+</script>

--- a/front/pages/admin/harvests/index.vue
+++ b/front/pages/admin/harvests/index.vue
@@ -102,7 +102,7 @@ const toolbarTitle = computed(() => {
   if (itemLength.value.current !== itemLength.value.total) {
     count = `${itemLength.value.current}/${itemLength.value.total}`;
   }
-  return t('harvest.toolbarTitle', { count: count ?? '?' });
+  return `${t('menu.harvest.title')} / ${t('harvest.toolbarTitle', { count: count ?? '?' })}`;
 });
 
 async function refresh() {


### PR DESCRIPTION
# API

- [x] Added way to delete harvests

# Front

- [x] Show harvested reports that are unsupported by their endpoints
  - Grouped by credentials, by reportId and by status
- [x] Allow checking harvest matrix
- [x] Can delete theses alerts to avoid confusion of users

![image](https://github.com/user-attachments/assets/93c56c30-ad3c-46d6-8626-7ffa181966b2)
