### PR TITLE
feat: global harvest matrix

### DIFF
--- a/api/lib/controllers/harvests-sessions/index.js
+++ b/api/lib/controllers/harvests-sessions/index.js
@@ -26,6 +26,7 @@ const {
   stopOne,
   getOneCredentials,
   upsertOne,
+  getMatrix,
 } = require('./actions');
 
 router.use(
@@ -184,6 +185,22 @@ router.route({
       type: Joi.string().valid('harvestable', 'all'),
       include: Joi.array().single().items(Joi.string().valid('endpoint', 'institution')),
     }).rename('include[]', 'include'),
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/:harvestId/_matrix',
+  handler: [
+    getMatrix,
+  ],
+  validate: {
+    params: {
+      harvestId: Joi.string().trim().required(),
+    },
+    query: {
+      retryCode: Joi.number().integer(),
+    },
   },
 });
 

--- a/api/lib/controllers/harvests/actions.js
+++ b/api/lib/controllers/harvests/actions.js
@@ -1,8 +1,13 @@
 const HarvestsService = require('../../entities/harvest.service');
+const InstitutionsService = require('../../entities/institutions.service');
+const EndpointsService = require('../../entities/sushi-endpoints.service');
+
 const { schema, includableFields } = require('../../entities/harvest.dto');
 
 const { prepareStandardQueryParams } = require('../../services/std-query');
 const { queryToPrismaFilter } = require('../../services/std-query/prisma-query');
+
+const MATRIX_CACHE_DURATION = 5 * 60 * 1000;
 
 const standardQueryParams = prepareStandardQueryParams({
   schema,
@@ -76,4 +81,193 @@ exports.deleteHarvestsByQuery = async (ctx) => {
   ctx.type = 'json';
   ctx.status = 200;
   ctx.body = { deleted };
+};
+
+const cache = new Map();
+
+async function computeInstitutionsMatrix(id, query) {
+  const data = { requestedAt: new Date() };
+
+  try {
+    cache.set(id, data);
+
+    const {
+      'period:from': from,
+      'period:to': to,
+    } = query;
+
+    const harvests = new HarvestsService();
+    const institutions = new InstitutionsService();
+
+    // Generate matrix
+    const matrix = await harvests.getMatrix(
+      (harvest) => harvest.credentials.institutionId,
+      (harvest) => harvest.period,
+      {
+        where: {
+          period: { gte: from, lte: to },
+        },
+        include: {
+          credentials: {
+            select: { endpointId: true, institutionId: true },
+          },
+        },
+      },
+    );
+
+    // Resolve headers
+    const rows = await institutions.findMany({ where: { id: { in: matrix.headers.rows } } });
+
+    const institutionMap = new Map(rows.map((institution) => [institution.id, institution]));
+
+    // Cache matrix
+    data.generatedAt = new Date();
+    data.matrix = {
+      ...matrix,
+      headers: {
+        columns: matrix.headers.columns,
+        rows,
+      },
+      rows: matrix.rows.sort((rowA, rowB) => {
+        const institutionA = institutionMap.get(rowA.id) ?? { name: '' };
+        const institutionB = institutionMap.get(rowB.id) ?? { name: '' };
+        return institutionA.name.localeCompare(institutionB.name);
+      }),
+    };
+
+    cache.set(id, data);
+  } catch (error) {
+    // Cache error
+    data.error = error;
+    cache.set(id, data);
+  } finally {
+    // Delete cache when it expires
+    setTimeout(() => {
+      cache.delete(id);
+    }, MATRIX_CACHE_DURATION);
+  }
+}
+
+exports.getInstitutionsMatrix = async (ctx) => {
+  const { retryCode = 202, ...query } = ctx.request.query;
+
+  const requestId = `institutions:${JSON.stringify(query)}`;
+  const cached = cache.get(requestId);
+
+  if (!cached) {
+    // Don't await promise so it runs in the background
+    computeInstitutionsMatrix(requestId, query);
+
+    ctx.type = 'json';
+    ctx.status = 425;
+    ctx.body = { requestedAt: new Date() };
+    return;
+  }
+
+  if (cached.error) {
+    ctx.throw(500, cached.error);
+    return;
+  }
+
+  ctx.type = 'json';
+  ctx.status = cached.matrix ? 200 : retryCode;
+  ctx.body = cached;
+};
+
+async function computeEndpointsMatrix(id, query) {
+  const data = { requestedAt: new Date() };
+
+  try {
+    cache.set(id, data);
+
+    const {
+      'period:from': from,
+      'period:to': to,
+    } = query;
+
+    const harvests = new HarvestsService();
+    const endpoints = new EndpointsService();
+
+    // Generate matrix
+    const matrix = await harvests.getMatrix(
+      (harvest) => harvest.credentials.endpointId,
+      (harvest) => harvest.reportId,
+      {
+        where: {
+          period: { gte: from, lte: to },
+        },
+        include: {
+          credentials: {
+            select: { endpointId: true },
+          },
+        },
+      },
+    );
+
+    // Resolve headers
+    const rows = await endpoints.findMany({ where: { id: { in: matrix.headers.rows } } });
+
+    const endpointMap = new Map(rows.map((endpoint) => [endpoint.id, endpoint]));
+
+    // Cache matrix
+    data.generatedAt = new Date();
+    data.matrix = {
+      ...matrix,
+      headers: {
+        columns: matrix.headers.columns,
+        rows,
+      },
+      rows: matrix.rows
+        // Sort cells by period
+        .map((row) => ({
+          ...row,
+          cells: row.cells.toSorted(
+            (cellA, cellB) => (cellA.period?.beginDate ?? '').localeCompare(cellB.period?.beginDate ?? ''),
+          ),
+        }))
+        // Sort rows by vendor
+        .sort((rowA, rowB) => {
+          const endpointA = endpointMap.get(rowA.id) ?? { vendor: '' };
+          const endpointB = endpointMap.get(rowB.id) ?? { vendor: '' };
+          return endpointA.vendor.localeCompare(endpointB.vendor);
+        }),
+    };
+
+    cache.set(id, data);
+  } catch (error) {
+    // Cache error
+    data.error = error;
+    cache.set(id, data);
+  } finally {
+    // Delete cache when it expires
+    setTimeout(() => {
+      cache.delete(id);
+    }, MATRIX_CACHE_DURATION);
+  }
+}
+
+exports.getEndpointsMatrix = async (ctx) => {
+  const { retryCode = 202, ...query } = ctx.request.query;
+
+  const requestId = `endpoints:${JSON.stringify(query)}`;
+  const cached = cache.get(requestId);
+
+  if (!cached) {
+    // Don't await promise so it runs in the background
+    computeEndpointsMatrix(requestId, query);
+
+    ctx.type = 'json';
+    ctx.status = retryCode;
+    ctx.body = { requestedAt: new Date() };
+    return;
+  }
+
+  if (cached.error) {
+    ctx.throw(500, cached.error);
+    return;
+  }
+
+  ctx.type = 'json';
+  ctx.status = cached.matrix ? 200 : retryCode;
+  ctx.body = cached;
 };

--- a/api/lib/controllers/harvests/index.js
+++ b/api/lib/controllers/harvests/index.js
@@ -13,6 +13,9 @@ const {
   standardQueryParams,
   getHarvests,
   deleteHarvestsByQuery,
+
+  getInstitutionsMatrix,
+  getEndpointsMatrix,
 } = require('./actions');
 
 router.use(
@@ -57,6 +60,36 @@ router.route({
       }).required(),
       status: Joi.string().trim(),
     }),
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/_institutions-matrix',
+  handler: [
+    getInstitutionsMatrix,
+  ],
+  validate: {
+    query: {
+      retryCode: Joi.number(),
+      'period:from': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+      'period:to': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+    },
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/_endpoints-matrix',
+  handler: [
+    getEndpointsMatrix,
+  ],
+  validate: {
+    query: {
+      retryCode: Joi.number().integer(),
+      'period:from': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+      'period:to': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+    },
   },
 });
 

--- a/api/lib/controllers/institutions/sushi/actions.js
+++ b/api/lib/controllers/institutions/sushi/actions.js
@@ -1,6 +1,8 @@
 const { prepareStandardQueryParams } = require('../../../services/std-query');
 
 const SushiCredentialsService = require('../../../entities/sushi-credentials.service');
+const HarvestsService = require('../../../entities/harvest.service');
+const EndpointsService = require('../../../entities/sushi-endpoints.service');
 
 const {
   schema,
@@ -10,8 +12,11 @@ const {
 /* eslint-disable max-len */
 /**
  * @typedef {import('@prisma/client').Prisma.RepositoryPermissionCreateInput} RepositoryPermissionCreateInput
+ * @typedef {import('@prisma/client').Prisma.HarvestWhereInput} HarvestWhereInput
 */
 /* eslint-enable max-len */
+
+const MATRIX_CACHE_DURATION = 5 * 60 * 1000;
 
 const standardQueryParams = prepareStandardQueryParams({
   schema,
@@ -93,4 +98,129 @@ exports.getMetrics = async (ctx) => {
       success,
     },
   };
+};
+
+const cache = new Map();
+
+async function computeMatrix(id, query) {
+  const data = { requestedAt: new Date() };
+
+  try {
+    cache.set(id, data);
+
+    const {
+      'period:from': from,
+      'period:to': to,
+      institutionId,
+    } = query;
+
+    const harvests = new HarvestsService();
+    const endpoints = new EndpointsService();
+
+    /** @type {HarvestWhereInput} */
+    const where = {
+      period: { gte: from, lte: to },
+      credentials: {
+        institutionId,
+      },
+    };
+
+    const matrix = await harvests.getMatrix(
+      (harvest) => harvest.credentials.endpointId,
+      (harvest) => harvest.period,
+      {
+        where,
+        include: {
+          credentials: {
+            select: { endpointId: true },
+          },
+        },
+      },
+    );
+
+    // Resolve headers
+    const rows = await endpoints.findMany({ where: { id: { in: matrix.headers.rows } } });
+
+    const endpointMap = new Map(rows.map((endpoint) => [endpoint.id, endpoint]));
+
+    // Get count of jobs by status
+    const countsPerStatus = await harvests.groupBy({
+      where,
+      by: ['status'],
+      _count: {
+        _all: true,
+      },
+    });
+    const statusCounts = Object.fromEntries(
+      // @ts-ignore
+      // eslint-disable-next-line no-underscore-dangle
+      countsPerStatus.map(({ status, _count }) => [status, _count?._all ?? 0]),
+    );
+
+    // Cache matrix
+    data.generatedAt = new Date();
+    data.matrix = {
+      ...matrix,
+      headers: {
+        // Sort periods
+        columns: matrix.headers.columns.sort(),
+        rows,
+      },
+      rows: matrix.rows
+        // Sort cells by period
+        .map((row) => ({
+          ...row,
+          cells: row.cells.toSorted(
+            (cellA, cellB) => (cellA.period?.beginDate ?? '').localeCompare(cellB.period?.beginDate ?? ''),
+          ),
+        }))
+        // Sort rows by vendor
+        .sort((rowA, rowB) => {
+          const endpointA = endpointMap.get(rowA.id) ?? { vendor: '' };
+          const endpointB = endpointMap.get(rowB.id) ?? { vendor: '' };
+          return endpointA.vendor.localeCompare(endpointB.vendor);
+        }),
+      statusCounts,
+    };
+
+    cache.set(id, data);
+  } catch (error) {
+    // Cache error
+    data.error = error;
+    cache.set(id, data);
+  } finally {
+    // Delete cache when it expires
+    setTimeout(() => {
+      cache.delete(id);
+    }, MATRIX_CACHE_DURATION);
+  }
+}
+
+exports.getMatrix = async (ctx) => {
+  const { institutionId } = ctx.params;
+
+  const { retryCode = 202, ...query } = ctx.request.query;
+  query.institutionId = institutionId;
+
+  const requestId = JSON.stringify(query);
+  const cached = cache.get(requestId);
+
+  if (!cached) {
+    // Don't await promise so it runs in the background
+    computeMatrix(requestId, query);
+
+    ctx.type = 'json';
+    ctx.status = retryCode;
+    ctx.body = { requestedAt: new Date() };
+    return;
+  }
+
+  if (cached.error) {
+    ctx.throw(500, cached.error);
+    return;
+  }
+
+  ctx.type = 'json';
+  ctx.status = cached.matrix ? 200 : retryCode;
+  ctx.body = cached;
 };

--- a/api/lib/controllers/institutions/sushi/index.js
+++ b/api/lib/controllers/institutions/sushi/index.js
@@ -15,6 +15,7 @@ const {
 
   getAll,
   getMetrics,
+  getMatrix,
 } = require('./actions');
 
 router.use(requireJwt, requireUser);
@@ -46,6 +47,26 @@ router.route({
     requireMemberPermissions(FEATURES.sushi.read),
     getMetrics,
   ],
+});
+
+router.route({
+  method: 'GET',
+  path: '/_matrix',
+  handler: [
+    fetchInstitution(),
+    requireMemberPermissions(FEATURES.sushi.read),
+    getMatrix,
+  ],
+  validate: {
+    params: {
+      institutionId: Joi.string().trim().required(),
+    },
+    query: {
+      retryCode: Joi.number().integer(),
+      'period:from': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+      'period:to': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+    },
+  },
 });
 
 module.exports = router;

--- a/api/lib/controllers/openapi.json
+++ b/api/lib/controllers/openapi.json
@@ -1176,7 +1176,8 @@
               "finished",
               "failed",
               "cancelled",
-              "interrupted"
+              "interrupted",
+              "empty"
             ]
           },
           "period": {
@@ -1235,6 +1236,137 @@
             "description": "Number of report items that failed to be inserted into Elasticsearch",
             "type": "integer",
             "readOnly": true
+          }
+        }
+      },
+      "HarvestMatrixCell": {
+        "description": "Aggregation of harvest states",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "columnId": {
+            "type": "string"
+          },
+          "harvestedAt": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2020-11-05T17:07:31.967Z",
+            "description": "The date of the harvest"
+          },
+          "status": {
+            "description": "Status of the aggregation",
+            "type": "string",
+            "enum": [
+              "waiting",
+              "running",
+              "delayed",
+              "finished",
+              "failed",
+              "cancelled",
+              "interrupted",
+              "empty"
+            ]
+          },
+          "counterVersions": {
+            "description": "Counter versions found in aggregated harvests",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "reportIds": {
+            "description": "Report ids found in aggregated harvests",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "errors": {
+            "description": "Errors found in aggregated harvests",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "total": {
+            "description": "Count of harvests in aggregation",
+            "type": "integer"
+          },
+          "counts": {
+            "description": "Count of each status found in aggregated harvests",
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            }
+          },
+          "period": {
+            "type": "object",
+            "properties": {
+              "beginDate": {
+                "description": "Start if the period found in aggregated harvests",
+                "type": "string",
+                "format": "date",
+                "pattern": "yyyy-MM"
+              },
+              "endDate": {
+                "description": "End if the period found in aggregated harvests",
+                "type": "string",
+                "format": "date",
+                "pattern": "yyyy-MM"
+              }
+            }
+          },
+          "items": {
+            "type": "object",
+            "properties": {
+              "inserted": {
+                "description": "Number of report items that were successfuly inserted into Elasticsearch",
+                "type": "integer"
+              },
+              "updated": {
+                "description": "Number of report items that were updated in Elasticsearch",
+                "type": "integer"
+              },
+              "failed": {
+                "description": "Number of report items that failed to be inserted into Elasticsearch",
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "HarvestMatrix": {
+        "type": "object",
+        "properties": {
+          "headers": {
+            "type": "object",
+            "properties": {
+              "columns": {
+                "type": "array"
+              },
+              "rows": {
+                "type": "array"
+              }
+            }
+          },
+          "rows": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "cells": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HarvestMatrixCell"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -4205,6 +4337,106 @@
         },
         "operationId": "get-institutions-id-sushi-metrics",
         "description": "Get metrics about sushi credentials",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/institutions/{id}/sushi/_matrix": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "id",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "Get harvest matrix of an institution",
+        "tags": ["Institutions", "Harvests"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:from",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:to",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "name": "retryCode",
+            "in": "query",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "generatedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "validUntil": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "matrix": {
+                      "$ref": "#/components/schemas/HarvestMatrix"
+                    },
+                    "statusCount": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "operationId": "get-institutions-id-sushi-matrix",
+        "description": "Get harvest matrix of an institution",
         "security": [
           {
             "bearerAuth": []
@@ -8827,6 +9059,180 @@
         ]
       }
     },
+    "/harvests/_institutions-matrix": {
+      "get": {
+        "summary": "Get harvest matrix about institutions",
+        "tags": ["Harvests"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:from",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:to",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "name": "retryCode",
+            "in": "query",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "generatedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "validUntil": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "matrix": {
+                      "$ref": "#/components/schemas/HarvestMatrix"
+                    },
+                    "unharvested": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Institution"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "operationId": "get-harvests-institions-matrix",
+        "description": "Get matrix about institutions",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/harvests/_endpoints-matrix": {
+      "get": {
+        "summary": "Get harvest matrix about endpoints",
+        "tags": ["Harvests"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:from",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:to",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "name": "retryCode",
+            "in": "query",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "generatedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "validUntil": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "matrix": {
+                      "$ref": "#/components/schemas/HarvestMatrix"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "operationId": "get-harvests-endpoints-matrix",
+        "description": "Get matrix about endpoints",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
     "/harvests-sessions": {
       "parameters": [],
       "get": {
@@ -9363,6 +9769,86 @@
         },
         "operationId": "delete-harvests-sessions",
         "description": "Delete an harvest session",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
+      }
+    },
+    "/harvests-sessions/{harvestId}/_matrix": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "harvestId",
+          "in": "path",
+          "required": true
+        }
+      ],
+      "get": {
+        "summary": "Get harvest matrix of an harvest session",
+        "tags": ["Harvests"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "name": "retryCode",
+            "in": "query",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "generatedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "validUntil": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "matrix": {
+                      "$ref": "#/components/schemas/HarvestMatrix"
+                    },
+                    "summary": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/HarvestMatrixCell"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "operationId": "get-harvests-sessions-id-matrix",
+        "description": "Get matrix about harvest session",
         "security": [
           {
             "bearerAuth": []
@@ -11254,6 +11740,101 @@
           }
         ],
         "tags": ["Sushi"]
+      }
+    },
+    "/sushi-endpoints/{id}/_matrix": {
+      "parameters": [
+        {
+          "schema": {
+            "type": "string"
+          },
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "ID of the endpoint"
+        }
+      ],
+      "get": {
+        "summary": "Get harvest matrix of an endpoint",
+        "tags": ["Sushi", "Harvests"],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:from",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "pattern": "yyyy-MM"
+            },
+            "name": "period:to",
+            "in": "query",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "name": "retryCode",
+            "in": "query",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "requestedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "generatedAt": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "validUntil": {
+                      "type": "string",
+                      "format": "date"
+                    },
+                    "error": {
+                      "type": "string"
+                    },
+                    "matrix": {
+                      "$ref": "#/components/schemas/HarvestMatrix"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          }
+        },
+        "operationId": "get-sushi-endpoints-id-matrix",
+        "description": "Get matrix about sushi endpoints",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/sushi-alerts": {

--- a/api/lib/controllers/sushi-endpoints/actions.js
+++ b/api/lib/controllers/sushi-endpoints/actions.js
@@ -1,7 +1,18 @@
-const { schema, adminImportSchema, includableFields } = require('../../entities/sushi-endpoints.dto');
 const SushiEndpointService = require('../../entities/sushi-endpoints.service');
+const HarvestsService = require('../../entities/harvest.service');
+const InstitutionsService = require('../../entities/institutions.service');
+
+const { schema, adminImportSchema, includableFields } = require('../../entities/sushi-endpoints.dto');
 
 const { prepareStandardQueryParams } = require('../../services/std-query');
+
+/* eslint-disable max-len */
+/**
+ * @typedef {import('@prisma/client').Prisma.HarvestWhereInput} HarvestWhereInput
+*/
+/* eslint-enable max-len */
+
+const MATRIX_CACHE_DURATION = 5 * 60 * 1000;
 
 const standardQueryParams = prepareStandardQueryParams({
   schema,
@@ -176,4 +187,120 @@ exports.importEndpoints = async (ctx) => {
 
   ctx.type = 'json';
   ctx.body = response;
+};
+
+const cache = new Map();
+
+async function computeMatrix(id, query) {
+  const data = { requestedAt: new Date() };
+
+  try {
+    cache.set(id, data);
+
+    const {
+      'period:from': from,
+      'period:to': to,
+      endpointId,
+    } = query;
+
+    const harvests = new HarvestsService();
+    const institutions = new InstitutionsService();
+
+    /** @type {HarvestWhereInput} */
+    const where = {
+      period: { gte: from, lte: to },
+      credentials: {
+        endpointId,
+      },
+    };
+
+    // Generate matrix
+    const matrix = await harvests.getMatrix(
+      (harvest) => harvest.credentials.institutionId,
+      (harvest) => harvest.reportId,
+      {
+        where,
+        include: {
+          credentials: {
+            select: { institutionId: true },
+          },
+        },
+      },
+    );
+
+    // Resolve headers
+    const rows = await institutions.findMany({ where: { id: { in: matrix.headers.rows } } });
+
+    const institutionMap = new Map(rows.map((institution) => [institution.id, institution]));
+
+    // Get count of jobs by status
+    const countsPerStatus = await harvests.groupBy({
+      where,
+      by: ['status'],
+      _count: {
+        _all: true,
+      },
+    });
+    const statusCounts = Object.fromEntries(
+      // @ts-ignore
+      // eslint-disable-next-line no-underscore-dangle
+      countsPerStatus.map(({ status, _count }) => [status, _count?._all ?? 0]),
+    );
+
+    // Cache matrix
+    data.generatedAt = new Date();
+    data.matrix = {
+      ...matrix,
+      headers: {
+        columns: matrix.headers.columns,
+        rows,
+      },
+      rows: matrix.rows.sort((rowA, rowB) => {
+        const institutionA = institutionMap.get(rowA.id) ?? { name: '' };
+        const institutionB = institutionMap.get(rowB.id) ?? { name: '' };
+        return institutionA.name.localeCompare(institutionB.name);
+      }),
+      statusCounts,
+    };
+
+    cache.set(id, data);
+  } catch (error) {
+    // Cache error
+    data.error = error;
+    cache.set(id, data);
+  } finally {
+    // Delete cache when it expires
+    setTimeout(() => {
+      cache.delete(id);
+    }, MATRIX_CACHE_DURATION);
+  }
+}
+
+exports.getMatrix = async (ctx) => {
+  const { endpointId } = ctx.params;
+
+  const { retryCode = 202, ...query } = ctx.request.query;
+  query.endpointId = endpointId;
+
+  const requestId = JSON.stringify(query);
+  const cached = cache.get(requestId);
+
+  if (!cached) {
+    // Don't await promise so it runs in the background
+    computeMatrix(requestId, query);
+
+    ctx.type = 'json';
+    ctx.status = retryCode;
+    ctx.body = { requestedAt: new Date() };
+    return;
+  }
+
+  if (cached.error) {
+    ctx.throw(500, cached.error);
+    return;
+  }
+
+  ctx.type = 'json';
+  ctx.status = cached.matrix ? 200 : retryCode;
+  ctx.body = cached;
 };

--- a/api/lib/controllers/sushi-endpoints/index.js
+++ b/api/lib/controllers/sushi-endpoints/index.js
@@ -22,6 +22,7 @@ const {
   updateEndpoint,
   addEndpoint,
   importEndpoints,
+  getMatrix,
 } = require('./actions');
 
 const registry = require('./_registry');
@@ -114,6 +115,24 @@ router.route({
   validate: {
     params: {
       endpointId: Joi.string().trim().required(),
+    },
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/:endpointId/_matrix',
+  handler: [
+    getMatrix,
+  ],
+  validate: {
+    params: {
+      endpointId: Joi.string().trim().required(),
+    },
+    query: {
+      retryCode: Joi.number().integer(),
+      'period:from': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
+      'period:to': Joi.string().regex(/^[0-9]{4}-[0-9]{2}$/).required(),
     },
   },
 });

--- a/api/lib/entities/harvest.service.js
+++ b/api/lib/entities/harvest.service.js
@@ -27,6 +27,7 @@ const BasePrismaService = require('./base-prisma.service');
  * @property {Date} harvestedAt
  * @property {string[]} counterVersions
  * @property {string[]} reportIds
+ * @property {string[]} errors
  * @property {number} total
  * @property {Record<string, number>} counts
  *

--- a/api/lib/entities/harvest.service.js
+++ b/api/lib/entities/harvest.service.js
@@ -4,15 +4,18 @@ const harvestPrisma = require('../services/prisma/harvest');
 const BasePrismaService = require('./base-prisma.service');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').Harvest} Harvest */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestInclude} HarvestInclude */
+/**
+ * @typedef {import('@prisma/client').Harvest} Harvest
+ * @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestGroupByArgs} HarvestGroupByArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestInclude} HarvestInclude
+ */
 /* eslint-enable max-len */
 
 module.exports = class HarvestsService extends BasePrismaService {
@@ -76,6 +79,14 @@ module.exports = class HarvestsService extends BasePrismaService {
   }
 
   /**
+   * @param {HarvestGroupByArgs} params
+   * @returns
+   */
+  groupBy(params) {
+    return harvestPrisma.groupBy(params, this.prisma);
+  }
+
+  /**
    * Scroll through harvests
    *
    * @param {Omit<HarvestFindManyArgs, 'skip' | 'cursor' | 'orderBy'>} [query]
@@ -110,5 +121,114 @@ module.exports = class HarvestsService extends BasePrismaService {
       // Update cursor
       skip += data.length;
     }
+  }
+
+  /**
+   * Get harvest matrix
+   *
+   * @param {(harvest: Harvest) => unknown} rowGetter
+   * @param {(harvest: Harvest) => unknown} columnGetter
+   * @param {Omit<HarvestFindManyArgs, 'skip' | 'cursor' | 'orderBy'>} [query]
+   */
+  async getMatrix(
+    rowGetter,
+    columnGetter,
+    query = {},
+  ) {
+    // Scroll over selected harvests
+    const scroller = this.scroll(query);
+
+    const rows = new Map();
+    const headers = {
+      columns: new Set(),
+      rows: new Set(),
+    };
+
+    // eslint-disable-next-line no-restricted-syntax
+    for await (const harvest of scroller) {
+      const rowId = rowGetter(harvest);
+      headers.rows.add(rowId);
+      const row = rows.get(rowId) ?? new Map();
+
+      const columnId = columnGetter(harvest);
+      headers.columns.add(columnId);
+      const cell = row.get(columnId) ?? {};
+
+      // Keep last harvestedAt
+      if ((cell.harvestedAt ?? 0) <= harvest.harvestedAt) {
+        cell.harvestedAt = harvest.harvestedAt;
+      }
+
+      // Aggregate errors into one cell
+      if (harvest.errorCode) {
+        const errors = cell.errors ?? new Set();
+        errors.add(harvest.errorCode);
+        cell.errors = errors;
+      }
+
+      // Aggregate period
+      cell.period = cell.period ?? { beginDate: harvest.period, endDate: harvest.period };
+      if (cell.period.beginDate >= harvest.period) {
+        cell.period.beginDate = harvest.period;
+      }
+      if (cell.period.endDate <= harvest.period) {
+        cell.period.endDate = harvest.period;
+      }
+
+      // Aggregate counts into one cell
+      cell.total = (cell.total ?? 0) + 1;
+      cell.counts = {
+        ...cell.counts,
+        [harvest.status]: (cell.counts?.[harvest.status] ?? 0) + 1,
+      };
+      cell.items = {
+        inserted: (cell.items?.inserted ?? 0) + harvest.insertedItems,
+        updated: (cell.items?.updated ?? 0) + harvest.updatedItems,
+        failed: (cell.items?.failed ?? 0) + harvest.failedItems,
+      };
+
+      row.set(columnId, cell);
+      rows.set(rowId, row);
+    }
+
+    return {
+      headers: {
+        columns: Array.from(headers.columns),
+        rows: Array.from(headers.rows),
+      },
+      rows: Array.from(rows.entries()).map(
+        ([rowId, row]) => ({
+          id: rowId,
+          cells: Array.from(headers.columns.values()).map(
+            (columnId) => {
+              const cellId = `${rowId}:${columnId}`;
+
+              const cell = row.get(columnId);
+              if (!cell) {
+                // fill with empty cell
+                return {
+                  id: cellId,
+                  total: 0,
+                };
+              }
+
+              const statuses = Object.entries(cell.counts)
+                .sort(([, aValue], [, bValue]) => bValue - aValue)
+                .map(([status]) => status);
+
+              return {
+                ...cell,
+                columnId,
+                id: cellId,
+                // Define status based on counts
+                status: statuses[0],
+                // Array-ify errors
+                errors: cell.errors ? Array.from(cell.errors) : [],
+              };
+            },
+          ),
+        }),
+      ),
+    };
   }
 };

--- a/api/lib/services/prisma/harvest.js
+++ b/api/lib/services/prisma/harvest.js
@@ -2,15 +2,18 @@
 const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient */
-/** @typedef {import('@prisma/client').Harvest} Harvest */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs */
+/**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('@prisma/client').Harvest} Harvest
+ * @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestGroupByArgs} HarvestGroupByArgs
+ */
 /* eslint-enable max-len */
 
 /**
@@ -68,6 +71,16 @@ function upsert(params, tx = prisma) {
 }
 
 /**
+ * @param {HarvestGroupByArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns
+ */
+function groupBy(params, tx = prisma) {
+  // @ts-ignore
+  return tx.harvest.groupBy(params);
+}
+
+/**
  * @param {HarvestDeleteManyArgs} params
  * @param {TransactionClient} [tx]
  * @returns {Promise<number>}
@@ -84,5 +97,6 @@ module.exports = {
   count,
   update,
   upsert,
+  groupBy,
   removeMany,
 };

--- a/front/app/components/institution/HarvestGlobalMatrixDialog.vue
+++ b/front/app/components/institution/HarvestGlobalMatrixDialog.vue
@@ -1,0 +1,227 @@
+<template>
+  <v-dialog
+    v-model="isOpen"
+    fullscreen
+  >
+    <v-card
+      :title="cardTitle"
+      :subtitle="institution.name"
+      :loading="status === 'pending' && 'primary'"
+      prepend-icon="mdi-table-headers-eye"
+      max-height="100vh"
+    >
+      <template #append>
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          @click="isOpen = falase"
+        />
+      </template>
+
+      <v-card-text class="pa-0" style="max-height: 100%; overflow-y: hidden;">
+        <SushiHarvestGlobalMatrix
+          v-model:period="period"
+          :model-value="data?.matrix"
+          :loading="status === 'pending'"
+          :max="MAX_HARVEST_MONTH"
+          column-key=""
+          column-value=""
+          class="matrix"
+        >
+          <template #top>
+            <v-alert
+              v-if="error"
+              :text="getErrorMessage(error)"
+              type="error"
+            />
+
+            <v-row v-else>
+              <v-col>
+                <p>
+                  {{ $t('sushi.globalHarvestState.institution.description') }}
+                </p>
+              </v-col>
+
+              <v-col cols="4">
+                <div v-if="status === 'pending'" class="d-flex justify-center align-center h-100">
+                  <v-progress-circular size="64" color="accent" indeterminate />
+                </div>
+
+                <template v-else>
+                  <ProgressLinearStack
+                    :model-value="bars"
+                    height="8"
+                  />
+
+                  <v-table height="150" density="comfortable">
+                    <tbody>
+                      <tr v-for="row in table" :key="row.key">
+                        <td>
+                          <v-icon
+                            v-if="row.header.icon"
+                            :icon="row.header.icon"
+                            :color="row.header.color"
+                            start
+                          />
+
+                          {{ row.header.text }}
+
+                          <v-icon
+                            v-if="row.header.tooltip"
+                            v-tooltip:top="row.header.tooltip"
+                            icon="mdi-information-outline"
+                            size="x-small"
+                            color="info"
+                            end
+                            style="vertical-align: baseline;"
+                          />
+                        </td>
+
+                        <td>{{ row.valueStr }}</td>
+                      </tr>
+                    </tbody>
+                  </v-table>
+                </template>
+              </v-col>
+            </v-row>
+          </template>
+
+          <template #row-header="{ item }">
+            <nuxt-link v-if="user.isAdmin" :to="`/admin/endpoints/${item.id}`">
+              {{ item.vendor }}
+            </nuxt-link>
+            <span v-else>
+              {{ item.vendor }}
+            </span>
+          </template>
+        </SushiHarvestGlobalMatrix>
+      </v-card-text>
+
+      <template #actions>
+        <v-btn
+          :text="$t('close')"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { format } from 'date-fns';
+
+import { getQuarterPeriod } from '@/lib/sushi';
+import { getErrorMessage } from '@/lib/errors';
+
+const NOW = new Date();
+const MAX_HARVEST_MONTH = format(NOW, 'yyyy-MM');
+
+const props = defineProps({
+  institution: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { data: user } = useAuthState();
+const { t, te, locale } = useI18n();
+
+const isOpen = shallowRef(false);
+const period = ref(getQuarterPeriod(NOW, -1));
+
+const {
+  data,
+  status,
+  error,
+  refresh,
+} = useFetch(`/api/institutions/${props.institution.id}/sushi/_matrix`, {
+  params: {
+    retryCode: 425,
+    'period:from': computed(() => period.value.beginDate),
+    'period:to': computed(() => period.value.endDate),
+  },
+
+  retry: 10,
+  retryDelay: 1000,
+  retryStatusCodes: [425],
+
+  lazy: true,
+  immediate: false,
+});
+
+const cardTitle = computed(() => {
+  const title = t('sushi.globalHarvestState.institution.title');
+  if (!user.value.isAdmin) {
+    return title;
+  }
+
+  return `${title} - ${t('institutions.title')}`;
+});
+
+const total = computed(() => {
+  if (!data.value) {
+    return 0;
+  }
+
+  return Object.values(data.value.statusCounts).reduce((acc, count) => acc + count, 0);
+});
+
+const bars = computed(
+  () => Object.entries(data.value?.statusCounts ?? {})
+    .map(([name, value]) => {
+      let type;
+      if (name === 'delayed') {
+        type = 'buffer';
+      }
+      if (name === 'waiting') {
+        type = 'stream';
+      }
+
+      return {
+        key: name,
+        type,
+        color: harvestStatus.get(name)?.color,
+        value: value / total.value,
+      };
+    })
+    .filter(({ value }) => value > 0)
+    .sort((a, b) => b.value - a.value),
+);
+
+const table = computed(() => {
+  const formatter = new Intl.NumberFormat(locale.value, { style: 'percent' });
+
+  return Object.entries(data.value?.statusCounts ?? {})
+    .map(([name, value]) => ({
+      key: name,
+      header: {
+        ...harvestStatus.get(name),
+        text: te(`tasks.status.${name}`) ? t(`tasks.status.${name}`) : name,
+        tooltip: te(`tasks.statusDescriptions.${name}`) && t(`tasks.statusDescriptions.${name}`),
+      },
+      value,
+      valueStr: formatter.format(value / total.value),
+    }))
+    .filter(({ value }) => value > 0)
+    .sort((a, b) => b.value - a.value);
+});
+
+async function open() {
+  isOpen.value = true;
+  await refresh();
+}
+
+defineExpose({
+  open,
+});
+</script>
+
+<style lang="css" scoped>
+.matrix :deep(.matrix--row-header) {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
+}
+</style>

--- a/front/app/components/sushiEndpoint/HarvestGlobalMatrixDialog.vue
+++ b/front/app/components/sushiEndpoint/HarvestGlobalMatrixDialog.vue
@@ -1,0 +1,127 @@
+<template>
+  <v-dialog
+    v-model="isOpen"
+    fullscreen
+  >
+    <v-card
+      :title="cardTitle"
+      :subtitle="endpoint.vendor"
+      :loading="status === 'pending' && 'primary'"
+      prepend-icon="mdi-table-headers-eye"
+    >
+      <template #append>
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+
+      <v-card-text class="pa-0" style="max-height: 100%; overflow-y: hidden;">
+        <SushiHarvestGlobalMatrix
+          v-model:period="period"
+          :model-value="data?.matrix"
+          :loading="status === 'pending'"
+          :max="MAX_HARVEST_MONTH"
+          column-key=""
+          class="matrix"
+        >
+          <template v-if="error" #top>
+            <v-alert
+              :text="getErrorMessage(error)"
+              type="error"
+            />
+          </template>
+
+          <template #column-header="{ item }">
+            <span class="text-uppercase">{{ item }}</span>
+          </template>
+
+          <template #row-header="{ item }">
+            <nuxt-link :to="`/admin/institutions/${item.id}/sushi`">
+              {{ item.name }}
+            </nuxt-link>
+          </template>
+        </SushiHarvestGlobalMatrix>
+      </v-card-text>
+
+      <template #actions>
+        <v-btn
+          :text="$t('close')"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { format } from 'date-fns';
+
+import { getQuarterPeriod } from '@/lib/sushi';
+import { getErrorMessage } from '@/lib/errors';
+
+const NOW = new Date();
+const MAX_HARVEST_MONTH = format(NOW, 'yyyy-MM');
+
+const props = defineProps({
+  endpoint: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { data: user } = useAuthState();
+const { t } = useI18n();
+
+const isOpen = shallowRef(false);
+const period = ref(getQuarterPeriod(NOW, -1));
+
+const {
+  data,
+  status,
+  error,
+  refresh,
+} = useFetch(`/api/sushi-endpoints/${props.endpoint.id}/_matrix`, {
+  params: {
+    retryCode: 425,
+    'period:from': computed(() => period.value.beginDate),
+    'period:to': computed(() => period.value.endDate),
+  },
+
+  retry: 10,
+  retryDelay: 1000,
+  retryStatusCodes: [425],
+
+  lazy: true,
+  immediate: false,
+});
+
+const cardTitle = computed(() => {
+  const title = t('sushi.globalHarvestState.endpoint.title');
+  if (!user.value.isAdmin) {
+    return title;
+  }
+
+  return `${title} - ${t('endpoints.endpoint')}`;
+});
+
+async function open() {
+  isOpen.value = true;
+  await refresh();
+}
+
+defineExpose({
+  open,
+});
+</script>
+
+<style lang="css" scoped>
+.matrix :deep(.matrix--row-header) {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
+}
+</style>

--- a/front/app/components/sushiHarvest/GlobalMatrix.vue
+++ b/front/app/components/sushiHarvest/GlobalMatrix.vue
@@ -1,0 +1,369 @@
+<template>
+  <v-table
+    density="compact"
+    height="100%"
+    fixed-header
+    class="h-100"
+  >
+    <template #top>
+      <v-toolbar v-if="period">
+        <div class="d-flex align-center ml-2">
+          <v-btn
+            :disabled="loading || isPreviousDisabled"
+            color="primary"
+            variant="text"
+            density="comfortable"
+            icon="mdi-arrow-left"
+            @click="changePeriod(-1)"
+          />
+
+          <MonthPickerField
+            :model-value="period.beginDate"
+            :label="$t('harvest.jobs.beginDate')"
+            :min="min"
+            :max="period.endDate"
+            :disabled="loading"
+            variant="underlined"
+            density="compact"
+            prepend-icon="mdi-calendar-start"
+            hide-details
+            style="width: 150px;"
+            @update:model-value="$emit('update:period', { ...period, beginDate: $event })"
+          />
+
+          <div class="mx-4">
+            ~
+          </div>
+
+          <MonthPickerField
+            :model-value="period.endDate"
+            :label="$t('harvest.jobs.endDate')"
+            :min="period.beginDate"
+            :max="max"
+            :disabled="loading"
+            variant="underlined"
+            density="compact"
+            prepend-icon="mdi-calendar-end"
+            hide-details
+            style="width: 150px;"
+            @update:model-value="$emit('update:period', { ...period, endDate: $event })"
+          />
+
+          <v-btn
+            :disabled="loading || isNextDisabled"
+            color="primary"
+            variant="text"
+            density="comfortable"
+            icon="mdi-arrow-right"
+            @click="changePeriod(1)"
+          />
+        </div>
+
+        <template #append>
+          <v-btn
+            :text="$t('sushi.globalHarvestState.periodShortcut', 1)"
+            :disabled="loading"
+            :active="periodDiff === 1"
+            active-color="accent"
+            density="comfortable"
+            size="small"
+            class="mx-1"
+            @click="switchToMonth()"
+          />
+          <v-btn
+            :text="$t('sushi.globalHarvestState.periodShortcut', monthsInQuarter)"
+            :disabled="loading"
+            :active="periodDiff === monthsInQuarter"
+            active-color="accent"
+            density="comfortable"
+            size="small"
+            class="mx-1"
+            @click="switchToQuarter()"
+          />
+          <v-btn
+            :text="$t('sushi.globalHarvestState.periodShortcut', monthsInSemester)"
+            :disabled="loading"
+            :active="periodDiff === monthsInSemester"
+            active-color="accent"
+            density="comfortable"
+            size="small"
+            class="mx-1"
+            @click="switchToSemester()"
+          />
+          <v-btn
+            :text="$t('sushi.globalHarvestState.periodShortcut', monthsInYear)"
+            :disabled="loading"
+            :active="periodDiff === monthsInYear"
+            active-color="accent"
+            density="comfortable"
+            size="small"
+            class="mx-1"
+            @click="switchToYear()"
+          />
+        </template>
+      </v-toolbar>
+
+      <v-container v-if="$slots.top" fluid>
+        <slot name="top" />
+      </v-container>
+    </template>
+
+    <div v-if="loading" class="d-flex align-center justify-center mt-8">
+      <v-empty-state
+        :title="$t('pleaseWait')"
+        :text="$t('sushi.globalHarvestState.loading')"
+      >
+        <template #media>
+          <v-progress-circular
+            color="primary"
+            size="128"
+            indeterminate
+            class="mb-4"
+          >
+            <v-icon icon="mdi-table-sync" />
+          </v-progress-circular>
+        </template>
+      </v-empty-state>
+    </div>
+
+    <template v-else-if="(modelValue?.rows.length ?? 0) > 0">
+      <thead>
+        <tr>
+          <th />
+          <th v-for="[, header] in columnHeaders" :key="header.id" class="matrix--column-header text-center">
+            <slot name="column-header" v-bind="header">
+              {{ header.value }}
+            </slot>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <tr v-for="row in rows" :key="row.id">
+          <th class="matrix--row-header">
+            <slot name="row-header" v-bind="row.header">
+              {{ row.header.value }}
+            </slot>
+          </th>
+          <td v-for="cell in row.cells" :key="cell.id" class="text-center">
+            <div class="d-flex align-center justify-center">
+              <SushiHarvestGlobalMatrixCell :model-value="cell" />
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </template>
+
+    <div v-else class="d-flex align-center justify-center">
+      <v-empty-state
+        icon="mdi-table-headers-eye-off"
+        :title="$t('sushi.noMatrix.title')"
+        :text="$t('sushi.noMatrix.description')"
+      />
+    </div>
+  </v-table>
+</template>
+
+<script setup>
+import { monthsInQuarter, monthsInYear } from 'date-fns/constants';
+import {
+  addMonths,
+  differenceInMonths,
+  getQuarter,
+  format,
+  parse,
+} from 'date-fns';
+
+// Avoid using magical numbers for semester calculation
+const quartersInSemester = 2;
+const monthsInSemester = monthsInQuarter * quartersInSemester;
+
+const DATE_MONTH_FORMAT = 'yyyy-MM';
+
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    default: () => undefined,
+  },
+  period: {
+    type: Object,
+    default: () => undefined,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  columnKey: {
+    type: String,
+    default: 'id',
+  },
+  columnValue: {
+    type: String,
+    default: 'name',
+  },
+  rowKey: {
+    type: String,
+    default: 'id',
+  },
+  rowValue: {
+    type: String,
+    default: 'name',
+  },
+  min: {
+    type: String,
+    default: undefined,
+  },
+  max: {
+    type: String,
+    default: undefined,
+  },
+});
+
+const emit = defineEmits({
+  'update:period': (value) => typeof value.beginDate === 'string' && typeof value.endDate === 'string',
+});
+
+const columnHeaders = computed(() => new Map(
+  (props.modelValue?.headers.columns ?? []).map((col) => {
+    const id = props.columnKey ? col[props.columnKey] : col;
+    return [id, {
+      id,
+      value: props.columnValue ? col[props.columnValue] : col,
+      item: col,
+    }];
+  }),
+));
+
+const rowHeaders = computed(() => new Map(
+  (props.modelValue?.headers.rows ?? []).map((row) => {
+    const id = props.rowKey ? row[props.rowKey] : row;
+    return [id, {
+      id,
+      value: props.rowValue ? row[props.rowValue] : row,
+      item: row,
+    }];
+  }),
+));
+
+const rows = computed(() => props.modelValue.rows.map(
+  (row) => ({
+    ...row,
+    header: rowHeaders.value.get(row.id) ?? { id: row.id, value: '???' },
+  }),
+));
+
+const periodDate = computed(() => {
+  if (!props.period) {
+    return undefined;
+  }
+
+  const now = new Date();
+
+  return {
+    beginDate: parse(props.period.beginDate, DATE_MONTH_FORMAT, now),
+    endDate: parse(props.period.endDate, DATE_MONTH_FORMAT, now),
+  };
+});
+
+const periodDiff = computed(() => {
+  if (!periodDate.value) {
+    return undefined;
+  }
+
+  return differenceInMonths(periodDate.value.endDate, periodDate.value.beginDate) + 1;
+});
+
+function getNewPeriod(multiplier = 0) {
+  if (!periodDate.value) {
+    return undefined;
+  }
+
+  const { beginDate, endDate } = periodDate.value;
+
+  return {
+    beginDate: format(addMonths(beginDate, periodDiff.value * multiplier), DATE_MONTH_FORMAT),
+    endDate: format(addMonths(endDate, periodDiff.value * multiplier), DATE_MONTH_FORMAT),
+  };
+}
+
+const isPreviousDisabled = computed(() => {
+  if (!periodDate.value || !props.min) {
+    return false;
+  }
+
+  const newPeriod = getNewPeriod(-1);
+
+  return newPeriod.beginDate <= props.min;
+});
+
+const isNextDisabled = computed(() => {
+  if (!periodDate.value || !props.max) {
+    return false;
+  }
+  const newPeriod = getNewPeriod(1);
+
+  return newPeriod.endDate >= props.max;
+});
+
+function changePeriod(multiplier = 0) {
+  emit('update:period', getNewPeriod(multiplier));
+}
+
+function switchToMonth() {
+  if (!props.period) {
+    return;
+  }
+
+  emit('update:period', {
+    beginDate: props.period.beginDate,
+    endDate: props.period.beginDate,
+  });
+}
+
+function switchToQuarter() {
+  if (!periodDate.value) {
+    return;
+  }
+
+  // 0-indexed quarter
+  const quarter = getQuarter(periodDate.value.beginDate) - 1;
+
+  const beginDate = new Date(periodDate.value.beginDate);
+  beginDate.setMonth(quarter * monthsInQuarter);
+
+  emit('update:period', {
+    beginDate: format(beginDate, DATE_MONTH_FORMAT),
+    endDate: format(addMonths(beginDate, monthsInQuarter - 1), DATE_MONTH_FORMAT),
+  });
+}
+
+function switchToSemester() {
+  if (!periodDate.value) {
+    return;
+  }
+
+  // 0-indexed semester
+  const semester = Math.floor((getQuarter(periodDate.value.beginDate) - 1) / quartersInSemester);
+
+  const beginDate = new Date(periodDate.value.beginDate);
+  beginDate.setMonth(semester * monthsInSemester);
+
+  emit('update:period', {
+    beginDate: format(beginDate, DATE_MONTH_FORMAT),
+    endDate: format(addMonths(beginDate, monthsInSemester - 1), DATE_MONTH_FORMAT),
+  });
+}
+
+function switchToYear() {
+  if (!periodDate.value) {
+    return;
+  }
+
+  const year = periodDate.value.beginDate.getFullYear();
+
+  emit('update:period', {
+    beginDate: `${year}-01`,
+    endDate: `${year}-12`,
+  });
+}
+</script>

--- a/front/app/components/sushiHarvest/GlobalMatrixCell.vue
+++ b/front/app/components/sushiHarvest/GlobalMatrixCell.vue
@@ -1,0 +1,230 @@
+<template>
+  <v-menu
+    v-if="modelValue.total > 0"
+    width="400"
+    close-delay="200"
+    open-on-hover
+  >
+    <template #activator="{ props: menu }">
+      <ProgressCircularStack
+        :model-value="bars"
+        size="32"
+        v-bind="menu"
+      >
+        <template #labels>
+          <v-icon
+            :icon="icon.icon"
+            :color="icon.color"
+            size="small"
+          />
+        </template>
+      </ProgressCircularStack>
+    </template>
+
+    <v-card :title="title">
+      <template #prepend>
+        <v-icon :icon="icon.icon" :color="icon.color" />
+      </template>
+
+      <template v-if="modelValue.harvestedAt" #subtitle>
+        <LocalDate :model-value="modelValue.harvestedAt" />
+      </template>
+
+      <template #text>
+        <v-row>
+          <v-col cols="6" class="pa-0">
+            <DetailsField
+              :label="`${$t('harvest.jobs.period')} :`"
+              :value="`${modelValue.period.beginDate} ~ ${modelValue.period.endDate}`"
+              prepend-icon="mdi-calendar-blank"
+            />
+
+            <DetailsField
+              v-if="modelValue.counterVersions.length > 0"
+              :label="`${$t('harvest.jobs.versions')} :`"
+              prepend-icon="mdi-api"
+            >
+              <v-chip
+                v-for="version in modelValue.counterVersions"
+                :key="version"
+                v-tooltip:top="$t('tasks.counterVersion', { version })"
+                :text="version"
+                :color="counterVersionsColors.get(version) || 'secondary'"
+                density="compact"
+                variant="flat"
+                label
+                class="ml-1 mt-1"
+              />
+            </DetailsField>
+          </v-col>
+
+          <DetailsField
+            :label="`${$t('harvest.jobs.reportType')} :`"
+            prepend-icon="mdi-file-document-outline"
+            cols="6"
+          >
+            <v-chip
+              v-for="report in modelValue.reportIds"
+              :key="report"
+              :text="report"
+              density="compact"
+              variant="outlined"
+              label
+              class="ml-1 mt-1 text-uppercase"
+            />
+          </DetailsField>
+
+          <DetailsField
+            :label="`${$t('status')} :`"
+            prepend-icon="mdi-gauge"
+            cols="12"
+          >
+            <ProgressLinearStack
+              :model-value="bars"
+              height="8"
+              class="mt-2"
+            />
+
+            <v-list max-height="200" density="compact" slim>
+              <template v-for="row in bars">
+                <v-list-item
+                  v-if="row.value > 0"
+                  :key="row.key"
+                  :title="row.label"
+                >
+                  <template #prepend>
+                    <v-icon
+                      v-if="row.icon"
+                      :icon="row.icon"
+                      :color="row.color"
+                    />
+                  </template>
+
+                  <template #append>
+                    {{ row.valueStr }}
+                  </template>
+                </v-list-item>
+              </template>
+            </v-list>
+          </DetailsField>
+        </v-row>
+
+        <template v-if="items">
+          <v-divider class="my-2" />
+
+          <v-row>
+            <v-col v-if="items.inserted > 0" cols="4">
+              <v-chip
+                v-tooltip:top="$t('harvest.jobs.inserted')"
+                :text="`${items.inserted}`"
+                prepend-icon="mdi-file-download"
+                color="success"
+                variant="outlined"
+                density="comfortable"
+              />
+            </v-col>
+            <v-col v-if="items.updated > 0" cols="4">
+              <v-chip
+                v-tooltip:top="$t('harvest.jobs.updated')"
+                :text="`${items.updated}`"
+                prepend-icon="mdi-file-replace"
+                color="info"
+                variant="outlined"
+                density="comfortable"
+              />
+            </v-col>
+            <v-col v-if="items.failed > 0" cols="4">
+              <v-chip
+                v-tooltip:top="$t('harvest.jobs.failed')"
+                :text="`${modelValue.items.failed}`"
+                prepend-icon="mdi-file-alert"
+                color="error"
+                variant="outlined"
+              />
+            </v-col>
+          </v-row>
+        </template>
+
+        <template v-if="modelValue.errors?.length > 0">
+          <v-divider class="my-2" />
+
+          <v-row>
+            <DetailsField
+              :label="$t('sushi.messagesFromEndpoint')"
+              prepend-icon="mdi-alert-outline"
+            >
+              <v-list max-height="150" density="compact" slim>
+                <v-list-item
+                  v-for="errorCode in modelValue.errors"
+                  :key="errorCode"
+                >
+                  {{ $te(`tasks.status.exceptions.${errorCode}`) ? $t(`tasks.status.exceptions.${errorCode}`) : errorCode }}
+
+                  <v-icon
+                    v-if="$te(`tasks.status.exceptionMeaning.${errorCode}`)"
+                    v-tooltip:top="$t(`tasks.status.exceptionMeaning.${errorCode}`)"
+                    icon="mdi-information-outline"
+                    size="x-small"
+                    color="info"
+                    end
+                    style="vertical-align: baseline;"
+                  />
+                </v-list-item>
+              </v-list>
+            </DetailsField>
+          </v-row>
+        </template>
+      </template>
+    </v-card>
+  </v-menu>
+</template>
+
+<script setup>
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    default: () => {},
+  },
+});
+
+const { t, te, locale } = useI18n();
+
+const icon = computed(() => harvestStatus.get(props.modelValue.status) ?? {
+  icon: 'mdi-question',
+  color: 'grey',
+});
+
+const title = computed(() => {
+  const { status } = props.modelValue ?? {};
+  const titleKey = `tasks.status.${status}`;
+  return te(titleKey) ? t(titleKey) : status;
+});
+
+const items = computed(() => {
+  const counts = Object.values(props.modelValue?.items ?? {}).filter((v) => v > 0);
+  if (counts.length <= 0) {
+    return undefined;
+  }
+  return props.modelValue.items;
+});
+
+const bars = computed(() => {
+  const formatter = new Intl.NumberFormat(locale.value, { style: 'percent' });
+
+  return Object.entries(props.modelValue.counts)
+    .map(([status, count]) => {
+      const key = `tasks.status.${status}`;
+      const value = count / props.modelValue.total;
+
+      return {
+        key: status,
+        label: te(key) ? t(key) : status,
+        value,
+        valueStr: formatter.format(value),
+        ...harvestStatus.get(status),
+      };
+    })
+    .filter(({ value }) => value > 0)
+    .sort((barA, barB) => barB.value - barA.value);
+});
+</script>

--- a/front/app/components/sushiHarvest/GlobalMatrixDialog.vue
+++ b/front/app/components/sushiHarvest/GlobalMatrixDialog.vue
@@ -1,0 +1,310 @@
+<template>
+  <v-dialog
+    v-model="isOpen"
+    fullscreen
+  >
+    <v-card
+      :title="$t('sushi.globalHarvestState.title')"
+      :loading="loading && 'primary'"
+      prepend-icon="mdi-table-headers-eye"
+    >
+      <template #append>
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+
+      <v-card-text class="pa-0" style="max-height: 100%; overflow-y: hidden;">
+        <v-tabs v-model="tab" grow>
+          <v-tab
+            :value="TABS.institutions"
+            :text="$t('menu.institutions')"
+            prepend-icon="mdi-domain"
+          />
+
+          <v-tab
+            :value="TABS.endpoints"
+            :text="$t('menu.sushiEndpoints')"
+            prepend-icon="mdi-api"
+          />
+        </v-tabs>
+
+        <v-tabs-window v-model="tab" class="h-100">
+          <v-tabs-window-item :value="TABS.institutions" class="h-100">
+            <SushiHarvestGlobalMatrix
+              v-model:period="period"
+              :model-value="institutionsData?.matrix"
+              :loading="institutionsStatus === 'pending'"
+              :max="MAX_HARVEST_MONTH"
+              column-key=""
+              column-value=""
+              class="matrix pb-2"
+            >
+              <template #top>
+                <v-alert
+                  v-if="institutionsError"
+                  :text="getErrorMessage(institutionsError)"
+                  type="error"
+                />
+
+                <v-row v-else>
+                  <v-col>
+                    <p>
+                      {{ $t('sushi.globalHarvestState.harvest-session.description') }}
+                    </p>
+                  </v-col>
+
+                  <v-col cols="4">
+                    <div v-if="institutionsStatus === 'pending'" class="d-flex justify-center align-center h-100">
+                      <v-progress-circular size="64" color="accent" indeterminate />
+                    </div>
+
+                    <template v-else-if="harvestedInstitutionBar">
+                      <v-progress-linear
+                        :model-value="harvestedInstitutionBar.value"
+                        height="8"
+                        color="primary"
+                        rounded
+                      />
+
+                      <v-table height="100" density="comfortable">
+                        <tbody>
+                          <tr>
+                            <td>
+                              <v-icon icon="mdi-file-outline" color="primary" start />
+
+                              {{ $t('tasks.status.harvested') }}
+                            </td>
+
+                            <td>
+                              {{ harvestedInstitutionBar.harvested.percent }}
+
+                              ({{ harvestedInstitutionBar.harvested.count }})
+                            </td>
+                          </tr>
+
+                          <tr>
+                            <td>
+                              <v-icon icon="mdi-help" color="primary" start style="opacity: var(--v-border-opacity);" />
+
+                              {{ $t('tasks.status.unharvested') }}
+                            </td>
+
+                            <td>
+                              {{ harvestedInstitutionBar.unharvested.percent }}
+
+                              ({{ harvestedInstitutionBar.unharvested.count }})
+                            </td>
+                          </tr>
+                        </tbody>
+                      </v-table>
+
+                      <v-menu
+                        v-if="institutionsData.unharvested.length > 0"
+                        height="500"
+                        width="600"
+                        :close-on-content-click="false"
+                      >
+                        <template #activator="{ props: menu, isActive }">
+                          <v-btn
+                            :text="$t('sushi.globalHarvestState.showUnharvested')"
+                            :prepend-icon="isActive ? 'mdi-chevron-up' : 'mdi-chevron-down'"
+                            color="secondary"
+                            block
+                            v-bind="menu"
+                          />
+                        </template>
+
+                        <v-list lines="2" density="compact" slim>
+                          <v-list-item
+                            v-for="institution in institutionsData.unharvested"
+                            :key="institution.id"
+                            :title="institution.name"
+                            :subtitle="institution.acronym"
+                            :to="`/admin/institutions/${institution.id}/sushi`"
+                          >
+                            <template #prepend>
+                              <InstitutionAvatar :institution="institution" />
+                            </template>
+                          </v-list-item>
+                        </v-list>
+                      </v-menu>
+                    </template>
+                  </v-col>
+                </v-row>
+              </template>
+
+              <template #row-header="{ item }">
+                <nuxt-link :to="`/admin/institutions/${item.id}/sushi`">
+                  {{ item.name }}
+                </nuxt-link>
+              </template>
+            </SushiHarvestGlobalMatrix>
+          </v-tabs-window-item>
+
+          <v-tabs-window-item :value="TABS.endpoints" class="h-100">
+            <SushiHarvestGlobalMatrix
+              v-model:period="period"
+              :model-value="endpointsData?.matrix"
+              :loading="endpointsStatus === 'pending'"
+              :max="MAX_HARVEST_MONTH"
+              column-key=""
+              class="matrix pb-2"
+            >
+              <template v-if="endpointsError" #top>
+                <v-alert
+                  :text="getErrorMessage(endpointsError)"
+                  type="error"
+                />
+              </template>
+
+              <template #column-header="{ item }">
+                <span class="text-uppercase">{{ item }}</span>
+              </template>
+
+              <template #row-header="{ item }">
+                <nuxt-link :to="`/admin/endpoints/${item.id}`">
+                  {{ item.vendor }}
+                </nuxt-link>
+              </template>
+            </SushiHarvestGlobalMatrix>
+          </v-tabs-window-item>
+        </v-tabs-window>
+
+        <template #actions>
+          <v-btn
+            :text="$t('close')"
+            variant="text"
+            @click="isOpen = false"
+          />
+        </template>
+      </v-card-text>
+
+      <template #actions>
+        <v-btn
+          :text="$t('close')"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { format } from 'date-fns';
+
+import { getQuarterPeriod } from '@/lib/sushi';
+import { getErrorMessage } from '@/lib/errors';
+
+const TABS = {
+  institutions: 'institutions',
+  endpoints: 'endpoints',
+};
+
+const NOW = new Date();
+const MAX_HARVEST_MONTH = format(NOW, 'yyyy-MM');
+
+const { locale } = useI18n();
+
+const tab = shallowRef(TABS.institutions);
+const isOpen = shallowRef(false);
+const period = ref(getQuarterPeriod(NOW, -1));
+
+const {
+  data: institutionsData,
+  status: institutionsStatus,
+  error: institutionsError,
+  refresh: institutionsRefresh,
+} = useFetch('/api/harvests/_institutions-matrix', {
+  params: {
+    retryCode: 425,
+    'period:from': computed(() => period.value.beginDate),
+    'period:to': computed(() => period.value.endDate),
+  },
+
+  retry: 10,
+  retryDelay: 1000,
+  retryStatusCodes: [425],
+
+  lazy: true,
+  immediate: false,
+});
+
+const harvestedInstitutionBar = computed(() => {
+  if (!institutionsData.value) {
+    return undefined;
+  }
+
+  const { unharvested, matrix: { rows } } = institutionsData.value;
+
+  const formatter = new Intl.NumberFormat(locale.value, { style: 'percent' });
+
+  const value = rows.length / (unharvested.length + rows.length);
+
+  return {
+    value: value * 100,
+    harvested: {
+      count: rows.length,
+      percent: formatter.format(value),
+    },
+    unharvested: {
+      count: unharvested.length,
+      percent: formatter.format(1 - value),
+    },
+  };
+});
+
+const {
+  data: endpointsData,
+  status: endpointsStatus,
+  error: endpointsError,
+  refresh: endpointsRefresh,
+} = useFetch('/api/harvests/_endpoints-matrix', {
+  params: {
+    retryCode: 425,
+    'period:from': computed(() => period.value.beginDate),
+    'period:to': computed(() => period.value.endDate),
+  },
+
+  retry: 10,
+  retryDelay: 1000,
+  retryStatusCodes: [425],
+
+  lazy: true,
+  immediate: false,
+});
+
+const loading = computed(() => institutionsStatus.value === 'pending' || endpointsStatus.value === 'pending');
+
+async function refresh() {
+  if (tab.value === TABS.institutions) {
+    await institutionsRefresh();
+  }
+  if (tab.value === TABS.endpoints) {
+    await endpointsRefresh();
+  }
+}
+
+async function open() {
+  isOpen.value = true;
+  await refresh();
+}
+
+watch(tab, refresh);
+
+defineExpose({
+  open,
+});
+</script>
+
+<style lang="css" scoped>
+.matrix :deep(.matrix--row-header) {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
+}
+</style>

--- a/front/app/components/sushiHarvest/MatrixCell.vue
+++ b/front/app/components/sushiHarvest/MatrixCell.vue
@@ -19,13 +19,28 @@
       min-width="350"
       max-width="500"
     >
-      <template v-if="user?.isAdmin" #append>
+      <template #prepend>
+        <v-icon :icon="icon.icon" :color="icon.color" />
+      </template>
+
+      <template v-if="props.modelValue.harvestedBy" #append>
+        <v-chip
+          v-tooltip:top="$t('tasks.counterVersion', { version: counterVersion })"
+          :text="counterVersion"
+          :color="counterVersionsColors.get(counterVersion) || 'secondary'"
+          density="comfortable"
+          variant="flat"
+          label
+        />
+
         <v-btn
+          v-if="user?.isAdmin"
           v-tooltip:top="$t('tasks.history')"
           icon="mdi-history"
           color="primary"
           variant="text"
           density="comfortable"
+          class="ml-1"
           @click="openTaskHistoryFromHarvest()"
         />
       </template>
@@ -37,7 +52,7 @@
           </v-col>
         </v-row>
 
-        <v-row v-if="counts.length > 0">
+        <v-row v-if="counts.length > 0 && modelValue.harvestedBy">
           <v-col>
             <i18n-t v-for="item in counts" :key="item.path" :keypath="item.path">
               <template #count>
@@ -45,11 +60,11 @@
               </template>
 
               <template #beignDate>
-                <span class="font-weight-bold">{{ modelValue.harvestedBy?.beginDate ?? '???' }}</span>
+                <span class="font-weight-bold">{{ modelValue.harvestedBy.beginDate }}</span>
               </template>
 
               <template #endDate>
-                <span class="font-weight-bold">{{ modelValue.harvestedBy?.endDate ?? '???' }}</span>
+                <span class="font-weight-bold">{{ modelValue.harvestedBy.endDate }}</span>
               </template>
             </i18n-t>
           </v-col>
@@ -117,9 +132,10 @@ const statusText = computed(() => {
     text: te(textKey) ? t(textKey) : '',
   };
 });
+const counterVersion = computed(() => props.modelValue.harvestedBy?.counterVersion);
 
 async function openTaskHistoryFromHarvest() {
-  if (!user.value?.isAdmin) {
+  if (!user.value?.isAdmin || !props.modelValue.harvestedBy) {
     return;
   }
 

--- a/front/app/components/sushiHarvest/session/Body.vue
+++ b/front/app/components/sushiHarvest/session/Body.vue
@@ -8,6 +8,17 @@
         <v-toolbar :title="$t('harvest.jobs.title')" color="transparent">
           <template #append>
             <v-btn
+              v-if="globalHarvestMatrixRef"
+              v-tooltip="$t('sushi.globalHarvestState.title')"
+              icon="mdi-table-headers-eye"
+              variant="tonal"
+              density="comfortable"
+              color="primary"
+              class="mr-2"
+              @click="globalHarvestMatrixRef.open()"
+            />
+
+            <v-btn
               v-tooltip="$t('refresh')"
               :loading="status === 'pending'"
               icon="mdi-reload"
@@ -130,7 +141,15 @@
       </template>
     </v-data-table-server>
 
-    <SushiHarvestTaskHistoryDialog ref="historyRef" :session="modelValue" />
+    <SushiHarvestTaskHistoryDialog
+      ref="historyRef"
+      :session="modelValue"
+    />
+
+    <SushiHarvestSessionGlobalMatrixDialog
+      ref="globalHarvestMatrixRef"
+      :session="modelValue"
+    />
   </div>
 </template>
 
@@ -151,6 +170,7 @@ const snacks = useSnacksStore();
 const { openConfirm } = useDialogStore();
 
 const historyRef = useTemplateRef('historyRef');
+const globalHarvestMatrixRef = useTemplateRef('globalHarvestMatrixRef');
 
 const {
   status,

--- a/front/app/components/sushiHarvest/session/GlobalMatrixDialog.vue
+++ b/front/app/components/sushiHarvest/session/GlobalMatrixDialog.vue
@@ -1,0 +1,143 @@
+<template>
+  <v-dialog
+    v-model="isOpen"
+    fullscreen
+  >
+    <v-card
+      :title="cardTitle"
+      :subtitle="session.id"
+      :loading="status === 'pending' && 'primary'"
+      prepend-icon="mdi-table-headers-eye"
+    >
+      <template #append>
+        <v-btn
+          icon="mdi-close"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+
+      <v-card-text style="max-height: 100%; overflow-y: hidden; padding: 0;">
+        <SushiHarvestGlobalMatrix
+          :model-value="data?.matrix"
+          :loading="status === 'pending'"
+          class="matrix"
+        >
+          <template v-if="error" #top>
+            <v-alert
+              :text="getErrorMessage(error)"
+              type="error"
+            />
+          </template>
+
+          <template #column-header="{ item }">
+            <div class="institution-header">
+              <nuxt-link v-tooltip:bottom="item.name" :to="`/admin/institutions/${item.id}/sushi`">
+                {{ item.name }}
+              </nuxt-link>
+            </div>
+            <div class="d-flex justify-center pb-4">
+              <SushiHarvestGlobalMatrixCell :model-value="summaryByColumn.get(item.id)" />
+            </div>
+          </template>
+
+          <template #row-header="{ item }">
+            <nuxt-link :to="`/admin/endpoints/${item.id}`">
+              {{ item.vendor }}
+            </nuxt-link>
+          </template>
+        </SushiHarvestGlobalMatrix>
+      </v-card-text>
+
+      <template #actions>
+        <v-btn
+          :text="$t('close')"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { getErrorMessage } from '@/lib/errors';
+
+const props = defineProps({
+  session: {
+    type: Object,
+    required: true,
+  },
+});
+
+const { data: user } = useAuthState();
+const { t } = useI18n();
+
+const isOpen = shallowRef(false);
+
+const {
+  data,
+  refresh,
+  error,
+  status,
+} = useFetch(`/api/harvests-sessions/${props.session.id}/_matrix`, {
+  params: {
+    retryCode: 425,
+  },
+
+  retry: 10,
+  retryDelay: 1000,
+  retryStatusCodes: [425],
+
+  lazy: true,
+  immediate: false,
+});
+
+const cardTitle = computed(() => {
+  const title = t('sushi.globalHarvestState.harvest-session.title');
+  if (!user.value.isAdmin) {
+    return title;
+  }
+
+  return `${title} - ${t('harvest.sessions.title')}`;
+});
+
+const summaryByColumn = computed(() => new Map(
+  data.value?.summary.map((cell) => [cell.id, cell]),
+));
+
+async function open() {
+  isOpen.value = true;
+  await refresh();
+}
+
+defineExpose({
+  open,
+});
+</script>
+
+<style lang="css" scoped>
+.institution-header {
+  height: 200px;
+  position: relative;
+}
+
+.institution-header > a {
+  bottom: 10px;
+  left: 50%;
+  position: absolute;
+  transform: rotate(-45deg);
+  transform-origin: center left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
+}
+
+.matrix :deep(.matrix--row-header) {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 250px;
+}
+</style>

--- a/front/app/lib/sushi.js
+++ b/front/app/lib/sushi.js
@@ -1,3 +1,10 @@
+import {
+  format,
+  startOfQuarter,
+  endOfQuarter,
+  addQuarters,
+} from 'date-fns';
+
 export const DEFAULT_REPORTS_IDS = [
   'DR',
   'DR_D1',
@@ -10,3 +17,11 @@ export const DEFAULT_REPORTS_IDS = [
 ];
 
 export const SUPPORTED_COUNTER_VERSIONS = ['5', '5.1'];
+
+export function getQuarterPeriod(reference = new Date(), offset = 0) {
+  const quarter = addQuarters(reference, offset);
+  return {
+    beginDate: format(startOfQuarter(quarter), 'yyyy-MM'),
+    endDate: format(endOfQuarter(quarter), 'yyyy-MM'),
+  };
+}

--- a/front/app/pages/admin/endpoints/[id].vue
+++ b/front/app/pages/admin/endpoints/[id].vue
@@ -132,6 +132,19 @@
           </v-col>
         </template>
       </v-row>
+
+      <v-row class="mt-4">
+        <v-col>
+          <v-btn
+            v-if="globalHarvestMatrixRef"
+            :text="$t('sushi.globalHarvestState.title')"
+            prepend-icon="mdi-table-headers-eye"
+            size="small"
+            variant="outlined"
+            @click="globalHarvestMatrixRef.open()"
+          />
+        </v-col>
+      </v-row>
     </v-container>
 
     <v-data-table
@@ -221,7 +234,7 @@
           </span>
 
           <v-btn
-            :disabled="status === 'pending' || currentHarvestYear >= maxHarvestYear"
+            :disabled="status === 'pending' || currentHarvestYear >= MAX_HARVEST_YEAR"
             color="primary"
             variant="text"
             density="comfortable"
@@ -368,6 +381,11 @@
     <SushiHarvestHistoryDialog ref="historyRef" />
 
     <SushiReportsDialog ref="reportsRef" />
+
+    <SushiEndpointHarvestGlobalMatrixDialog
+      ref="globalHarvestMatrixRef"
+      :endpoint="endpoint"
+    />
   </div>
 </template>
 
@@ -377,7 +395,7 @@ definePageMeta({
   middleware: ['sidebase-auth', 'terms', 'admin'],
 });
 
-const maxHarvestYear = new Date().getFullYear();
+const MAX_HARVEST_YEAR = new Date().getFullYear();
 
 const { params } = useRoute();
 const { t, locale } = useI18n();
@@ -391,10 +409,11 @@ const filters = ref({});
 const sushiMetrics = ref(undefined);
 const loading = shallowRef(false);
 const selectedInstitutions = ref([]);
-const currentHarvestYear = ref(maxHarvestYear);
+const currentHarvestYear = ref(MAX_HARVEST_YEAR);
 
 const endpointFormDialogRef = useTemplateRef('endpointFormDialogRef');
 const harvestMatrixRef = useTemplateRef('harvestMatrixRef');
+const globalHarvestMatrixRef = useTemplateRef('globalHarvestMatrixRef');
 const reportsRef = useTemplateRef('reportsRef');
 const filesRef = useTemplateRef('filesRef');
 const historyRef = useTemplateRef('historyRef');

--- a/front/app/pages/admin/harvests/index.vue
+++ b/front/app/pages/admin/harvests/index.vue
@@ -7,7 +7,18 @@
       search
       icons
       @update:model-value="debouncedRefresh()"
-    />
+    >
+      <v-btn
+        v-if="globalHarvestMatrixRef"
+        v-tooltip="$t('sushi.globalHarvestState.title')"
+        icon="mdi-table-headers-eye"
+        variant="tonal"
+        density="comfortable"
+        color="primary"
+        class="mr-2"
+        @click="globalHarvestMatrixRef.open()"
+      />
+    </SkeletonPageBar>
 
     <v-data-iterator :items="sessionsWithStatus" items-per-page="0">
       <template #default="{ items }">
@@ -49,6 +60,8 @@
         </div>
       </template>
     </v-data-iterator>
+
+    <SushiHarvestGlobalMatrixDialog ref="globalHarvestMatrixRef" />
   </div>
 </template>
 
@@ -60,6 +73,8 @@ definePageMeta({
 
 const { t } = useI18n();
 const snacks = useSnacksStore();
+
+const globalHarvestMatrixRef = useTemplateRef('globalHarvestMatrixRef');
 
 const {
   data: sessions,

--- a/front/app/pages/myspace/institutions/[id]/sushi.vue
+++ b/front/app/pages/myspace/institutions/[id]/sushi.vue
@@ -113,19 +113,29 @@
 
       <v-row class="mt-4">
         <v-col>
+          <v-btn
+            v-if="harvestMatrixRef"
+            :text="$t('sushi.globalHarvestState.title')"
+            prepend-icon="mdi-table-headers-eye"
+            size="small"
+            variant="outlined"
+            @click="harvestMatrixRef.open()"
+          />
+        </v-col>
+
+        <v-col class="text-end">
           <v-chip
             :text="sushiReadyLabels.status.text"
             :color="sushiReadyLabels.status.color"
             size="small"
             variant="outlined"
+            class="mr-2"
           >
             <template v-if="!!sushiReadyLabels.status.icon" #prepend>
               <v-icon :icon="sushiReadyLabels.status.icon" start />
             </template>
           </v-chip>
-        </v-col>
 
-        <v-col class="text-end">
           <ConfirmPopover
             v-if="canEdit"
             :title="sushiReadyLabels.confirm.title"
@@ -191,6 +201,11 @@
       @submit="refresh()"
       @update:model-value="refresh()"
     />
+
+    <InstitutionHarvestGlobalMatrixDialog
+      ref="harvestMatrixRef"
+      :institution="institution"
+    />
   </div>
 </template>
 
@@ -219,6 +234,7 @@ const tabsData = ref(new Map());
 const currentTabId = shallowRef('');
 
 const sushiFormRef = useTemplateRef('sushiFormRef');
+const harvestMatrixRef = useTemplateRef('harvestMatrixRef');
 
 const {
   error,

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -540,6 +540,8 @@ tasks:
     cancelled: The harvest has been cancelled.
     delayed: The harvest has been initiated, but the report was not ready yet. A new attempt will be made soon.
     missing: The harvest is terminated, but the requested period is missing.
+    harvested: The harvest has been initiated.
+    unharvested: The harvest hasn't initiated.
   status:
     notLaunchedYet: Not launched yet
     waiting: Waiting
@@ -551,6 +553,8 @@ tasks:
     cancelled: Cancelled
     delayed: Delayed
     missing: Empty report
+    harvested: Harvested
+    unharvested: Unharvested
     exceptions:
       network_error: Unreachable service
       unreadable_report: Unreadable report
@@ -655,6 +659,19 @@ sushi:
   unchangeableParam: Unchangeable parameter defined at the access point level.
   harvestState: Harvest state
   harvestStateDescription: This matrix shows the different results of the harvesting of those credentials. Each result can be hovered to get more information, including any errors that may have occurred while retrieving the data.
+  globalHarvestState:
+    institution:
+      title: Harvest state
+      description: This matrix shows the different results of the harvesting of endpoints. Each result can be hovered to get more information, including any errors that may have occurred while retrieving the data.
+    endpoint:
+      title: Harvest state
+    harvest-session:
+      title: Harvest state
+      description: This matrix shows the different results of the harvesting of institutions. Each result can be hovered to get more information, including any errors that may have occurred while retrieving the data.
+    title: Global harvest state
+    loading: Global harvest state is beign generated, it can take a few seconds
+    periodShortcut: 1 month|{n} months
+    showUnharvested: Show unharvested institutions
   harvestedAt: Harvested on {date}
   inactive: Inactive credentials
   inactiveDescription: Institution made theses credentials inactive and will not be harvested.
@@ -954,6 +971,7 @@ spaces:
 harvest:
   toolbarTitle: Sessions ({count})
   sessions:
+    title: Harvest session
     pendingSession: Pending harvest...
     startedAt: Harvest started {date}
     metrics:
@@ -974,6 +992,7 @@ harvest:
   jobs:
     title: Harvesting Tasks
     filtersTitle: Filter Tasks
+    versions: Versions
     harvestId: Harvesting ID
     reportType: Report Type
     errorCode: Error Code
@@ -1176,3 +1195,4 @@ deletedSince: Deleted since {date}
 cantCancel: This operation cannot be undone.
 version: Version
 back: Back
+pleaseWait: Please wait...

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -527,6 +527,7 @@ group:
 tasks:
   failedToFetchTasks: Failed to fetch tasks list
   logs: Logs
+  counterVersion: Harvested with COUNTER {version}
   history: Tasks history
   oneHistory: Task history
   parameters: Parameters

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -531,6 +531,7 @@ group:
 tasks:
   failedToFetchTasks: Impossible de récupérer la liste des tâches
   logs: Logs
+  counterVersion: Moissonné avec COUNTER {version}
   history: Historique des tâches
   oneHistory: Historique de la tâche
   parameters: Paramètres

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -544,6 +544,8 @@ tasks:
     cancelled: Le moissonnage a été annulé.
     delayed: Le moissonnage a été lancé, mais le rapport n'était pas encore prêt. Une nouvelle tentative aura bientôt lieu.
     missing: Le moissonnage est terminé, mais la période demandée est manquante.
+    harvested: Le moissonnage a été lancé.
+    unharvested: Le moissonnage n'a pas été lancé.
   status:
     notLaunchedYet: Pas encore lancé
     waiting: En attente
@@ -555,6 +557,8 @@ tasks:
     cancelled: Annulé
     delayed: Reporté
     missing: Rapport vide
+    harvested: Moissonné
+    unharvested: Non moissonné
     exceptions:
       network_error: Service injoignable
       unreadable_report: Rapport illisible
@@ -673,6 +677,19 @@ sushi:
   inactiveDescription: L'établissement à rendu cet identifiant inactif et ne sera donc pas moissonné.
   harvestState: État du moissonnage
   harvestStateDescription: Cette matrice présente les différents résultats du moissonnage de ces identifiants. Chaque résultat peut être survolé pour obtenir plus d'informations, notamment quelles erreurs ont pu survenir lors de la récupération des données.
+  globalHarvestState:
+    institution:
+      title: État du moissonnage
+      description: Cette matrice présente les différents résultats du moissonnage des différents points d'accès. Chaque résultat peut être survolé pour obtenir plus d'informations, notamment quelles erreurs ont pu survenir lors de la récupération des données.
+    endpoint:
+      title: État du moissonnage
+    harvest-session:
+      title: État du moissonnage
+      description: Cette matrice présente les différents résultats du moissonnage des différents établissement. Chaque résultat peut être survolé pour obtenir plus d'informations, notamment quelles erreurs ont pu survenir lors de la récupération des données.
+    title: État global du moissonnage
+    loading: L'état global du moissonnage est entrain d'être généré, cela peut prendre quelques secondes
+    periodShortcut: '{n} mois'
+    showUnharvested: Afficher les établissements non moissonnés
   harvestedAt: Moissonné le {date}
   checking: Vérification de la connexion de {vendor} pour {name}
   report: Rapport
@@ -972,6 +989,7 @@ spaces:
 harvest:
   toolbarTitle: Sessions ({count})
   sessions:
+    title: Session de moissonnage
     pendingSession: Moissonnage en attente...
     startedAt: Moissonnage lancé le {date}
     metrics:
@@ -994,6 +1012,7 @@ harvest:
   jobs:
     title: Tâches de moissonnage
     filtersTitle: Filtrer les tâches
+    versions: Versions
     harvestId: Identifiant de moissonnage
     reportType: Type de rapport
     errorCode: Code d'erreur
@@ -1195,3 +1214,4 @@ deletedSince: Supprimé depuis le {date}
 cantCancel: Cette action est irreversible
 version: Version
 back: Retour
+pleaseWait: Veuillez patienter...


### PR DESCRIPTION
# API

- [x] Added routes to generate harvest matrix
  - Thoses routes are async, when you acces them for the first time it starts the computing in the background and you need to come back later to get the full matrix
- [x] Added doc for new routes

# Front

- [x] Added counter version in harvest cells
<img width="542" height="333" alt="2025-09-18T10:19:27,874930111+02:00" src="https://github.com/user-attachments/assets/2c65528f-ba21-41a1-bcc9-7b2ed62a2228" />

- [x] Added global harvest matrix
  - One per institution
<img width="1643" height="948" alt="image" src="https://github.com/user-attachments/assets/ba15d2af-de10-48bb-b8be-684e79792dd7" />

  - One per endpoint
<img width="1645" height="949" alt="image" src="https://github.com/user-attachments/assets/5fe67479-2821-4fbc-bf65-9e915e8dff82" />

  - One per harvest session
<img width="1638" height="942" alt="image" src="https://github.com/user-attachments/assets/1531f525-1a88-4648-8731-012ba9e4e03c" />

  - One for all institutions
<img width="1642" height="944" alt="image" src="https://github.com/user-attachments/assets/fb04d0af-a863-406e-adb9-938079abf73e" />

  - One for all endpoints
<img width="1640" height="942" alt="image" src="https://github.com/user-attachments/assets/215c9cd9-f366-4463-919e-91661cfa533b" />

- [x] Added details in global harvest matrix
<img width="598" height="687" alt="2025-09-18T10:22:29,200721627+02:00" src="https://github.com/user-attachments/assets/1c716db7-3fe8-4588-8c35-ba72093a7222" />
