### PR TITLE
feat(front): switched to a bar to show connection status of credentials

### DIFF
--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -482,6 +482,7 @@ institutions:
     resetNbChecks: You will reset {count} connection states. Untested identifiers are not taken into account.
     cannotResetCheck: Failed to reset connection status for {name}
     connection: Connection
+    connectionStatus: '@:institutions.sushi.connection status'
     untested: Untested
     operational: Valid credentials
     operationalShort: Valid

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -482,7 +482,7 @@ institutions:
     resetNbChecks: You will reset {count} connection states. Untested identifiers are not taken into account.
     cannotResetCheck: Failed to reset connection status for {name}
     connection: Connection
-    connectionStatus: '@:institutions.sushi.connection status'
+    connectionStatus: 'Connection status'
     untested: Untested
     operational: Valid credentials
     operationalShort: Valid

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -486,6 +486,7 @@ institutions:
       |Vous allez réinitialiser {count} états de connexion. Les identifiants non testés ne sont pas pris en compte.
     cannotResetCheck: Impossible de réinitialiser l'état de connexion pour {name}
     connection: Connexion
+    connectionStatus: Status de @:institutions.sushi.connection
     untested: Non testé
     operational: Identifiants valides
     operationalShort: Valides

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -486,7 +486,7 @@ institutions:
       |Vous allez réinitialiser {count} états de connexion. Les identifiants non testés ne sont pas pris en compte.
     cannotResetCheck: Impossible de réinitialiser l'état de connexion pour {name}
     connection: Connexion
-    connectionStatus: Status de @:institutions.sushi.connection
+    connectionStatus: Statut de connexion
     untested: Non testé
     operational: Identifiants valides
     operationalShort: Valides


### PR DESCRIPTION
# Front

- [x] Shows bar in institution list and endpoint list

<img width="442" height="326" alt="image" src="https://github.com/user-attachments/assets/3404fa5d-9c63-4b74-a00d-66d89abe23d3" />

<img width="1304" height="773" alt="image" src="https://github.com/user-attachments/assets/adf3b609-fd02-4a4f-89cd-e385f1f9e68f" />

<img width="1306" height="692" alt="image" src="https://github.com/user-attachments/assets/76a54688-f3fe-4037-b35e-b2b375cb395c" />

