### PR TITLE
feat(api): give perms to contacts when syncing repo aliases

### DIFF
--- a/api/lib/controllers/repository-alias-templates/actions.js
+++ b/api/lib/controllers/repository-alias-templates/actions.js
@@ -20,6 +20,7 @@ const {
 /**
  * @typedef {import('@prisma/client').Prisma.InstitutionGetPayload<{ include: { customProps: true } }>} InstitutionWithProps
  * @typedef {import('@prisma/client').Prisma.RepositoryAliasGetPayload<{ include: { institutions: true } }>} RepoAliasWithInstitutions
+ * @typedef {import('@prisma/client').Prisma.RepositoryAliasGetPayload<{ select: { institutions: { select: { id: true } } } }>} RepoAliasWithOnlyInstitutionIds
  * @typedef {import('@prisma/client').RepositoryAliasTemplate} RepositoryAliasTemplate
  * @typedef {import('@prisma/client').Prisma.RepositoryAliasUncheckedCreateInput} RepositoryAliasUncheckedCreateInput
  * @typedef {import('@prisma/client').Prisma.RepositoryAliasTemplateCreateInput} RepositoryAliasTemplateCreateInput
@@ -58,6 +59,7 @@ const {
 
 const { prepareStandardQueryParams } = require('../../services/std-query');
 const { appLogger } = require('../../services/logger');
+const { triggerHooks } = require('../../hooks/hookEmitter');
 
 const standardQueryParams = prepareStandardQueryParams({
   ...repoAliasTemplateDto,
@@ -212,10 +214,15 @@ exports.applyOne = async (ctx) => {
       };
 
       try {
+        /** @type {RepoAliasWithOnlyInstitutionIds | null} */
+        // @ts-ignore
         // eslint-disable-next-line no-await-in-loop
         const existingAlias = await repositoryAliasesService.findUnique({
           where: { pattern: alias.pattern },
+          select: { institutions: { select: { id: true } } },
         });
+
+        const currentInstitutions = new Set(existingAlias?.institutions?.map((i) => i.id));
 
         if (existingAlias) {
           if (!dryRun) {
@@ -247,6 +254,12 @@ exports.applyOne = async (ctx) => {
 
           addResponseItem(alias, 'created', null);
         }
+
+        alias.institutions?.forEach((institution) => {
+          if (!currentInstitutions.has(institution.id)) {
+            triggerHooks('repository_alias:connected', { alias, institutionId: institution.id });
+          }
+        });
       } catch (e) {
         appLogger.error(`[alias-template] Failed to upsert alias [${alias.pattern}]:\n${e}`);
         addResponseItem(alias, 'error', e.message);

--- a/api/lib/services/sync/elastic/alias.js
+++ b/api/lib/services/sync/elastic/alias.js
@@ -4,14 +4,6 @@ const { appLogger } = require('../../logger');
 const RepositoriesService = require('../../../entities/repositories.service');
 const RepositoryAliasesService = require('../../../entities/repository-aliases.service');
 const SpacesService = require('../../../entities/spaces.service');
-const MembershipsService = require('../../../entities/memberships.service');
-
-const {
-  MEMBER_ROLES: {
-    docContact: DOC_CONTACT,
-    techContact: TECH_CONTACT,
-  },
-} = require('../../../entities/memberships.dto');
 
 const { syncIndexPatterns } = require('../kibana');
 
@@ -92,65 +84,6 @@ const syncRepositoryAlias = async (alias) => {
     appLogger.verbose(`[elastic] Alias [${alias.pattern}] has been upserted`);
   } catch (error) {
     appLogger.error(`[elastic] Alias [${alias.pattern}] cannot be upserted:\n${error}`);
-  }
-
-  const membershipsService = new MembershipsService();
-
-  const contacts = await membershipsService.findMany({
-    where: {
-      roles: {
-        hasSome: [DOC_CONTACT, TECH_CONTACT],
-      },
-      institution: {
-        repositoryAliases: {
-          some: {
-            pattern: alias.pattern,
-          },
-        },
-      },
-    },
-    select: {
-      username: true,
-      institutionId: true,
-    },
-  });
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const contact of contacts) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      await membershipsService.update({
-        where: {
-          username_institutionId: {
-            username: contact.username,
-            institutionId: contact.institutionId,
-          },
-        },
-        data: {
-          repositoryAliasPermissions: {
-            upsert: {
-              where: {
-                username_institutionId_aliasPattern: {
-                  aliasPattern: alias.pattern,
-                  institutionId: contact.institutionId,
-                  username: contact.username,
-                },
-              },
-              update: {
-                aliasPattern: alias.pattern,
-              },
-              create: {
-                aliasPattern: alias.pattern,
-              },
-            },
-          },
-        },
-      });
-    } catch (e) {
-      appLogger.error(`[elastic] Permissions for alias [${alias.pattern}] cannot be granted to [${contact.username}] in institution [${contact.institutionId}]:\n${e}`);
-    }
-
-    appLogger.verbose(`[elastic] Permissions for alias [${alias.pattern}] has been granted to [${contact.username}] in institution [${contact.institutionId}]`);
   }
 
   const spacesService = new SpacesService();


### PR DESCRIPTION
# Changes

When synchronizing aliases, grant permission to institution contacts. That way admins don't have to loop over all institutions to grant it manually.