### PR TITLE
feat: async sushi alerts in db

### DIFF
--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -87,6 +87,14 @@
     "deleteSushi": {
       "schedule": "EZMESURE_DELETE_SUSHI_COUNTER_SCHEDULE",
       "maxDayAge": "EZMESURE_DELETE_SUSHI_COUNTER_FOLLOW_INTERVAL"
+    },
+    "alerts": {
+      "harvestedButUnsupported": {
+        "schedule": "EZMESURE_SUSHI_ALERT_HARVESTED_BUT_UNSUPPORTED_SCHEDULE"
+      },
+      "endpoint": {
+        "schedule": "EZMESURE_SUSHI_ALERT_ENDPOINT_SCHEDULE"
+      }
     }
   },
   "depositors": {

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -109,6 +109,14 @@ module.exports = {
       schedule: '0 */15 * * * *',
       followInterval: 10000,
     },
+    alerts: {
+      harvestedButUnsupported: {
+        schedule: '0 0 * * 7',
+      },
+      endpoint: {
+        schedule: '0 0 0 * * *',
+      },
+    },
   },
   notifications: {
     sender: 'ezMESURE',

--- a/api/lib/controllers/sushi-alerts/index.js
+++ b/api/lib/controllers/sushi-alerts/index.js
@@ -4,7 +4,13 @@ const { Joi } = require('koa-joi-router');
 const { requireJwt, requireUser, requireAdmin } = require('../../services/auth');
 
 const {
-  list,
+  standardQueryParams,
+
+  getAllAlerts,
+  getOneAlert,
+  deleteOneAlert,
+  refreshUnsupportedButHarvestedUpdateAlerts,
+  refreshEndpointAlerts,
 } = require('./actions');
 
 router.use(requireJwt, requireUser, requireAdmin);
@@ -12,12 +18,45 @@ router.use(requireJwt, requireUser, requireAdmin);
 router.route({
   method: 'GET',
   path: '/',
-  handler: list,
+  handler: getAllAlerts,
   validate: {
-    query: {
-      type: Joi.string(),
+    query: standardQueryParams.manyValidation,
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/:id',
+  handler: getOneAlert,
+  validate: {
+    params: {
+      id: Joi.string().trim().required(),
+    },
+    query: standardQueryParams.oneValidation,
+  },
+});
+
+router.route({
+  method: 'DELETE',
+  path: '/:id',
+  handler: deleteOneAlert,
+  validate: {
+    params: {
+      id: Joi.string().trim().required(),
     },
   },
+});
+
+router.route({
+  method: 'POST',
+  path: '/_refresh/unsupported-but-harvested',
+  handler: refreshUnsupportedButHarvestedUpdateAlerts,
+});
+
+router.route({
+  method: 'POST',
+  path: '/_refresh/endpoint',
+  handler: refreshEndpointAlerts,
 });
 
 module.exports = router;

--- a/api/lib/entities/sushi-alerts.dto.js
+++ b/api/lib/entities/sushi-alerts.dto.js
@@ -1,0 +1,45 @@
+const { Joi } = require('koa-joi-router');
+
+const { enums } = require('../services/prisma');
+
+const {
+  withModifiers,
+  ignoreFields,
+} = require('./schema.utils');
+
+/**
+ * Base schema
+ * @type {Record<string, import('joi').AnySchema>}
+ */
+const schema = {
+  id: Joi.string().trim(),
+  createdAt: Joi.date(),
+
+  type: Joi.string().allow(...Object.values(enums.SushiAlertType)),
+  severity: Joi.string().required(),
+  context: Joi.object(),
+};
+
+/**
+ * Fields that cannot be changed but could be found in request body
+ */
+const immutableFields = [
+  'id',
+  'deletedAt',
+  'type',
+  'severity',
+  'context',
+];
+
+/**
+ * Schema to be applied when a regular user creates SUSHI credentials
+ */
+const createSchema = withModifiers(
+  schema,
+  ignoreFields(immutableFields),
+);
+
+module.exports = {
+  schema,
+  createSchema: Joi.object(createSchema).required(),
+};

--- a/api/lib/entities/sushi-alerts.service.js
+++ b/api/lib/entities/sushi-alerts.service.js
@@ -1,0 +1,427 @@
+// @ts-check
+const { formatISO } = require('date-fns');
+const BasePrismaService = require('./base-prisma.service');
+const alertsPrisma = require('../services/prisma/sushi-alerts');
+
+const { getStatus } = require('../services/sushi');
+const { appLogger } = require('../services/logger');
+
+const HarvestService = require('./harvest.service');
+const EndpointsService = require('./sushi-endpoints.service');
+
+const isObject = require('../utils/isObject');
+
+/* eslint-disable max-len */
+/**
+ * @typedef {import('@prisma/client').SushiAlert} SushiAlert
+ * @typedef {import('@prisma/client').Prisma.SushiAlertUpdateArgs} SushiAlertUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertUpsertArgs} SushiAlertUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertFindUniqueArgs} SushiAlertFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertFindManyArgs} SushiAlertFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertCreateArgs} SushiAlertCreateArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertCreateInput} SushiAlertCreateInput
+ * @typedef {import('@prisma/client').Prisma.SushiAlertDeleteArgs} SushiAlertDeleteArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertDeleteManyArgs} SushiAlertDeleteManyArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertCountArgs} SushiAlertCountArgs
+ * @typedef {import('@prisma/client').Prisma.SushiEndpointGetPayload<{ include: { credentials: true } }>} SushiEndpointWithCredentials
+ * @typedef {import('@prisma/client').Prisma.HarvestGetPayload<{ include: { credentials: { include: { endpoint: true, institution: true } } } }>} HarvestWithInstitutionAndEndpoint
+ * @typedef {import('@prisma/client').Prisma.PrismaPromise<unknown>} PrismaPromise
+ */
+/* eslint-enable max-len */
+
+module.exports = class SushiAlertsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<SushiAlertsService>} */
+  static $transaction = super.$transaction;
+
+  /**
+   * @param {SushiAlertCreateArgs} params
+   * @returns {Promise<SushiAlert>}
+   */
+  async create(params) {
+    const space = await alertsPrisma.create(params, this.prisma);
+    this.triggerHooks('sushi-alerts:create', space);
+    return space;
+  }
+
+  /**
+   * @param {SushiAlertFindManyArgs} params
+   * @returns {Promise<SushiAlert[]>}
+   */
+  findMany(params) {
+    return alertsPrisma.findMany(params, this.prisma);
+  }
+
+  /**
+   * @param {SushiAlertFindUniqueArgs} params
+   * @returns {Promise<SushiAlert | null>}
+   */
+  findUnique(params) {
+    return alertsPrisma.findUnique(params, this.prisma);
+  }
+
+  /**
+   * @param {SushiAlertUpdateArgs} params
+   * @returns {Promise<SushiAlert>}
+   */
+  async update(params) {
+    const alert = await alertsPrisma.update(params, this.prisma);
+    this.triggerHooks('sushi-alerts:update', alert);
+    return alert;
+  }
+
+  /**
+   * @param {SushiAlertUpsertArgs} params
+   * @returns {Promise<SushiAlert>}
+   */
+  async upsert(params) {
+    const alert = await alertsPrisma.upsert(params, this.prisma);
+    this.triggerHooks('sushi-alerts:upsert', alert);
+    return alert;
+  }
+
+  /**
+   * @param {SushiAlertCountArgs} params
+   * @returns {Promise<number>}
+   */
+  async count(params) {
+    return alertsPrisma.count(params, this.prisma);
+  }
+
+  /**
+   * @param {SushiAlertDeleteArgs} params
+   * @returns {Promise<SushiAlert | null>}
+   */
+  async delete(params) {
+    const result = await alertsPrisma.remove(params, this.prisma);
+    if (!result) {
+      return null;
+    }
+
+    const { deleteResult, deletedAlert } = result;
+
+    this.triggerHooks('sushi-alerts:delete', deletedAlert);
+    return deleteResult;
+  }
+
+  /**
+   * @param {SushiAlertDeleteManyArgs} params
+   * @returns {Promise<SushiAlert[]>}
+   */
+  async deleteMany(params) {
+    const deleted = await alertsPrisma.removeMany(params, this.prisma);
+    deleted.forEach((deletedAlert) => this.triggerHooks('sushi-alerts:delete', deletedAlert));
+    return deleted;
+  }
+
+  /**
+   * @returns {Promise<Array<SushiAlert> | null>}
+   */
+  async removeAll() {
+    if (process.env.NODE_ENV !== 'dev') { return null; }
+
+    /** @param {SushiAlertsService} service */
+    const transaction = async (service) => {
+      const alerts = await service.findMany({});
+
+      if (alerts.length === 0) { return null; }
+
+      await Promise.all(
+        alerts.map(
+          (space) => service.delete({
+            where: {
+              id: space.id,
+            },
+          }),
+        ),
+      );
+
+      return alerts;
+    };
+
+    if (this.currentTransaction) {
+      return transaction(this);
+    }
+    return SushiAlertsService.$transaction(transaction);
+  }
+
+  /**
+   * Update HARVESTED_BUT_UNSUPPORTED alerts
+   */
+  async updateHarvestedButUnsupported() {
+    if (!this.prisma) {
+      throw new Error('No prisma initialised');
+    }
+    if (this.currentTransaction) {
+      throw new Error("Cannot run this method in a transaction (it's a heavy and time consuming operation)");
+    }
+
+    const harvestService = new HarvestService(this);
+
+    // Severity by harvest status
+    const SEVERITY_PER_STATUS = new Map([
+      ['finished', 'info'],
+      ['missing', 'warning'],
+      // will defaults to "error"
+    ]);
+
+    /** @type {Map<string, PrismaPromise>} */
+    const operations = new Map();
+
+    /** @type {AsyncGenerator<HarvestWithInstitutionAndEndpoint>} */
+    // @ts-expect-error
+    const scroller = harvestService.scroll({
+      where: {
+        status: {
+          notIn: ['running', 'waiting', 'delayed'],
+        },
+        credentials: {
+          deletedAt: null,
+        },
+      },
+      select: {
+        reportId: true,
+        credentialsId: true,
+        status: true,
+        period: true,
+
+        credentials: {
+          include: {
+            endpoint: true,
+            institution: true,
+          },
+        },
+      },
+    });
+
+    const existingAlerts = new Map(
+      (await this.findMany({ where: { type: 'HARVESTED_BUT_UNSUPPORTED' } }))
+        .map((al) => [al.id, al]),
+    );
+
+    appLogger.verbose(`[sushi-alerts][HARVESTED_BUT_UNSUPPORTED] Found [${existingAlerts.size}] existing alerts`);
+
+    let harvestCount = 0;
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const harvest of scroller) {
+      harvestCount += 1;
+      // Log progress
+      if (harvestCount % 10000 === 0) {
+        appLogger.verbose(`[sushi-alerts][HARVESTED_BUT_UNSUPPORTED] Still processing... (Prepared [${operations.size}] operations; Analysed [${harvestCount}] harvests)`);
+      }
+
+      const id = `${harvest.credentialsId}:${harvest.reportId}:${harvest.status}`;
+      // Get existing alert
+      const currentAlert = existingAlerts.get(id);
+
+      // Filter harvests with a reportId marked as "supported" in the endpoint
+      // or endpoints without supportedData
+      if (!harvest.credentials.endpoint.supportedData) {
+        if (currentAlert) {
+          existingAlerts.delete(id);
+          operations.set(id, this.prisma.sushiAlert.delete({ where: { id } }));
+        }
+        appLogger.debug(`[sushi-alerts][HARVESTED_BUT_UNSUPPORTED] [${harvest.credentials.endpoint.id}] doesn't have supported data`);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      // TODO: should use first/last month available
+      // We don't need first/last month available, so we can merge all versions
+      const supportedData = new Map(
+        Object.values(harvest.credentials.endpoint.supportedData)
+          .flatMap((data) => Object.entries(data)),
+      );
+      if (supportedData.get(harvest.reportId)?.supported?.value !== false) {
+        if (currentAlert) {
+          existingAlerts.delete(id);
+          operations.set(id, this.prisma.sushiAlert.delete({ where: { id } }));
+        }
+        appLogger.debug(`[sushi-alerts][HARVESTED_BUT_UNSUPPORTED] [${harvest.credentials.endpoint.id}] does support ${harvest.reportId}`);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      /** @type {SushiAlert} */
+      // @ts-expect-error
+      const payload = currentAlert ?? {
+        id,
+        type: 'HARVESTED_BUT_UNSUPPORTED',
+        severity: SEVERITY_PER_STATUS.get(harvest.status) ?? 'error',
+
+        context: {
+          reportId: harvest.reportId,
+          status: harvest.status,
+          credentialsId: harvest.credentialsId,
+
+          beginDate: harvest.period,
+          endDate: harvest.period,
+
+          credentials: harvest.credentials,
+        },
+
+        createdAt: new Date(),
+      };
+
+      if (isObject(payload.context)) {
+        // TODO: what if missing one ?
+        if ((payload.context.beginDate ?? '') >= harvest.period) {
+          payload.context.beginDate = harvest.period;
+        }
+        if ((payload.context.endDate ?? '') <= harvest.period) {
+          payload.context.endDate = harvest.period;
+        }
+      }
+
+      existingAlerts.set(id, payload);
+      operations.set(id, this.prisma.sushiAlert.upsert({
+        where: { id },
+        // @ts-expect-error
+        create: payload,
+        // @ts-expect-error
+        update: payload,
+      }));
+    }
+
+    appLogger.verbose(`[sushi-alerts][HARVESTED_BUT_UNSUPPORTED] Completed ! Running [${operations.size}] operations (Analysed [${harvestCount}] harvests)`);
+    // TODO: do by bulk to avoid timeout issues
+    await SushiAlertsService.$transaction(Array.from(operations.values()));
+  }
+
+  /**
+   * Update ENDPOINT alerts
+   */
+  async updateEndpointAlerts() {
+    if (!this.prisma) {
+      throw new Error('No prisma initialised');
+    }
+    if (this.currentTransaction) {
+      throw new Error("Cannot run this method in a transaction (it's a heavy and time consuming operation)");
+    }
+
+    /** @type {Omit<SushiAlertCreateInput, 'type'>[]} */
+    const alerts = [];
+    const collectedAt = new Date();
+
+    const endpointService = new EndpointsService(this);
+
+    /** @type {SushiEndpointWithCredentials[]} */
+    // @ts-expect-error
+    const endpointsToDo = await endpointService.findMany({
+      where: {
+        active: true,
+        credentials: {
+          some: {
+            connection: {
+              path: ['status'],
+              equals: 'success',
+            },
+          },
+        },
+      },
+      include: {
+        credentials: {
+          take: 1,
+        },
+      },
+    });
+
+    appLogger.verbose(`[sushi-alerts][ENDPOINT] Found [${endpointsToDo.length}] endpoints to check`);
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const endpoint of endpointsToDo) {
+      const credentials = endpoint.credentials.at(0);
+      if (!credentials) {
+        appLogger.warn(`[sushi-alerts][ENDPOINT] No credentials found for [${endpoint.id}] (shouldn't happen)`);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const version of endpoint.counterVersions) {
+        try {
+          appLogger.verbose(`[sushi-alerts][ENDPOINT] Getting status for [${endpoint.id}] (using COUNTER [${version}])`);
+          // eslint-disable-next-line no-await-in-loop
+          let { data: statuses } = await getStatus({ ...credentials, endpoint }, version);
+          if (!Array.isArray(statuses)) {
+            statuses = [statuses];
+          }
+
+          statuses.forEach((status) => {
+            if (status.Note) {
+              appLogger.verbose(`[sushi-alerts][ENDPOINT] Found note for [${endpoint.id}]`);
+              alerts.push({
+                id: `${endpoint.id}:note`,
+                severity: 'info',
+                context: {
+                  message: status.Note,
+                  collectedAt,
+                  endpoint,
+                },
+              });
+            }
+
+            // TODO: handle few edge cases like "False", "false", "no", "off", etc.
+            if (status.Service_Active === false) {
+              appLogger.verbose(`[sushi-alerts][ENDPOINT] Found that service is inactive for [${endpoint.id}]`);
+              alerts.push({
+                id: `${endpoint.id}:inactive`,
+                severity: 'error',
+                context: {
+                  message: 'Endpoint reported itself as inactive',
+                  collectedAt,
+                  endpoint,
+                },
+              });
+            }
+
+            if (Array.isArray((status.Alerts))) {
+              appLogger.verbose(`[sushi-alerts][ENDPOINT] Found [${status.Alerts.length}] alerts for [${endpoint.id}]`);
+              alerts.push(
+                ...status.Alerts
+                  .filter((al) => !!al?.Alert)
+                  .map((al, i) => ({
+                    id: `${endpoint.id}:${i}`,
+                    // not standard, so must have a fallback
+                    severity: al.Severity,
+                    context: {
+                      message: al.Alert,
+                      collectedAt,
+                      endpoint,
+                    },
+                    createdAt: formatISO(al.Date_Time),
+                  })),
+              );
+            }
+          });
+        } catch (err) {
+          appLogger.error(`[sushi-alerts][ENDPOINT] Error while getting alerts for [${endpoint.id}] (using COUNTER [${version}]): ${err instanceof Error ? err.message : err}`);
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+      }
+    }
+
+    const tx = this.prisma;
+    /** @type {PrismaPromise[]} */
+    const operations = alerts.map((payload) => tx.sushiAlert.upsert({
+      where: { id: payload.id },
+      update: { ...payload, type: 'ENDPOINT' },
+      create: { ...payload, type: 'ENDPOINT' },
+    }));
+    // Reset all previous alerts
+    operations.push(this.prisma.sushiAlert.deleteMany({
+      where: {
+        type: 'ENDPOINT',
+        context: {
+          path: ['collectedAt'],
+          lt: collectedAt,
+        },
+      },
+    }));
+
+    appLogger.verbose(`[sushi-alerts][ENDPOINT] Completed ! Running [${operations.length}] operations (Checked [${endpointsToDo.length}] endpoints)`);
+
+    // TODO: do by bulk to avoid timeout issues
+    await SushiAlertsService.$transaction(operations);
+  }
+};

--- a/api/lib/services/prisma/index.js
+++ b/api/lib/services/prisma/index.js
@@ -1,4 +1,9 @@
-const { PrismaClient, Prisma, HarvestJobStatus } = require('@prisma/client');
+const {
+  PrismaClient,
+  Prisma,
+  HarvestJobStatus,
+  SushiAlertType,
+} = require('@prisma/client');
 
 module.exports = {
   Prisma,
@@ -6,6 +11,7 @@ module.exports = {
 
   enums: {
     HarvestJobStatus,
+    SushiAlertType,
   },
 
   PrismaErrors: {

--- a/api/lib/services/prisma/sushi-alerts.js
+++ b/api/lib/services/prisma/sushi-alerts.js
@@ -1,0 +1,155 @@
+// @ts-check
+const { client: prisma } = require('./index');
+
+/* eslint-disable max-len */
+/**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('@prisma/client').SushiAlert} SushiAlert
+ * @typedef {import('@prisma/client').Prisma.SushiAlertUpdateArgs} SushiAlertUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertUpsertArgs} SushiAlertUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertFindUniqueArgs} SushiAlertFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertFindManyArgs} SushiAlertFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertCreateArgs} SushiAlertCreateArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertDeleteArgs} SushiAlertDeleteArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertDeleteManyArgs} SushiAlertDeleteManyArgs
+ * @typedef {import('@prisma/client').Prisma.SushiAlertCountArgs} SushiAlertCountArgs
+ *
+ * @typedef {{deleteResult: SushiAlert, deletedAlert: SushiAlert }} AlertRemoved
+ */
+/* eslint-enable max-len */
+
+/**
+ * @param {SushiAlertCreateArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SushiAlert>}
+ */
+function create(params, tx = prisma) {
+  return tx.sushiAlert.create(params);
+}
+
+/**
+ * @param {SushiAlertFindManyArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SushiAlert[]>}
+ */
+function findMany(params, tx = prisma) {
+  return tx.sushiAlert.findMany(params);
+}
+
+/**
+ * @param {SushiAlertFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SushiAlert | null>}
+ */
+function findUnique(params, tx = prisma) {
+  return tx.sushiAlert.findUnique(params);
+}
+
+/**
+ * @param {SushiAlertUpdateArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SushiAlert>}
+ */
+function update(params, tx = prisma) {
+  return tx.sushiAlert.update(params);
+}
+
+/**
+ * @param {SushiAlertUpsertArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SushiAlert>}
+ */
+function upsert(params, tx = prisma) {
+  return tx.sushiAlert.upsert(params);
+}
+
+/**
+ * @param {SushiAlertCountArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<number>}
+ */
+function count(params, tx = prisma) {
+  return tx.sushiAlert.count(params);
+}
+
+/**
+ * @param {SushiAlertDeleteArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<AlertRemoved | null>}
+ */
+async function remove(params, tx = prisma) {
+  const alert = await tx.sushiAlert.findUnique({
+    where: params.where,
+  });
+
+  if (!alert) {
+    return null;
+  }
+
+  return {
+    deleteResult: await tx.sushiAlert.delete(params),
+    deletedAlert: alert,
+  };
+}
+
+/**
+ * @param {SushiAlertDeleteManyArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<SushiAlert[]>}
+ */
+async function removeMany(params, tx = prisma) {
+  const alerts = await tx.sushiAlert.findMany({
+    where: params.where,
+  });
+
+  await tx.sushiAlert.deleteMany(params);
+
+  return alerts;
+}
+
+/**
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Array<SushiAlert> | null>}
+ */
+async function removeAll(tx) {
+  if (process.env.NODE_ENV !== 'dev') { return null; }
+
+  /** @param {TransactionClient} txx */
+  const transaction = async (txx) => {
+    const alerts = await findMany({}, txx);
+
+    if (alerts.length === 0) { return null; }
+
+    await Promise.all(
+      alerts.map(
+        (space) => remove(
+          {
+            where: {
+              id: space.id,
+            },
+          },
+          txx,
+        ),
+      ),
+    );
+
+    return alerts;
+  };
+
+  if (tx) {
+    return transaction(tx);
+  }
+  return prisma.$transaction(transaction);
+}
+
+module.exports = {
+  create,
+  findMany,
+  findUnique,
+  update,
+  upsert,
+  count,
+  remove,
+  removeMany,
+  removeAll,
+};

--- a/api/lib/services/sushi-alerts.js
+++ b/api/lib/services/sushi-alerts.js
@@ -1,0 +1,92 @@
+const { CronJob } = require('cron');
+const config = require('config');
+
+const { appLogger } = require('./logger');
+const SushiAlertsService = require('../entities/sushi-alerts.service');
+
+const {
+  harvestedButUnsupported: harvestedButUnsupportedConfig,
+  endpoint: endpointConfig,
+} = config.get('counter.alerts');
+
+// #region HARVESTED_BUT_UNSUPPORTED
+
+async function updateHarvestedButUnsupported() {
+  appLogger.verbose('[sushi-alerts] Starting updating HARVEST_BUT_UNSUPPORTED alerts');
+
+  const service = new SushiAlertsService();
+  try {
+    await service.updateHarvestedButUnsupported();
+  } catch (err) {
+    appLogger.error(`[sushi-alerts] Couldn't update HARVEST_BUT_UNSUPPORTED alerts: ${err instanceof Error ? err.message : err}`);
+  }
+
+  // TODO: send mail
+
+  appLogger.verbose('[sushi-alerts] Update of HARVEST_BUT_UNSUPPORTED alerts ended');
+}
+
+const harvestButUnsupportedJob = CronJob.from({
+  cronTime: harvestedButUnsupportedConfig.schedule,
+  runOnInit: false,
+  onTick: updateHarvestedButUnsupported,
+});
+
+async function startUpdateHarvestButUnsupportedAlerts() {
+  if (harvestButUnsupportedJob.isCallbackRunning) {
+    throw new Error('An update of HARVEST_BUT_UNSUPPORTED alerts is already running');
+  }
+
+  await harvestButUnsupportedJob.stop();
+  // Don't await promise to avoid waiting for cron to finish
+  updateHarvestedButUnsupported()
+    .then(() => harvestButUnsupportedJob.start());
+}
+
+// #endregion HARVESTED_BUT_UNSUPPORTED
+
+// #region ENDPOINT
+
+async function updateEndpointAlerts() {
+  appLogger.verbose('[sushi-alerts] Starting updating ENDPOINT alerts');
+
+  const service = new SushiAlertsService();
+  try {
+    await service.updateEndpointAlerts();
+  } catch (err) {
+    appLogger.error(`[sushi-alerts] Couldn't update ENDPOINT alerts: ${err instanceof Error ? err.message : err}`);
+  }
+  // TODO: send mail
+
+  appLogger.verbose('[sushi-alerts] Update of ENDPOINT alerts ended');
+}
+
+const endpointJob = CronJob.from({
+  cronTime: endpointConfig.schedule,
+  runOnInit: false,
+  onTick: updateEndpointAlerts,
+});
+
+async function startUpdateEndpointAlerts() {
+  if (endpointJob.isCallbackRunning) {
+    throw new Error('An update of ENDPOINT alerts is already running');
+  }
+
+  await endpointJob.stop();
+  // Don't await promise to avoid waiting for cron to finish
+  updateEndpointAlerts()
+    .then(() => endpointJob.start());
+}
+
+// #endregion HARVESTED_BUT_UNSUPPORTED
+
+async function startCron() {
+  harvestButUnsupportedJob.start();
+  endpointJob.start();
+}
+
+module.exports = {
+  startUpdateHarvestButUnsupportedAlerts,
+  startUpdateEndpointAlerts,
+  startCron,
+};

--- a/api/lib/services/sushi.js
+++ b/api/lib/services/sushi.js
@@ -137,6 +137,38 @@ async function getAvailableReports(sushi, version = '5') {
   return response;
 }
 
+/**
+ * Get the status of a endpoint using a given SUSHI item
+ * @param {SushiCredentials} sushi - The SUSHI item
+ * @param {string} [version=5] - The COUNTER version
+ * @returns {Promise<any>} The endpoint response
+ */
+async function getStatus(sushi, version = '5.1') {
+  const { baseUrl } = getSushiURL(sushi?.endpoint || {}, version);
+
+  const allowedScopes = [undefined, 'all'];
+  const params = getSushiParams(sushi, allowedScopes);
+
+  const response = await axios({
+    method: 'get',
+    url: `${baseUrl}/alerts`,
+    responseType: 'json',
+    params,
+  });
+
+  if (!response) {
+    throw new Error('sushi endpoint didn\'t respond');
+  }
+  if (response.status !== 200) {
+    throw new Error(`sushi endpoint responded with status ${response.status}`);
+  }
+  if (!response.data) {
+    throw new Error('sushi endpoint didn\'t return any data');
+  }
+
+  return response;
+}
+
 function getReportDownloadConfig(endpoint, sushi, version, opts = {}) {
   const options = opts || {};
 
@@ -573,6 +605,7 @@ module.exports = {
   getReportPath,
   getReportTmpPath,
   getAvailableReports,
+  getStatus,
   downloadReport,
   getOngoingDownload,
   initiateDownload,

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -225,23 +225,23 @@ model SpacePermission {
 /// A repository (a section of elasticsearch allocated to an institution)
 model Repository {
   /// The institution this repository is associated to
-  institutions            Institution[]
+  institutions           Institution[]
   /// Creation date
-  createdAt               DateTime                          @default(now())
+  createdAt              DateTime                          @default(now())
   /// Latest update date
-  updatedAt               DateTime                          @updatedAt
+  updatedAt              DateTime                          @updatedAt
   /// The index pattern (ex: b-bibcnrs*)
-  pattern                 String                            @id
+  pattern                String                            @id
   /// The repository type (ezpaarse, counter5)
-  type                    String                            @db.VarChar(50)
+  type                   String                            @db.VarChar(50)
   /// Member permissions associated to this repository
-  permissions             RepositoryPermission[]
+  permissions            RepositoryPermission[]
   /// Aliases associated to this repository
-  aliases                 RepositoryAlias[]
+  aliases                RepositoryAlias[]
   /// Permissions granted by role for this repository
-  elasticRolePermissions  ElasticRoleRepositoryPermission[]
+  elasticRolePermissions ElasticRoleRepositoryPermission[]
   /// Alias templates that target this repository
-  aliasTemplates RepositoryAliasTemplate[]
+  aliasTemplates         RepositoryAliasTemplate[]
 }
 
 /// A repository permission (access rights of a member for a specific repository)
@@ -423,39 +423,39 @@ model Action {
 /// Represent a harvest session
 model HarvestSession {
   /// ID of the session
-  id                  String       @id @default(cuid())
+  id                     String       @id @default(cuid())
   /// Beginning of the requested period
-  beginDate           String
+  beginDate              String
   /// End of the requested period
-  endDate             String
+  endDate                String
   /// Query to get sushi credentials
-  credentialsQuery    Json
+  credentialsQuery       Json
   /// Jobs created after request
-  jobs                HarvestJob[]
+  jobs                   HarvestJob[]
   /// IDs of the requested reports (ex: tr_j1)
-  reportTypes         String[]
+  reportTypes            String[]
   /// Allowed COUNTER versions (ex: ['5.1', '5'])
-  allowedCounterVersions         String[]
+  allowedCounterVersions String[]
   /// Maximum execution time of a job
-  timeout             Int          @default(600)
+  timeout                Int          @default(600)
   /// Whether the reports should be fetched even if credentials aren't verified or wrong
-  allowFaulty         Boolean      @default(false)
+  allowFaulty            Boolean      @default(false)
   /// Whether the reports should be downloaded even if not supported by the endpoint
-  downloadUnsupported Boolean      @default(false)
+  downloadUnsupported    Boolean      @default(false)
   /// Whether the reports should be downloaded even if a local copy already exists
-  forceDownload       Boolean      @default(false)
+  forceDownload          Boolean      @default(false)
   /// Whether a mail should be sent when session ended
   sendEndMail            Boolean      @default(true)
   /// Whether the reports should be inserted even if it does not pass the validation step
-  ignoreValidation    Boolean?
+  ignoreValidation       Boolean?
   /// Parameters to pass to jobs
-  params              Json?        @default("{}")
+  params                 Json?        @default("{}")
   /// Start date
-  startedAt           DateTime?
+  startedAt              DateTime?
   /// Creation date
-  createdAt           DateTime     @default(now())
+  createdAt              DateTime     @default(now())
   /// Latest update date
-  updatedAt           DateTime     @updatedAt
+  updatedAt              DateTime     @updatedAt
 }
 
 /// Possible statuses of a harvest job
@@ -495,7 +495,7 @@ model HarvestJob {
   /// ID of the harvested report (ex: tr_j1)
   reportType      String
   /// Version of COUNTER to harvest (ex: 5.1)
-  counterVersion         String
+  counterVersion  String
   /// ID of the harvest session
   sessionId       String
   /// Session that created the job
@@ -598,69 +598,69 @@ model Step {
 /// A SUSHI endpoint
 model SushiEndpoint {
   /// ID of the endpoint
-  id                        String             @id @default(cuid())
+  id                          String             @id @default(cuid())
   /// Creation date
-  createdAt                 DateTime           @default(now())
+  createdAt                   DateTime           @default(now())
   /// Latest update date
-  updatedAt                 DateTime           @updatedAt
+  updatedAt                   DateTime           @updatedAt
   /// Base URL of the SUSHI service
-  sushiUrl                  String
+  sushiUrl                    String
   /// Vendor name of the endpoint
-  vendor                    String
+  vendor                      String
   /// Abritrary tag list associated to the endpoint
-  tags                      String[]
+  tags                        String[]
   /// Description of the endpoint
-  description               String?
+  description                 String?
   /// Counter versions of the SUSHI service
-  counterVersions           String[]           @default(["5"])
+  counterVersions             String[]           @default(["5"])
   /// Minimum period where a COUNTER version can be used. If not provided, version can be used for every period. Format: { [version: string]: string }
-  counterVersionsAvailability           Json           @default("{}")
+  counterVersionsAvailability Json               @default("{}")
   /// Technical provider of the endpoint (ex: Atypon)
-  technicalProvider         String?
+  technicalProvider           String?
   /// Whether the endpoint is active and can be harvested
-  active                    Boolean            @default(true)
+  active                      Boolean            @default(true)
   /// Date on which the active status was last modified
-  activeUpdatedAt           DateTime           @default(now())
+  activeUpdatedAt             DateTime           @default(now())
   /// Whether the endpoint requires a customer ID
-  requireCustomerId         Boolean            @default(false)
+  requireCustomerId           Boolean            @default(false)
   /// Whether the endpoint requires a requestor ID
-  requireRequestorId        Boolean            @default(false)
+  requireRequestorId          Boolean            @default(false)
   /// Whether the endpoint requires an API key
-  requireApiKey             Boolean            @default(false)
+  requireApiKey               Boolean            @default(false)
   /// Whether report validation errors should be ignored
-  ignoreReportValidation    Boolean            @default(false)
+  ignoreReportValidation      Boolean            @default(false)
   /// Date until which the endpoint is disabled (no harvest allowed)
-  disabledUntil             DateTime?
+  disabledUntil               DateTime?
   /// Default value for the customer_id parameter
-  defaultCustomerId         String?
+  defaultCustomerId           String?
   /// Default value for the requestor_id parameter
-  defaultRequestorId        String?
+  defaultRequestorId          String?
   /// Default value for the api_key parameter
-  defaultApiKey             String?
+  defaultApiKey               String?
   /// Separator used for multivaluated sushi params like Attributes_To_Show (defaults to "|")
-  paramSeparator            String?
+  paramSeparator              String?
   /// [Deprecated] List report IDs that are supported by the endpoint
-  supportedReports          String[]
+  supportedReports            String[]
   /// [Deprecated] List of report IDs that should be ignored, even if the endpoint indicates that they are supported
-  ignoredReports            String[]
+  ignoredReports              String[]
   /// [Deprecated] Additional report IDs to be added to the list of supported reports provided by the endpoint
-  additionalReports         String[]
+  additionalReports           String[]
   /// [Deprecated] Date on which the list of supported reports was last updated
-  supportedReportsUpdatedAt DateTime?
+  supportedReportsUpdatedAt   DateTime?
   /// List of reports that are supported (or unsupported) by the endpoint, with periods available
-  supportedData             Json               @default("{}")
+  supportedData               Json               @default("{}")
   /// Date on which the list of supported data was last updated
-  supportedDataUpdatedAt    DateTime?
+  supportedDataUpdatedAt      DateTime?
   /// Date format to use for the begin_date and end_date parameters (defaults to "yyyy-MM")
-  harvestDateFormat         String?
+  harvestDateFormat           String?
   /// Report used when testing endpoint
-  testedReport              String?
+  testedReport                String?
   /// Id of platform in https://registry.countermetrics.org
-  registryId                String?
+  registryId                  String?
   /// SUSHI credentials associated with the endpoint
-  credentials               SushiCredentials[]
+  credentials                 SushiCredentials[]
   /// Additionnal default parameters. Each param has a name, a value, and a scope.
-  params                    Json[]
+  params                      Json[]
 }
 
 /// A set of SUSHI credentials, associated to a SUSHI endpoint
@@ -732,4 +732,22 @@ model SushiCredentialsDeletionTask {
   updatedAt    DateTime           @updatedAt
   /// Credentials related to task
   credentials  SushiCredentials[]
+}
+
+enum SushiAlertType {
+  HARVESTED_BUT_UNSUPPORTED
+  ENDPOINT
+}
+
+model SushiAlert {
+  /// ID of the alert
+  id        String         @id @default(cuid())
+  /// Type of the alert
+  type      SushiAlertType
+  /// Severity of the alert (info, warn, error, etc.)
+  severity  String
+  /// Context about alert
+  context   Json           @default("{}")
+  /// Creation date
+  createdAt DateTime       @default(now())
 }

--- a/api/server.js
+++ b/api/server.js
@@ -18,6 +18,7 @@ const opendata = require('./lib/services/opendata');
 const elastic = require('./lib/services/elastic');
 const sushi = require('./lib/services/sushi');
 const sushiCredentials = require('./lib/services/sushi-credentials');
+const sushiAlerts = require('./lib/services/sushi-alerts');
 const harvest = require('./lib/services/harvest');
 
 const ezreeportSync = require('./lib/services/sync/ezreeport');
@@ -148,6 +149,7 @@ function start() {
   ezreeportSync.startCron();
   sushi.startCleanCron();
   sushiCredentials.startCron();
+  sushiAlerts.startCron();
   harvest.startCancelCron();
   cronMetrics.start();
 


### PR DESCRIPTION
- **feat(api): added table for sushi-alerts**
- **feat(api): added method to get status of COUNTER endpoint**
- **feat(api): added service for SUSHI alerts**
- **feat(api): added crons to look for SUSHI alerts**
- **feat(api): added routes to get, delete and force refresh of SUSHI alerts**
- **feat(front): use new routes to show unsupported but harvested alerts**
