### PR TITLE
Feature/alias index templates

### DIFF
--- a/api/lib/hooks/utils.js
+++ b/api/lib/hooks/utils.js
@@ -20,9 +20,8 @@ const generateRoleNameFromRepository = (repository, modifier) => `repository.${r
 
 /**
  * @param {RepositoryAlias} alias
- * @param {string} modifier
  */
-const generateRoleNameFromAlias = (alias, repository) => `alias.${alias.pattern}.${repository.type}`;
+const generateRoleNameFromAlias = (alias) => `alias.${alias.pattern}`;
 
 /**
  *
@@ -115,9 +114,11 @@ const generateUserRoles = async (username) => {
   const additionalRoles = user.elasticRoles.map((role) => role.name);
 
   const roles = new Set(user.memberships?.flatMap?.((membership) => {
-    const repoRoles = membership?.repositoryPermissions?.map((perm) => generateRoleNameFromRepository(perm.repository, perm.readonly ? 'readonly' : 'all')) || [];
+    const repoRoles = membership?.repositoryPermissions?.map(
+      (perm) => generateRoleNameFromRepository(perm.repository, perm.readonly ? 'readonly' : 'all'),
+    ) || [];
     const aliasRoles = membership?.repositoryAliasPermissions?.map(
-      (perm) => generateRoleNameFromAlias(perm.alias, perm.alias.repository),
+      (perm) => generateRoleNameFromAlias(perm.alias),
     ) || [];
     const spaceRoles = membership?.spacePermissions?.map((perm) => generateRoleNameFromSpace(perm.space, perm.readonly ? 'readonly' : 'all')) || [];
     const institutionRoles = membership?.institution?.elasticRoles.map((role) => role.name);

--- a/api/lib/services/elastic/indices.js
+++ b/api/lib/services/elastic/indices.js
@@ -2,9 +2,18 @@ const elastic = require('.');
 
 /* eslint-disable max-len */
 /**
- * @typedef {import('@elastic/elasticsearch/index.js').ApiResponse} ApiResponse
+ * @typedef {import('.').ESResponse} ESResponse
  * @typedef {import('@elastic/elasticsearch/lib/Transport.d.ts').TransportRequestOptions} TransportRequestOptions
- * @typedef {import('@elastic/elasticsearch/api/requestParams.d.ts').IndicesPutIndexTemplate} IndicesPutIndexTemplate
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesGetResponse} GetIndexResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesCreateResponse} IndicesCreateResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesPutAliasResponse} IndicesPutAliasResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesPutIndexTemplateRequest} IndicesPutIndexTemplateRequest
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesPutIndexTemplateResponse} IndicesPutIndexTemplateResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesDeleteIndexTemplateResponse} IndicesDeleteIndexTemplateResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesDeleteResponse} IndicesDeleteResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesDeleteAliasResponse} IndicesDeleteAliasResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesStatsResponse} IndicesStatsResponse
+ * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesExistsResponse} IndicesExistsResponse
 */
 /* eslint-enable max-len */
 
@@ -15,7 +24,7 @@ const elastic = require('.');
  * @param {Object} opts - options.
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
- * @return {Promise<>} index.
+ * @return {Promise<ESResponse<GetIndexResponse>>} index.
  */
 exports.get = async function getIndex(indexName, opts, requestConfig) {
   return elastic.indices.get({
@@ -31,7 +40,7 @@ exports.get = async function getIndex(indexName, opts, requestConfig) {
  * @param {string} mapping - mapping of index.
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
- * @return {Promise<>} index created.
+ * @return {Promise<IndicesCreateResponse>} index created.
  */
 exports.create = async function createIndex(indexName, mapping, requestConfig) {
   return elastic.indices.create({
@@ -48,7 +57,7 @@ exports.create = async function createIndex(indexName, mapping, requestConfig) {
  * @param {object} [filter] The filter for the alias
  * @param {TransportRequestOptions} [requestConfig] - Request config (timeouts, headers, ignore...)
  *
- * @returns {Promise<>} alias created
+ * @returns {Promise<ESResponse<IndicesPutAliasResponse>>} alias created
  */
 exports.upsertAlias = async function upsertAlias(aliasName, indexName, filter, requestConfig) {
   return elastic.indices.putAlias({
@@ -60,9 +69,9 @@ exports.upsertAlias = async function upsertAlias(aliasName, indexName, filter, r
 
 /**
  * Upsert an index template
- * @param {IndicesPutIndexTemplate} body The template definition
+ * @param {IndicesPutIndexTemplateRequest} body The template definition
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
- * @returns {Promise<ApiResponse>}
+ * @returns {Promise<ApiResponse<IndicesPutIndexTemplateResponse>>}
  */
 exports.upsertTemplate = async function upsertTemplate(body, requestConfig) {
   return elastic.indices.putIndexTemplate(body, requestConfig);
@@ -72,7 +81,7 @@ exports.upsertTemplate = async function upsertTemplate(body, requestConfig) {
  * Delete an index template
  * @param {string} templateName The template name
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
- * @returns {Promise<ApiResponse>}
+ * @returns {Promise<ApiResponse<IndicesDeleteIndexTemplateResponse>>}
  */
 exports.deleteTemplate = async function deleteTemplate(templateName, requestConfig) {
   return elastic.indices.deleteIndexTemplate({ name: templateName }, requestConfig);
@@ -84,7 +93,7 @@ exports.deleteTemplate = async function deleteTemplate(templateName, requestConf
  * @param {string} indexName - index name.
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
- * @return {Promise<>} index.
+ * @return {Promise<ApiResponse<IndicesDeleteResponse>>} index.
  */
 exports.delete = async function deleteIndex(indexName, requestConfig) {
   return elastic.indices.delete({
@@ -98,7 +107,7 @@ exports.delete = async function deleteIndex(indexName, requestConfig) {
  * @param {string} aliasName The name of the alias
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
- * @returns {Promise<>} alias deleted
+ * @returns {Promise<ApiResponse<IndicesDeleteAliasResponse>>} alias deleted
  */
 exports.deleteAlias = async function deleteAlias(aliasName, requestConfig) {
   return elastic.indices.deleteAlias({ index: '*', name: aliasName }, requestConfig);
@@ -109,7 +118,7 @@ exports.deleteAlias = async function deleteAlias(aliasName, requestConfig) {
  *
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
- * @return {Promise<>} index.
+ * @return {Promise<ApiResponse<IndicesDeleteResponse>>} index.
  */
 exports.removeAll = async function removeAllIndices(requestConfig) {
   if (process.env.NODE_ENV !== 'dev') { return null; }
@@ -132,7 +141,7 @@ exports.removeAll = async function removeAllIndices(requestConfig) {
  * @param {Object} body - body of search.
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
- * @return {Promise<>} index.
+ * @return {Promise<ApiResponse<IndicesStatsResponse>>} index.
  */
 exports.stats = async function statsIndices(body, requestConfig) {
   return elastic.indices.stats(body, requestConfig);
@@ -144,7 +153,7 @@ exports.stats = async function statsIndices(body, requestConfig) {
  * @param {string} indexName - index name.
  * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
- * @return {Promise<>} index.
+ * @return {Promise<ApiResponse<IndicesExistsResponse>>} index.
  */
 exports.exists = async function existIndex(indexName, requestConfig) {
   return elastic.indices.exists({

--- a/api/lib/services/elastic/indices.js
+++ b/api/lib/services/elastic/indices.js
@@ -7,7 +7,7 @@ const elastic = require('.');
  * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesGetResponse} GetIndexResponse
  * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesCreateResponse} IndicesCreateResponse
  * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesPutAliasResponse} IndicesPutAliasResponse
- * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesPutIndexTemplateRequest} IndicesPutIndexTemplateRequest
+ * @typedef {import('@elastic/elasticsearch/api/requestParams.d.ts').IndicesPutIndexTemplate<import('@elastic/elasticsearch').default.estypes.IndicesPutIndexTemplateRequest['body']>} IndicesPutIndexTemplateRequest
  * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesPutIndexTemplateResponse} IndicesPutIndexTemplateResponse
  * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesDeleteIndexTemplateResponse} IndicesDeleteIndexTemplateResponse
  * @typedef {import('@elastic/elasticsearch').default.estypes.IndicesDeleteResponse} IndicesDeleteResponse

--- a/api/lib/services/elastic/indices.js
+++ b/api/lib/services/elastic/indices.js
@@ -1,11 +1,19 @@
 const elastic = require('.');
 
+/* eslint-disable max-len */
+/**
+ * @typedef {import('@elastic/elasticsearch/index.js').ApiResponse} ApiResponse
+ * @typedef {import('@elastic/elasticsearch/lib/Transport.d.ts').TransportRequestOptions} TransportRequestOptions
+ * @typedef {import('@elastic/elasticsearch/api/requestParams.d.ts').IndicesPutIndexTemplate} IndicesPutIndexTemplate
+*/
+/* eslint-enable max-len */
+
 /**
  * get index in elastic.
  *
  * @param {string} indexName - index name.
  * @param {Object} opts - options.
- * @param {Object} [requestConfig] - config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
  * @return {Promise<>} index.
  */
@@ -21,7 +29,7 @@ exports.get = async function getIndex(indexName, opts, requestConfig) {
  *
  * @param {string} indexName - index name.
  * @param {string} mapping - mapping of index.
- * @param {Object} [requestConfig] - config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
  * @return {Promise<>} index created.
  */
@@ -38,7 +46,7 @@ exports.create = async function createIndex(indexName, mapping, requestConfig) {
  * @param {string} aliasName The name of the alias
  * @param {string} indexName The name of the index targeted by the alias
  * @param {object} [filter] The filter for the alias
- * @param {object} [requestConfig] config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] - Request config (timeouts, headers, ignore...)
  *
  * @returns {Promise<>} alias created
  */
@@ -49,11 +57,32 @@ exports.upsertAlias = async function upsertAlias(aliasName, indexName, filter, r
     body: filter ? { filter } : undefined,
   }, requestConfig);
 };
+
+/**
+ * Upsert an index template
+ * @param {IndicesPutIndexTemplate} body The template definition
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
+ * @returns {Promise<ApiResponse>}
+ */
+exports.upsertTemplate = async function upsertTemplate(body, requestConfig) {
+  return elastic.indices.putIndexTemplate(body, requestConfig);
+};
+
+/**
+ * Delete an index template
+ * @param {string} templateName The template name
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
+ * @returns {Promise<ApiResponse>}
+ */
+exports.deleteTemplate = async function deleteTemplate(templateName, requestConfig) {
+  return elastic.indices.deleteIndexTemplate({ name: templateName }, requestConfig);
+};
+
 /**
  * delete index in elastic.
  *
  * @param {string} indexName - index name.
- * @param {Object} [requestConfig] - config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
  * @return {Promise<>} index.
  */
@@ -67,7 +96,7 @@ exports.delete = async function deleteIndex(indexName, requestConfig) {
  * Delete an alias from all indices in elastic.
  *
  * @param {string} aliasName The name of the alias
- * @param {object} [requestConfig] config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
  * @returns {Promise<>} alias deleted
  */
@@ -78,7 +107,7 @@ exports.deleteAlias = async function deleteAlias(aliasName, requestConfig) {
 /**
  * delete all indices in elastic.
  *
- * @param {Object} [requestConfig] - config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
  * @return {Promise<>} index.
  */
@@ -101,7 +130,7 @@ exports.removeAll = async function removeAllIndices(requestConfig) {
  * get stats of indices in elastic.
  *
  * @param {Object} body - body of search.
- * @param {Object} [requestConfig] - config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
  * @return {Promise<>} index.
  */
@@ -113,7 +142,7 @@ exports.stats = async function statsIndices(body, requestConfig) {
  * check if index exist in elastic.
  *
  * @param {string} indexName - index name.
- * @param {Object} [requestConfig] - config of request (timeouts, headers, ignore, and so on).
+ * @param {TransportRequestOptions} [requestConfig] Request config (timeouts, headers, ignore...)
  *
  * @return {Promise<>} index.
  */

--- a/api/lib/services/sync/elastic/alias.js
+++ b/api/lib/services/sync/elastic/alias.js
@@ -1,5 +1,4 @@
 // @ts-check
-const { createHash } = require('node:crypto');
 const { appLogger } = require('../../logger');
 
 const RepositoriesService = require('../../../entities/repositories.service');
@@ -15,71 +14,14 @@ const {
 const { execThrottledPromises } = require('../../promises');
 
 const { upsertRole, deleteRole } = require('../../elastic/roles');
-const {
-  upsertAlias,
-  deleteAlias,
-  upsertTemplate,
-  deleteTemplate,
-} = require('../../elastic/indices');
+const { upsertAlias, deleteAlias } = require('../../elastic/indices');
 const { filtersToESQuery } = require('../../elastic/filters');
+const { triggerHooks } = require('../../../hooks/hookEmitter');
 
-/* eslint-disable max-len */
 /**
  * @typedef {import('../../promises').ThrottledPromisesResult} ThrottledPromisesResult
  * @typedef {import('@prisma/client').RepositoryAlias} RepositoryAlias
- * @typedef {import('@prisma/client').Prisma.RepositoryGetPayload<{ include: { aliases: true } }>} RepositoryWithAliases
-*/
-/* eslint-enable max-len */
-
-// Namespace for index templates dedicated to aliases
-const aliasTemplatePrefix = 'ezm-aliases';
-// Random high priority for templates for minimizing risks of conflict
-const aliasTemplatePriority = 679;
-// Metadata added to the templates created by ezMESURE so that we can easily recognize them
-const templateMeta = {
-  createdBy: 'ezmesure',
-  description: 'Created by the ezMESURE API to keep indices in sync with aliases',
-};
-
-/**
- * Get the name of the index template that contains the aliases for a given repository
- * @param {RepositoryWithAliases} repo - The repository
- * @returns {string}
  */
-const getAliasesIndexTemplateName = (repo) => {
-  // Adding a short hash to make sure there cannot be any conflict on index template name
-  const hash = createHash('sha1').update(repo.pattern).digest('hex').substring(0, 10);
-
-  return [
-    aliasTemplatePrefix,
-    repo.pattern.replace(/\*/g, ''), // Asterisk not allowed in template names
-    hash,
-  ].join('_');
-};
-
-/**
- * Upsert an index template that contains aliases for a repository
- * @param {string} name - The name of the index template
- * @param {RepositoryWithAliases} repo - The repository with its aliases
- * @returns {Promise<import('@elastic/elasticsearch/index.js').ApiResponse>}
- */
-const upsertIndexTemplate = (name, repo) => upsertTemplate({
-  name,
-  create: false,
-  body: {
-    priority: aliasTemplatePriority,
-    index_patterns: [repo.pattern],
-    _meta: templateMeta,
-    template: {
-      aliases: Object.fromEntries(
-        repo.aliases.map((a) => [
-          a.pattern,
-          a.filters ? { filter: filtersToESQuery(a.filters) } : {},
-        ]),
-      ),
-    },
-  },
-});
 
 /**
  * Remove roles associated to a repository alias
@@ -102,24 +44,6 @@ const unmountAlias = async (alias) => {
   } catch (error) {
     appLogger.error(`[elastic] Alias [${alias.pattern}] cannot be deleted:\n${error}`);
   }
-
-  const indexTemplateName = getAliasesIndexTemplateName(repo);
-
-  if (repo.aliases.length === 0) {
-    try {
-      await deleteTemplate(indexTemplateName);
-      appLogger.verbose(`[elastic] Index template [${indexTemplateName}] has been deleted (no alias remaining)`);
-    } catch (error) {
-      appLogger.error(`[elastic] Index template [${indexTemplateName}] cannot be deleted:\n${error}`);
-    }
-  } else {
-    try {
-      await upsertIndexTemplate(indexTemplateName, repo);
-      appLogger.verbose(`[elastic] Index template [${indexTemplateName}] has been upserted`);
-    } catch (error) {
-      appLogger.error(`[elastic] Index template [${indexTemplateName}] cannot be upserted:\n${error}`);
-    }
-  }
 };
 
 /**
@@ -130,15 +54,14 @@ const unmountAlias = async (alias) => {
 const syncRepositoryAlias = async (alias) => {
   const repositoryService = new RepositoriesService();
 
-  /** @type {RepositoryWithAliases} */
-  // @ts-ignore
   const repo = await repositoryService.findUnique({
     where: { pattern: alias.target },
     select: { pattern: true, type: true, aliases: true },
   });
 
   if (!repo) {
-    appLogger.error(`[elastic] Cannot create alias [${alias.pattern}], repository [${alias.target}] not found`);
+    appLogger.verbose(`[elastic] Unmounting alias [${alias.pattern}]: repository [${alias.target}] not found`);
+    await unmountAlias(alias);
     return;
   }
 
@@ -164,14 +87,6 @@ const syncRepositoryAlias = async (alias) => {
     appLogger.error(`[elastic] Alias [${alias.pattern}] cannot be upserted:\n${error}`);
   }
 
-  const indexTemplateName = getAliasesIndexTemplateName(repo);
-
-  try {
-    await upsertIndexTemplate(indexTemplateName, repo);
-    appLogger.verbose(`[elastic] Index template [${indexTemplateName}] has been upserted`);
-  } catch (error) {
-    appLogger.error(`[elastic] Index template [${indexTemplateName}] cannot be upserted:\n${error}`);
-  }
 
   const spacesService = new SpacesService();
 

--- a/api/lib/services/sync/elastic/alias.js
+++ b/api/lib/services/sync/elastic/alias.js
@@ -16,7 +16,6 @@ const { execThrottledPromises } = require('../../promises');
 const { upsertRole, deleteRole } = require('../../elastic/roles');
 const { upsertAlias, deleteAlias } = require('../../elastic/indices');
 const { filtersToESQuery } = require('../../elastic/filters');
-const { triggerHooks } = require('../../../hooks/hookEmitter');
 
 /**
  * @typedef {import('../../promises').ThrottledPromisesResult} ThrottledPromisesResult
@@ -86,7 +85,6 @@ const syncRepositoryAlias = async (alias) => {
   } catch (error) {
     appLogger.error(`[elastic] Alias [${alias.pattern}] cannot be upserted:\n${error}`);
   }
-
 
   const spacesService = new SpacesService();
 

--- a/api/lib/services/sync/elastic/alias.js
+++ b/api/lib/services/sync/elastic/alias.js
@@ -87,21 +87,7 @@ const upsertIndexTemplate = (name, repo) => upsertTemplate({
  * @returns {Promise<void>}
  */
 const unmountAlias = async (alias) => {
-  const repositoryService = new RepositoriesService();
-
-  /** @type {RepositoryWithAliases} */
-  // @ts-ignore
-  const repo = await repositoryService.findUnique({
-    where: { pattern: alias.target },
-    select: { pattern: true, type: true, aliases: true },
-  });
-
-  if (!repo) {
-    appLogger.error(`[elastic] Cannot unmount alias [${alias.pattern}], repository [${alias.target}] not found`);
-    return;
-  }
-
-  const readOnlyRole = generateRoleNameFromAlias(alias, repo);
+  const readOnlyRole = generateRoleNameFromAlias(alias);
 
   try {
     await deleteRole(readOnlyRole);
@@ -156,7 +142,7 @@ const syncRepositoryAlias = async (alias) => {
     return;
   }
 
-  const readOnlyRole = generateRoleNameFromAlias(alias, repo);
+  const readOnlyRole = generateRoleNameFromAlias(alias);
 
   try {
     const permissions = new Map([[alias.pattern, generateElasticPermissions({ readonly: true })]]);

--- a/api/lib/services/sync/elastic/alias.js
+++ b/api/lib/services/sync/elastic/alias.js
@@ -81,7 +81,7 @@ const syncRepositoryAlias = async (alias) => {
   }
 
   try {
-    await upsertAlias(alias.pattern, repo.pattern, filters);
+    await upsertAlias(alias.pattern, repo.pattern, filters, { ignore: [404] });
     appLogger.verbose(`[elastic] Alias [${alias.pattern}] has been upserted`);
   } catch (error) {
     appLogger.error(`[elastic] Alias [${alias.pattern}] cannot be upserted:\n${error}`);

--- a/api/lib/services/sync/elastic/index.js
+++ b/api/lib/services/sync/elastic/index.js
@@ -3,7 +3,12 @@ const config = require('config');
 const { CronJob } = require('cron');
 const { appLogger } = require('../../logger');
 
-const { syncRepositories, syncRepository, unmountRepository } = require('./repositories');
+const {
+  syncRepositories,
+  syncRepository,
+  unmountRepository,
+  syncRepositoryIndexTemplate,
+} = require('./repositories');
 const { syncRepositoryAlias, syncRepositoryAliases, unmountAlias } = require('./alias');
 const { syncUser, syncUsers } = require('./users');
 
@@ -46,6 +51,7 @@ module.exports = {
   syncRepositoryAlias,
   unmountAlias,
   syncRepositoryAliases,
+  syncRepositoryIndexTemplate,
   syncUser,
   syncUsers,
 };


### PR DESCRIPTION
# Changes

Each repositories now have a dedicated index template that contains all of its aliases, so that newly created indices are properly initialized with the relevant aliases.

Later in time, this template could also be used to customize the mapping at the repository level