### PR TITLE
feat(api): asynchronous start, stop and delete for harvest sessions

### DIFF
--- a/api/lib/controllers/harvests-sessions/actions.js
+++ b/api/lib/controllers/harvests-sessions/actions.js
@@ -252,20 +252,18 @@ exports.getStartStatus = async (ctx) => {
 
   const session = await harvestSessionService.findUnique({
     where: { id: harvestId },
-    include: { jobs: true },
+    select: { id: true, status: true, jobs: true },
   });
 
   if (!session) {
     ctx.throw(404, ctx.$t('errors.harvest.sessionNotFound', harvestId));
   }
 
-  const cached = jobsStarted.get(session.id);
-  if (!cached) {
-    ctx.throw(400, ctx.$t('errors.harvest.sessionNotRecentlyStarted', harvestId));
-  }
-
   ctx.status = 200;
-  ctx.body = cached;
+  ctx.body = jobsStarted.get(session.id) ?? {
+    status: session.status,
+    jobs: session.jobs,
+  };
 };
 
 exports.startOne = async (ctx) => {
@@ -398,7 +396,7 @@ exports.getStopStatus = async (ctx) => {
 
   const session = await harvestSessionService.findUnique({
     where: { id: harvestId },
-    include: { jobs: true },
+    select: { id: true, status: true, jobs: true },
   });
 
   if (!session) {
@@ -409,13 +407,11 @@ exports.getStopStatus = async (ctx) => {
     ctx.throw(409, ctx.$t('errors.harvest.sessionNotRunning', harvestId));
   }
 
-  const cached = jobsStopped.get(session.id);
-  if (!cached) {
-    ctx.throw(400, ctx.$t('errors.harvest.sessionNotRecentlyStopped', harvestId));
-  }
-
   ctx.status = 200;
-  ctx.body = cached;
+  ctx.body = jobsStopped.get(session.id) ?? {
+    status: session.status,
+    jobs: session.jobs,
+  };
 };
 
 exports.stopOne = async (ctx) => {

--- a/api/lib/controllers/harvests-sessions/actions.js
+++ b/api/lib/controllers/harvests-sessions/actions.js
@@ -10,6 +10,8 @@ const { appLogger } = require('../../services/logger');
 const { prepareStandardQueryParams } = require('../../services/std-query');
 const { propsToPrismaInclude } = require('../../services/std-query/prisma-query');
 
+const JOBS_CACHE_DURATION = 5 * 60 * 1000;
+
 const standardQueryParams = prepareStandardQueryParams({
   schema,
   includableFields,
@@ -190,6 +192,82 @@ exports.upsertOne = async (ctx) => {
   ctx.body = upsertedSession;
 };
 
+const jobsStarted = new Map();
+
+async function startSession(session, options = {}) {
+  try {
+    const service = new HarvestSessionService();
+    const harvestJobs = service.start(session, options);
+
+    const now = new Date();
+    const jobs = [];
+    // Add jobs to queue
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const harvestJob of harvestJobs) {
+      jobs.push(harvestJob);
+      jobsStarted.set(session.id, {
+        status: 'starting',
+        jobs,
+      });
+
+      if (options.dryRun) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      const job = await harvestQueue.getJob(harvestJob.id);
+      if (job) {
+        await job.moveToDelayed(now + 100);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      await harvestQueue.add(
+        'harvest',
+        { taskId: harvestJob.id, timeout: session.timeout },
+        { jobId: harvestJob.id },
+      );
+    }
+
+    jobsStarted.set(session.id, {
+      status: 'running',
+      jobs,
+    });
+  } catch (err) {
+    jobsStarted.set(session.id, {
+      status: 'starting',
+      error: err instanceof Error ? err.message : `${err}`,
+    });
+  }
+
+  setTimeout(() => {
+    jobsStarted.delete(session.id);
+  }, JOBS_CACHE_DURATION);
+}
+
+exports.getStartStatus = async (ctx) => {
+  const { harvestId } = ctx.params;
+
+  const harvestSessionService = new HarvestSessionService();
+
+  const session = await harvestSessionService.findUnique({
+    where: { id: harvestId },
+    include: { jobs: true },
+  });
+
+  if (!session) {
+    ctx.throw(404, ctx.$t('errors.harvest.sessionNotFound', harvestId));
+  }
+
+  const cached = jobsStarted.get(session.id);
+  if (!cached) {
+    ctx.throw(400, ctx.$t('errors.harvest.sessionNotRecentlyStarted', harvestId));
+  }
+
+  ctx.status = 200;
+  ctx.body = cached;
+};
+
 exports.startOne = async (ctx) => {
   ctx.action = 'harvest-sessions/start';
   ctx.type = 'json';
@@ -216,37 +294,20 @@ exports.startOne = async (ctx) => {
     return;
   }
 
-  const harvestJobs = harvestSessionService.start(session, {
+  jobsStarted.set(session.id, { status: 'starting', jobs: [] });
+
+  // Don't await promise so it runs in the background
+  startSession(session, {
     restartAll,
     forceRefreshSupported,
     dryRun,
   });
 
-  const now = new Date();
-  const jobs = [];
-  // Add jobs to queue
-  // eslint-disable-next-line no-restricted-syntax
-  for await (const harvestJob of harvestJobs) {
-    jobs.push(harvestJob);
-
-    if (!dryRun) {
-      const job = await harvestQueue.getJob(harvestJob.id);
-      if (job) {
-        await job.moveToDelayed(now + 100);
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-
-      await harvestQueue.add(
-        'harvest',
-        { taskId: harvestJob.id, timeout: session.timeout },
-        { jobId: harvestJob.id },
-      );
-    }
-  }
-
-  ctx.status = 201;
-  ctx.body = jobs;
+  ctx.status = 200;
+  ctx.body = {
+    ...session,
+    status: 'starting',
+  };
 };
 
 exports.deleteOne = async (ctx) => {
@@ -255,9 +316,106 @@ exports.deleteOne = async (ctx) => {
 
   const harvestSessionService = new HarvestSessionService();
 
-  await harvestSessionService.delete({ where: { id: harvestId } });
+  const where = { id: harvestId };
+
+  const session = await harvestSessionService.findUnique({ where });
+  if (!session) {
+    return null;
+  }
+
+  await harvestSessionService.update({ where, data: { deletedAt: new Date() } });
+
+  // Don't wait for promise to allow running in the background
+  harvestSessionService.delete({ where: { id: harvestId } })
+    .then(() => { appLogger.info(`[harvest-sessions] Deleted ${harvestId}`); })
+    .catch((error) => { appLogger.error(`[harvest-sessions] Couldn't delete ${harvestId}: ${error}`); });
 
   ctx.status = 204;
+};
+
+const jobsStopped = new Map();
+
+async function stopSession(session) {
+  try {
+    const service = new HarvestSessionService();
+    const harvestJobs = service.stop(session);
+
+    const jobs = [];
+    // Cancel jobs from queue
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const harvestJob of harvestJobs) {
+      try {
+        jobs.push(harvestJob);
+        jobsStopped.set(session.id, {
+          status: 'stopping',
+          jobs,
+        });
+
+        const job = await harvestQueue.getJob(harvestJob.id);
+        if (!job) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        // Remove job if not currently running
+        if (!await job.isActive()) {
+          await job.remove();
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+
+        // Kill job if currently running
+        if (!job?.data?.pid) {
+          throw new Error('Cannot cancel job without PID');
+        }
+
+        process.kill(job.data.pid, 'SIGTERM');
+      } catch (error) {
+        appLogger.error(`[Harvest Queue] Failed to stop job ${harvestJob.id}: ${error}`);
+      }
+    }
+
+    jobsStopped.set(session.id, {
+      status: 'stopped',
+      jobs,
+    });
+  } catch (err) {
+    jobsStopped.set(session.id, {
+      status: 'stopping',
+      error: err instanceof Error ? err.message : `${err}`,
+    });
+  }
+
+  setTimeout(() => {
+    jobsStopped.delete(session.id);
+  }, JOBS_CACHE_DURATION);
+}
+
+exports.getStopStatus = async (ctx) => {
+  const { harvestId } = ctx.params;
+
+  const harvestSessionService = new HarvestSessionService();
+
+  const session = await harvestSessionService.findUnique({
+    where: { id: harvestId },
+    include: { jobs: true },
+  });
+
+  if (!session) {
+    ctx.throw(404, ctx.$t('errors.harvest.sessionNotFound', harvestId));
+  }
+
+  if (session.status !== 'running') {
+    ctx.throw(409, ctx.$t('errors.harvest.sessionNotRunning', harvestId));
+  }
+
+  const cached = jobsStopped.get(session.id);
+  if (!cached) {
+    ctx.throw(400, ctx.$t('errors.harvest.sessionNotRecentlyStopped', harvestId));
+  }
+
+  ctx.status = 200;
+  ctx.body = cached;
 };
 
 exports.stopOne = async (ctx) => {
@@ -281,35 +439,14 @@ exports.stopOne = async (ctx) => {
     return;
   }
 
-  const harvestJobs = harvestSessionService.stop(session);
+  jobsStopped.set(session.id, { status: 'stopping', jobs: [] });
 
-  // Cancel jobs from queue
-  // eslint-disable-next-line no-restricted-syntax
-  for await (const harvestJob of harvestJobs) {
-    try {
-      const job = await harvestQueue.getJob(harvestJob.id);
-      if (!job) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
+  // Don't await promise so it runs in the background
+  stopSession(session);
 
-      // Remove job if not currently running
-      if (!await job.isActive()) {
-        await job.remove();
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-
-      // Kill job if currently running
-      if (!job?.data?.pid) {
-        throw new Error('Cannot cancel job without PID');
-      }
-
-      process.kill(job.data.pid, 'SIGTERM');
-    } catch (error) {
-      appLogger.error(`[Harvest Queue] Failed to stop job ${harvestJob.id}: ${error}`);
-    }
-  }
-
-  ctx.status = 204;
+  ctx.status = 200;
+  ctx.body = {
+    ...session,
+    status: 'stopping',
+  };
 };

--- a/api/lib/controllers/harvests-sessions/actions.js
+++ b/api/lib/controllers/harvests-sessions/actions.js
@@ -403,10 +403,6 @@ exports.getStopStatus = async (ctx) => {
     ctx.throw(404, ctx.$t('errors.harvest.sessionNotFound', harvestId));
   }
 
-  if (session.status !== 'running') {
-    ctx.throw(409, ctx.$t('errors.harvest.sessionNotRunning', harvestId));
-  }
-
   ctx.status = 200;
   ctx.body = jobsStopped.get(session.id) ?? {
     status: session.status,

--- a/api/lib/controllers/harvests-sessions/actions.js
+++ b/api/lib/controllers/harvests-sessions/actions.js
@@ -211,7 +211,7 @@ exports.startOne = async (ctx) => {
     return;
   }
 
-  if (await harvestSessionService.isActive(session)) {
+  if (HarvestSessionService.isActive(session)) {
     ctx.throw(409, ctx.$t('errors.harvest.sessionAlreadyRunning', harvestId));
     return;
   }
@@ -276,7 +276,7 @@ exports.stopOne = async (ctx) => {
     return;
   }
 
-  if (!await harvestSessionService.isActive(session)) {
+  if (!HarvestSessionService.isActive(session)) {
     ctx.status = 204;
     return;
   }

--- a/api/lib/controllers/harvests-sessions/index.js
+++ b/api/lib/controllers/harvests-sessions/index.js
@@ -19,8 +19,10 @@ const {
   getOne,
   getManyStatus,
   createOne,
+  getStartStatus,
   startOne,
   deleteOne,
+  getStopStatus,
   stopOne,
   getOneCredentials,
   upsertOne,
@@ -111,6 +113,19 @@ router.route({
 });
 
 router.route({
+  method: 'GET',
+  path: '/:harvestId/_start',
+  handler: [
+    getStartStatus,
+  ],
+  validate: {
+    params: {
+      harvestId: Joi.string().trim().required(),
+    },
+  },
+});
+
+router.route({
   method: 'POST',
   path: '/:harvestId/_start',
   handler: [
@@ -126,6 +141,19 @@ router.route({
       forceRefreshSupported: Joi.boolean().default(false),
       dryRun: Joi.boolean().default(false),
     }),
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/:harvestId/_stop',
+  handler: [
+    getStopStatus,
+  ],
+  validate: {
+    params: {
+      harvestId: Joi.string().trim().required(),
+    },
   },
 });
 

--- a/api/lib/controllers/openapi.json
+++ b/api/lib/controllers/openapi.json
@@ -1000,6 +1000,10 @@
           "id": {
             "$ref": "#/components/schemas/ItemID"
           },
+          "status": {
+            "description": "Status of the session",
+            "type": "string"
+          },
           "beginDate": {
             "description": "Begin date of the period to be harvested",
             "type": "string",
@@ -1086,6 +1090,9 @@
           },
           "updatedAt": {
             "$ref": "#/components/schemas/ItemUpdateDate"
+          },
+          "deletedAt": {
+            "$ref": "#/components/schemas/ItemDeleteDate"
           },
           "_count": {
             "type": "object",
@@ -9372,6 +9379,53 @@
           "required": true
         }
       ],
+      "get": {
+        "summary": "Get status of harvest session start",
+        "tags": ["Harvests"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status"],
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "jobs": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/HarvestJob"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "419": {
+            "$ref": "#/components/responses/ConflictError"
+          }
+        },
+        "operationId": "get-harvests-sessions-_start",
+        "description": "Get status of harvest session start",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
       "post": {
         "summary": "Start a harvest session",
         "tags": ["Harvests"],
@@ -9436,6 +9490,53 @@
           "required": true
         }
       ],
+      "get": {
+        "summary": "Get status of harvest session stop",
+        "tags": ["Harvests"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["status"],
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "jobs": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/HarvestJob"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
+          },
+          "419": {
+            "$ref": "#/components/responses/ConflictError"
+          }
+        },
+        "operationId": "get-harvests-sessions-_stop",
+        "description": "Get status of harvest session stop",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      },
       "post": {
         "summary": "Stop a harvest session and cancel jobs under it",
         "tags": ["Harvests"],

--- a/api/lib/entities/harvest-session.dto.js
+++ b/api/lib/entities/harvest-session.dto.js
@@ -1,5 +1,7 @@
 const { Joi } = require('koa-joi-router');
 
+const { enums } = require('../services/prisma');
+
 const {
   withModifiers,
   ignoreFields,
@@ -16,6 +18,8 @@ const schema = {
   updatedAt: Joi.date(),
   createdAt: Joi.date(),
   startedAt: Joi.date(),
+
+  status: Joi.string().allow(...Object.values(enums.HarvestSessionStatus)),
 
   credentialsQuery: Joi.object({
     sushiIds: Joi.array().items(Joi.string()),

--- a/api/lib/entities/harvest-session.service.js
+++ b/api/lib/entities/harvest-session.service.js
@@ -366,21 +366,11 @@ module.exports = class HarvestSessionService extends BasePrismaService {
   }
 
   /**
-   * Returns whether the session is terminated or not by checking its jobs' status
+   * Returns whether the session is terminated or not
    * @param {HarvestSession} session - The session to check
    */
-  async isActive(session) {
-    const harvestJobsService = new HarvestJobsService(this.prisma);
-    const activeJob = await harvestJobsService.findFirst({
-      where: {
-        sessionId: session.id,
-        status: {
-          notIn: HarvestJobsService.endStatuses,
-        },
-      },
-    });
-
-    return !!activeJob;
+  static isActive(session) {
+    return session.status === 'starting' || session.status === 'running';
   }
 
   /* eslint-disable max-len */

--- a/api/lib/hooks/harvest/jobs.js
+++ b/api/lib/hooks/harvest/jobs.js
@@ -92,7 +92,7 @@ const onHarvestJobUpdate = async (harvestJob) => {
     );
 
     // Check if session is still active, if not: trigger hook as session ended
-    if (!(await harvestSessionService.isActive(session))) {
+    if (!HarvestSessionService.isActive(session)) {
       triggerHooks('harvest-session:end', session);
     }
   });

--- a/api/lib/services/prisma/index.js
+++ b/api/lib/services/prisma/index.js
@@ -1,4 +1,9 @@
-const { PrismaClient, Prisma, HarvestJobStatus } = require('@prisma/client');
+const {
+  PrismaClient,
+  Prisma,
+  HarvestJobStatus,
+  HarvestSessionStatus,
+} = require('@prisma/client');
 
 module.exports = {
   Prisma,
@@ -6,6 +11,7 @@ module.exports = {
 
   enums: {
     HarvestJobStatus,
+    HarvestSessionStatus,
   },
 
   PrismaErrors: {

--- a/api/locales/en.yml
+++ b/api/locales/en.yml
@@ -18,6 +18,9 @@ errors:
     sessionNotFound: The session [%s] does not exist
     updateSessionAfterStart: Impossible to update the session [%s] once started
     sessionAlreadyRunning: The session [%s] is already running
+    sessionNotRunning: The session [%s] is not running
+    sessionNotRecentlyStarted: The session [%s] wasn't started recently
+    sessionNotRecentlyStopped: The session [%s] wasn't stopped recently
 
   queue:
     notFound: Queue not found

--- a/api/locales/fr.yml
+++ b/api/locales/fr.yml
@@ -18,6 +18,9 @@ errors:
     sessionNotFound: La session [%s] n'existe pas
     updateSessionAfterStart: Impossible de mettre a jour la session [%s] une fois lancée
     sessionAlreadyRunning: La session [%s] est déjà lancée
+    sessionNotRunning: La session [%s] n'est pas lancée
+    sessionNotRecentlyStarted: La session [%s] n'as pas été lancée récemment
+    sessionNotRecentlyStopped: La session [%s] n'as pas été stopée récemment
 
   queue:
     notFound: File d'attente introuvable

--- a/api/locales/fr.yml
+++ b/api/locales/fr.yml
@@ -19,8 +19,8 @@ errors:
     updateSessionAfterStart: Impossible de mettre a jour la session [%s] une fois lancée
     sessionAlreadyRunning: La session [%s] est déjà lancée
     sessionNotRunning: La session [%s] n'est pas lancée
-    sessionNotRecentlyStarted: La session [%s] n'as pas été lancée récemment
-    sessionNotRecentlyStopped: La session [%s] n'as pas été stopée récemment
+    sessionNotRecentlyStarted: La session [%s] n'a pas été lancée récemment
+    sessionNotRecentlyStopped: La session [%s] n'a pas été stoppée récemment
 
   queue:
     notFound: File d'attente introuvable

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -422,42 +422,62 @@ model Action {
   data          Json         @default("{}")
 }
 
+/// Possible statuses of an harvest session
+enum HarvestSessionStatus {
+  /// The session is prepared, ready to be started
+  prepared
+  /// The session is starting, preparing things before launching jobs
+  starting
+  /// The session is running, it launched jobs and wait for them to finish
+  running
+  /// The session terminated
+  finished
+  /// The session is stopping
+  stopping
+  /// The session was forcefully stopped
+  stopped
+}
+
 /// Represent a harvest session
 model HarvestSession {
   /// ID of the session
-  id                  String       @id @default(cuid())
+  id                     String               @id @default(cuid())
   /// Beginning of the requested period
-  beginDate           String
+  beginDate              String
   /// End of the requested period
-  endDate             String
+  endDate                String
   /// Query to get sushi credentials
-  credentialsQuery    Json
+  credentialsQuery       Json
   /// Jobs created after request
-  jobs                HarvestJob[]
+  jobs                   HarvestJob[]
   /// IDs of the requested reports (ex: tr_j1)
-  reportTypes         String[]
+  reportTypes            String[]
   /// Allowed COUNTER versions (ex: ['5.1', '5'])
-  allowedCounterVersions         String[]
+  allowedCounterVersions String[]
   /// Maximum execution time of a job
-  timeout             Int          @default(600)
+  timeout                Int                  @default(600)
   /// Whether the reports should be fetched even if credentials aren't verified or wrong
-  allowFaulty         Boolean      @default(false)
+  allowFaulty            Boolean              @default(false)
   /// Whether the reports should be downloaded even if not supported by the endpoint
-  downloadUnsupported Boolean      @default(false)
+  downloadUnsupported    Boolean              @default(false)
   /// Whether the reports should be downloaded even if a local copy already exists
-  forceDownload       Boolean      @default(false)
+  forceDownload          Boolean              @default(false)
   /// Whether a mail should be sent when session ended
-  sendEndMail            Boolean      @default(true)
+  sendEndMail            Boolean              @default(true)
   /// Whether the reports should be inserted even if it does not pass the validation step
-  ignoreValidation    Boolean?
+  ignoreValidation       Boolean?
   /// Parameters to pass to jobs
-  params              Json?        @default("{}")
+  params                 Json?                @default("{}")
+  /// Status of session
+  status                 HarvestSessionStatus @default(prepared)
   /// Start date
-  startedAt           DateTime?
-  /// Creation date
-  createdAt           DateTime     @default(now())
+  startedAt              DateTime?
+  /// Deletion date
+  deletedAt              DateTime?
+  /// Creation date (the first time is got prepared)
+  createdAt              DateTime             @default(now())
   /// Latest update date
-  updatedAt           DateTime     @updatedAt
+  updatedAt              DateTime             @updatedAt
 }
 
 /// Possible statuses of a harvest job


### PR DESCRIPTION
- [x] Added status to Harvest Sessions
- [x] Using cache to check progress (get cleared after 5 mins)
- [x] Don't wait for start/stop/delete to finish before returning response
- [x] Added routes to check progress