### PR TITLE
feat(front): properly shows the state of sushi item in endpoint page

### DIFF
--- a/front/components/sushi/ApiFilters.vue
+++ b/front/components/sushi/ApiFilters.vue
@@ -71,6 +71,14 @@
             prepend-icon="mdi-toggle-switch"
           />
         </v-col>
+
+        <v-col v-if="!institution" cols="6">
+          <ApiFiltersButtonsGroup
+            v-model="filters.archived"
+            :label="$t('archived')"
+            prepend-icon="mdi-archive"
+          />
+        </v-col>
       </v-row>
     </v-container>
   </div>

--- a/front/components/sushi/StateText.vue
+++ b/front/components/sushi/StateText.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-chip
+    v-tooltip="content.tooltip"
+    :text="content.text"
+    :prepend-icon="content.icon"
+    :color="content.color"
+    variant="text"
+  />
+</template>
+
+<script setup>
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { t, locale } = useI18n();
+
+const content = computed(() => {
+  if (props.modelValue.deletedAt) {
+    return {
+      text: t('deleted'),
+      tooltip: t('deletedSince', { date: dateFormat(props.modelValue.deletedAt, locale.value) }),
+      icon: 'mdi-delete',
+      color: 'red',
+    };
+  }
+
+  if (props.modelValue.archived) {
+    return {
+      text: t('archived'),
+      tooltip: t('archivedSince', { date: dateFormat(props.modelValue.archivedUpdatedAt, locale.value) }),
+      icon: 'mdi-archive',
+      color: 'blue',
+    };
+  }
+
+  if (!props.modelValue.active) {
+    return {
+      text: t('inactive'),
+      tooltip: t('endpoints.inactiveSince', { date: dateFormat(props.modelValue.activeUpdatedAt, locale.value) }),
+      icon: 'mdi-close',
+    };
+  }
+
+  return {
+    text: t('active'),
+    tooltip: t('endpoints.activeSince', { date: dateFormat(props.modelValue.activeUpdatedAt, locale.value) }),
+    icon: 'mdi-check',
+    color: 'green',
+  };
+});
+</script>

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -1130,3 +1130,7 @@ applyToAll: Apply to all
 minValueError: "The value is too small. Minimum: {min}"
 maxValueError: "The value is too big. Maximum: {max}"
 synchronize: Synchronize
+archived: Archived
+archivedSince: Archived since {date}
+deleted: Deleted
+deletedSince: Deleted since {date}

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -1146,3 +1146,7 @@ applyToAll: Appliquer à tous
 minValueError: "La valeur est trop petite. Minimum: {min}"
 maxValueError: "La valeur est trop grande. Maximum: {max}"
 synchronize: Synchroniser
+archived: Archivé
+archivedSince: Archivé depuis le {date}
+deleted: Supprimé
+deletedSince: Supprimé depuis le {date}

--- a/front/pages/admin/endpoints/[id].vue
+++ b/front/pages/admin/endpoints/[id].vue
@@ -418,6 +418,7 @@ const {
     q: debouncedSearch,
     connection: computed(() => filters.value.connection),
     active: computed(() => filters.value.active),
+    archived: computed(() => filters.value.archived),
     include: ['harvests', 'institution.memberships.user'],
     sort: 'institution.name',
     order: 'asc',

--- a/front/pages/admin/endpoints/[id].vue
+++ b/front/pages/admin/endpoints/[id].vue
@@ -139,7 +139,7 @@
       :headers="headers"
       :group-by="[{ key: 'institution.id' }]"
       :loading="status === 'pending' && 'primary'"
-      :row-props="({ item }) => ({ class: !item.active && 'bg-grey-lighten-4 text-grey' })"
+      :row-props="({ item }) => ({ class: shouldGreyRow(item) && 'bg-grey-lighten-4 text-grey' })"
       items-per-page="0"
       density="comfortable"
       hide-default-footer
@@ -263,13 +263,8 @@
         <LocalDate :model-value="item.updatedAt" />
       </template>
 
-      <template #[`item.active`]="{ item }">
-        <span
-          v-tooltip:left="$t(`endpoints.${item.active ? 'activeSince' : 'inactiveSince'}`, { date: dateFormat(item.activeUpdatedAt, locale) })"
-          :class="[`text-${item.active ? 'green' : 'red-lighten-3'}`]"
-        >
-          {{ item.active ? $t('endpoints.active') : $t('endpoints.inactive') }}
-        </span>
+      <template #[`item.status`]="{ item }">
+        <SushiStateText :model-value="item" />
       </template>
 
       <template #[`item.actions`]="{ item }">
@@ -455,7 +450,7 @@ const headers = computed(() => [
   },
   {
     title: t('status'),
-    value: 'active',
+    value: 'status',
     align: 'center',
     width: '130px',
   },
@@ -480,6 +475,10 @@ const institutionsSelectionStatus = computed(() => {
   }
   return 'partial';
 });
+
+function shouldGreyRow(item) {
+  return item.deletedAt || item.archived || !item.active;
+}
 
 function calcSushiMetrics() {
   if (!sushis.value) {


### PR DESCRIPTION
# Front

- [x] Shows state of sushi credentials in endpoint page
- [x] Filter to show/hide archived credentials

![image](https://github.com/user-attachments/assets/9ac45868-e76f-4947-8c32-2285cb5cf55c)
