### PR TITLE
Bugfix/custom fields form

### DIFF
--- a/api/lib/entities/custom-fields.dto.js
+++ b/api/lib/entities/custom-fields.dto.js
@@ -27,8 +27,8 @@ const schema = {
   descriptionFr: Joi.string().allow('').empty(null),
   descriptionEn: Joi.string().allow('').empty(null),
 
-  helpUrl: Joi.string().trim().empty(null),
-  itemUrl: Joi.string().trim().empty(null),
+  helpUrl: Joi.string().trim().allow('').empty(null),
+  itemUrl: Joi.string().trim().allow('').empty(null),
 
   autocomplete: Joi.object().empty(null),
   institutionProperties: Joi.array().items(Joi.object()),

--- a/front/app/components/customField/Form.vue
+++ b/front/app/components/customField/Form.vue
@@ -160,7 +160,18 @@ const idRules = [
 
 const saving = shallowRef(false);
 const valid = shallowRef(false);
-const customField = ref({ ...(props.modelValue ?? {}) });
+const customField = ref({
+  id: props.modelValue?.id,
+  labelFr: props.modelValue?.labelFr,
+  labelEn: props.modelValue?.labelEn,
+  descriptionFr: props.modelValue?.descriptionFr,
+  descriptionEn: props.modelValue?.descriptionEn,
+  helpUrl: props.modelValue?.helpUrl,
+  itemUrl: props.modelValue?.itemUrl,
+  multiple: props.modelValue?.multiple,
+  editable: props.modelValue?.editable,
+  visible: props.modelValue?.visible,
+});
 
 /** @type {Ref<Object | null>} */
 const formRef = useTemplateRef('formRef');

--- a/front/app/components/customField/Form.vue
+++ b/front/app/components/customField/Form.vue
@@ -6,7 +6,6 @@
     <template #text>
       <v-form
         id="fieldForm"
-        ref="formRef"
         v-model="valid"
         @submit.prevent="save()"
       >
@@ -172,9 +171,6 @@ const customField = ref({
   editable: props.modelValue?.editable,
   visible: props.modelValue?.visible,
 });
-
-/** @type {Ref<Object | null>} */
-const formRef = useTemplateRef('formRef');
 
 const originalId = computed(() => props.modelValue?.id);
 const isEditing = computed(() => !!originalId.value);


### PR DESCRIPTION
# Changes

This PR resolves some issues that prevent users from modifying custom fields

- Fix: the custom field form does not send the `_count` field anymore
- Fix: the API now allows empty strings for `helpUrl` and `itemUrl`