### PR TITLE
Feature/space avatars

### DIFF
--- a/api/lib/controllers/openapi.json
+++ b/api/lib/controllers/openapi.json
@@ -612,6 +612,11 @@
             "example": "#458df9",
             "type": "string"
           },
+          "imageUrl": {
+            "description": "Space logo as a base64 data URL",
+            "type": "string",
+            "format": "byte"
+          },
           "permissions": {
             "description": "List of permissions associated to this space",
             "type": "array",

--- a/api/lib/entities/spaces.dto.js
+++ b/api/lib/entities/spaces.dto.js
@@ -24,6 +24,7 @@ const schema = {
   initials: Joi.string().trim().allow('').max(2)
     .empty(null),
   color: Joi.string().trim().allow('').empty(null),
+  imageUrl: Joi.string().trim().base64().allow(null),
 
   indexPatterns: Joi.array().items(Joi.object({
     title: Joi.string().required().min(1),

--- a/api/lib/services/images.js
+++ b/api/lib/services/images.js
@@ -23,6 +23,31 @@ module.exports = class ImagesService {
   }
 
   /**
+   * Take a base64 image, resize it, and return a base64 data URL
+   *
+   * @param {String} base64image - The base64 image to resize
+   * @param {Object} [options]
+   * @param {import('sharp').ResizeOptions} [options.resize] - The resize options
+   * @param {import('sharp').FormatEnum} [options.format] - The output format
+   * @returns {Promise<string>}
+   */
+  static async toDataUrl(base64image, options = {}) {
+    const imageContent = Buffer.from(base64image, 'base64');
+
+    const buffer = await sharp(imageContent)
+      .resize({
+        width: 64,
+        height: 64,
+        fit: sharp.fit.inside,
+        ...options.resize ?? {},
+      })
+      .toFormat(options.format ?? 'png')
+      .toBuffer();
+
+    return `data:image/png;base64,${buffer.toString('base64')}`;
+  }
+
+  /**
    * Take a Base64 image, resize it and store it
    *
    * @param {String} base64logo

--- a/api/lib/services/sync/kibana.js
+++ b/api/lib/services/sync/kibana.js
@@ -32,6 +32,10 @@ const { syncSchedule, dateFormat } = config.get('kibana');
  * @returns {Promise<string | undefined>}
  */
 const getSpaceLogo = async (space) => {
+  if (space.imageUrl) {
+    return space.imageUrl;
+  }
+
   let data;
   switch (space.type) {
     case 'counter5':

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -192,6 +192,8 @@ model Space {
   color                  String?
   /// Space type (ezpaarse, counter5)
   type                   String                       @db.VarChar(50)
+  /// Space logo as a base64 data URL
+  imageUrl               String?
   /// A list of index patterns that should be available in the space
   indexPatterns          Json[]
   /// Member permissions associated to this space

--- a/front/app/components/institution/Form.vue
+++ b/front/app/components/institution/Form.vue
@@ -346,7 +346,7 @@
                 class="drop-files-here"
                 contained
               >
-                {{ $t('institutions.institution.dropImageHere') }}
+                {{ $t('images.dropImageHere') }}
               </v-overlay>
             </v-card>
 
@@ -419,6 +419,8 @@
 </template>
 
 <script setup>
+import prettySize from 'pretty-bytes';
+
 import defaultLogo from '@@/static/images/logo-etab.png';
 import { fileToBase64 } from '@/lib/base64';
 
@@ -601,7 +603,7 @@ async function save() {
     }
   } catch (err) {
     if (err.statusCode === 413) {
-      snacks.error(t('institutions.institution.imageTooLarge'));
+      snacks.error(t('images.imageTooLarge'));
     } else {
       snacks.error(t('institutions.institution.unableToUpate'), err);
     }
@@ -622,12 +624,12 @@ async function save() {
  */
 async function updateLogo(file) {
   if (!/\.(jpe?g|png|svg)$/.exec(file.name)) {
-    logoError.value = t('institutions.institution.invalidImageFile', { accept: LOGO_ACCEPT });
+    logoError.value = t('images.invalidImageFile', { accept: LOGO_ACCEPT });
     return;
   }
 
   if (file.size > LOGO_MAX_SIZE) {
-    logoError.value = t('institutions.institution.imageTooLarge');
+    logoError.value = t('images.imageTooLarge', { size: prettySize(LOGO_MAX_SIZE) });
     return;
   }
 

--- a/front/app/components/space/Card.vue
+++ b/front/app/components/space/Card.vue
@@ -21,6 +21,20 @@
       />
     </template>
 
+    <template #text>
+      <slot name="text">
+        <div class="d-flex ga-4">
+          <v-avatar v-if="modelValue.imageUrl" size="32">
+            <v-img :src="modelValue.imageUrl" />
+          </v-avatar>
+
+          <div class="flex-grow-1">
+            {{ modelValue.description }}
+          </div>
+        </div>
+      </slot>
+    </template>
+
     <template v-if="$slots.append" #append>
       <slot name="append" />
     </template>

--- a/front/app/components/space/Card.vue
+++ b/front/app/components/space/Card.vue
@@ -1,7 +1,6 @@
 <template>
   <v-card
     :title="modelValue.name"
-    :text="modelValue.description"
     variant="outlined"
     :style="{ borderColor: repoColors.get(modelValue.type), borderWidth: '2px' }"
   >

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -346,9 +346,6 @@ institutions:
     localisation: Localisation
     automations: Automations
     monitor: Monitoring
-    dropImageHere: Drop your image here
-    invalidImageFile: "Invalid image file. Accepted file types: {accept}"
-    imageTooLarge: "Image is too large. Maximum allowed size: 2mb"
     noDataFound: Your institution's information could not be retrieved.
     dataSent: Institution informations transmitted
     updated: Institution updated
@@ -933,6 +930,7 @@ spaces:
   noSpace: No space has been assigned yet
   id: Identifier
   type: Type
+  logo: Logo
   types:
     ezpaarse: ezPAARSE
     counter5: COUNTER
@@ -1063,6 +1061,10 @@ statuses:
   updated: Updated
   deleted: Deleted
   error: Error
+images:
+  dropImageHere: Drop your image here
+  invalidImageFile: "Invalid image file. Accepted file types: {accept}"
+  imageTooLarge: "Image is too large. Maximum allowed size: 2mb"
 anErrorOccurred: An error occurred
 url: URL
 type: Type

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -1064,7 +1064,7 @@ statuses:
 images:
   dropImageHere: Drop your image here
   invalidImageFile: "Invalid image file. Accepted file types: {accept}"
-  imageTooLarge: "Image is too large. Maximum allowed size: 2mb"
+  imageTooLarge: "Image is too large. Maximum allowed size: {size}"
 anErrorOccurred: An error occurred
 url: URL
 type: Type

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -348,9 +348,6 @@ institutions:
     localisation: Localisation
     automations: Automatisations
     monitor: Contrôle
-    dropImageHere: Déposez votre image ici
-    invalidImageFile: 'Format de fichier invalide. Types de fichiers supportés : {accept}'
-    imageTooLarge: 'L''image est trop volumineuse. Taille maximale autorisée : 2mb'
     noDataFound: Les informations de votre établissement n'ont pas pu être récupérées.
     dataSent: Informations d'établissement transmises
     updated: Établissement mis à jour
@@ -949,6 +946,7 @@ spaces:
   noSpace: Aucun espace n'est encore attribué
   id: Identifiant
   type: Type
+  logo: Logo
   types:
     ezpaarse: ezPAARSE
     counter5: COUNTER
@@ -1080,6 +1078,10 @@ statuses:
   updated: Mis à jour
   deleted: Supprimé
   error: Erreur
+images:
+  dropImageHere: Déposez votre image ici
+  invalidImageFile: 'Format de fichier invalide. Types de fichiers supportés : {accept}'
+  imageTooLarge: 'L''image est trop volumineuse. Taille maximale autorisée : 2mb'
 anErrorOccurred: Une erreur est survenue
 url: URL
 type: Type

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -1081,7 +1081,7 @@ statuses:
 images:
   dropImageHere: Déposez votre image ici
   invalidImageFile: 'Format de fichier invalide. Types de fichiers supportés : {accept}'
-  imageTooLarge: 'L''image est trop volumineuse. Taille maximale autorisée : 2mb'
+  imageTooLarge: 'L''image est trop volumineuse. Taille maximale autorisée : {size}'
 anErrorOccurred: Une erreur est survenue
 url: URL
 type: Type


### PR DESCRIPTION
# Changes

Add the possibility to customize the space logos. For the sake of simplicity, the logos are stored in the DB as **base64 data URLs**, which makes it easier to use and export them. The logos are resized to `64x64` (the recommended size for Kibana), so they remains lightweight.

##  API
 - [x] Add `imageUrl` to the `Space` entity
 - [x] Handle the image in `create`/`update` routes
 - [x] Use the custom logo (if any) when synchronizing spaces to Kibana

##  Front
 - [x] Add an input for the logo in the space form
 - [x] Show custom logos in the space cards