### PR TITLE
feat: added views for harvestable institutions

### DIFF
--- a/api/lib/controllers/institutions/actions.js
+++ b/api/lib/controllers/institutions/actions.js
@@ -3,6 +3,7 @@ const config = require('config');
 const { sendMail, generateMail } = require('../../services/mail');
 const { appLogger } = require('../../services/logger');
 const InstitutionsService = require('../../entities/institutions.service');
+const SushiCredentialsService = require('../../entities/sushi-credentials.service');
 const ImagesService = require('../../services/images');
 const MembershipsService = require('../../entities/memberships.service');
 
@@ -532,4 +533,45 @@ exports.deleteInstitution = async (ctx) => {
 
   ctx.status = 200;
   ctx.body = data;
+};
+
+exports.harvestableInstitutions = async (ctx) => {
+  const institutionsService = new InstitutionsService();
+
+  const institutions = await institutionsService.findMany({
+    where: {
+      sushiCredentials: {
+        some: {
+          active: true,
+        },
+      },
+    },
+    orderBy: {
+      name: 'asc',
+    },
+    include: {
+      _count: {
+        select: {
+          spaces: { where: { type: 'counter5' } },
+          repositories: { where: { type: 'counter5' } },
+          memberships: { where: { roles: { has: 'contact:doc' } } },
+          sushiCredentials: { where: SushiCredentialsService.enabledCredentialsQuery },
+        },
+      },
+    },
+  });
+
+  const response = [];
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const institution of institutions) {
+    response.push({
+      institution,
+      // eslint-disable-next-line no-await-in-loop
+      harvestable: await institutionsService.isHarvestable(institution.id, ctx.query),
+    });
+  }
+
+  ctx.status = 200;
+  ctx.body = response;
 };

--- a/api/lib/controllers/institutions/index.js
+++ b/api/lib/controllers/institutions/index.js
@@ -21,6 +21,7 @@ const {
   getInstitution,
   updateInstitution,
   updateInstitutionSushiReady,
+  harvestableInstitutions,
 } = require('./actions');
 
 const memberships = require('./memberships');
@@ -53,6 +54,23 @@ router.route({
   handler: getInstitutions,
   validate: {
     query: standardQueryParams.manyValidation,
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/_harvestable',
+  handler: [
+    harvestableInstitutions,
+  ],
+  validate: {
+    query: {
+      allowNotReady: Joi.boolean(),
+      allowFaulty: Joi.boolean(),
+      allowHarvested: Joi.boolean(),
+      allEndpointsMustBeUnharvested: Joi.boolean(),
+      harvestedMonth: Joi.string(),
+    },
   },
 });
 

--- a/api/lib/controllers/institutions/sushi/actions.js
+++ b/api/lib/controllers/institutions/sushi/actions.js
@@ -6,6 +6,7 @@ const {
   schema,
   includableFields,
 } = require('../../../entities/sushi-credentials.dto');
+const InstitutionsService = require('../../../entities/institutions.service');
 
 /* eslint-disable max-len */
 /**
@@ -66,6 +67,7 @@ exports.getAll = async (ctx) => {
 exports.getMetrics = async (ctx) => {
   const sushiCredentialsService = new SushiCredentialsService();
 
+  // Get counts of credentials
   const [
     untested,
     unauthorized,
@@ -83,9 +85,16 @@ exports.getMetrics = async (ctx) => {
     ),
   );
 
+  // Get if institution is harvestable
+  const institutionService = new InstitutionsService();
+
   ctx.type = 'json';
   ctx.status = 200;
   ctx.body = {
+    harvestable: await institutionService.isHarvestable(
+      ctx.state.institution.id,
+      { allowHarvested: true },
+    ),
     statuses: {
       untested,
       unauthorized,

--- a/api/lib/controllers/institutions/sushi/actions.js
+++ b/api/lib/controllers/institutions/sushi/actions.js
@@ -75,12 +75,21 @@ exports.getMetrics = async (ctx) => {
     success,
   ] = await Promise.all(
     [UNTESTED_FILTER, UNAUTHORIZED_FILTER, FAILED_FILTER, SUCCESS_FILTER].map(
-      (connection) => sushiCredentialsService.count({
-        where: {
-          connection,
-          institutionId: ctx.state.institution.id,
-          archived: false,
-        },
+      async (connection) => ({
+        total: await sushiCredentialsService.count({
+          where: {
+            connection,
+            institutionId: ctx.state.institution.id,
+            archived: false,
+          },
+        }),
+        enabled: await sushiCredentialsService.count({
+          where: {
+            connection,
+            institutionId: ctx.state.institution.id,
+            ...SushiCredentialsService.enabledCredentialsQuery,
+          },
+        }),
       }),
     ),
   );

--- a/api/lib/entities/harvest-session.service.js
+++ b/api/lib/entities/harvest-session.service.js
@@ -228,14 +228,10 @@ module.exports = class HarvestSessionService extends BasePrismaService {
     const sushiCredentialsService = new SushiCredentialsService(this);
     const credentials = await sushiCredentialsService.findMany({
       where: {
+        ...SushiCredentialsService.enabledCredentialsQuery,
         id: queryToPrismaFilter(session.credentialsQuery.sushiIds?.toString()),
         institutionId: queryToPrismaFilter(session.credentialsQuery.institutionIds?.toString()),
         endpointId: queryToPrismaFilter(session.credentialsQuery.endpointIds?.toString()),
-        active: true,
-        archived: false,
-        endpoint: {
-          active: true,
-        },
       },
       include: {
         endpoint: { select: { counterVersions: true } },

--- a/api/lib/entities/harvest.service.js
+++ b/api/lib/entities/harvest.service.js
@@ -4,15 +4,18 @@ const harvestPrisma = require('../services/prisma/harvest');
 const BasePrismaService = require('./base-prisma.service');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').Harvest} Harvest */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestInclude} HarvestInclude */
+/**
+ * @typedef {import('@prisma/client').Harvest} Harvest
+ * @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindFirstArgs} HarvestFindFirstArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestInclude} HarvestInclude
+ */
 /* eslint-enable max-len */
 
 module.exports = class HarvestsService extends BasePrismaService {
@@ -41,6 +44,14 @@ module.exports = class HarvestsService extends BasePrismaService {
    */
   findUnique(params) {
     return harvestPrisma.findUnique(params, this.prisma);
+  }
+
+  /**
+   * @param {HarvestFindFirstArgs} params
+   * @returns {Promise<Harvest | null>}
+   */
+  findFirst(params) {
+    return harvestPrisma.findFirst(params, this.prisma);
   }
 
   /**

--- a/api/lib/entities/sushi-credentials.service.js
+++ b/api/lib/entities/sushi-credentials.service.js
@@ -21,6 +21,19 @@ module.exports = class SushiCredentialsService extends BasePrismaService {
   static $transaction = super.$transaction;
 
   /**
+   * Prisma query to find enabled credentials
+   *
+   * @type {import('@prisma/client').Prisma.SushiCredentialsWhereInput}
+   */
+  static enabledCredentialsQuery = {
+    active: true,
+    archived: false,
+    endpoint: {
+      active: true,
+    },
+  };
+
+  /**
    * @param {SushiCredentialsCreateArgs} params
    * @returns {Promise<SushiCredentials>}
    */

--- a/api/lib/services/prisma/harvest.js
+++ b/api/lib/services/prisma/harvest.js
@@ -2,15 +2,18 @@
 const { client: prisma } = require('./index');
 
 /* eslint-disable max-len */
-/** @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient */
-/** @typedef {import('@prisma/client').Harvest} Harvest */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs */
-/** @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs */
+/**
+ * @typedef {import('@prisma/client').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('@prisma/client').Harvest} Harvest
+ * @typedef {import('@prisma/client').Prisma.HarvestUpdateArgs} HarvestUpdateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestUpsertArgs} HarvestUpsertArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindUniqueArgs} HarvestFindUniqueArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindFirstArgs} HarvestFindFirstArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestFindManyArgs} HarvestFindManyArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCountArgs} HarvestCountArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestCreateArgs} HarvestCreateArgs
+ * @typedef {import('@prisma/client').Prisma.HarvestDeleteManyArgs} HarvestDeleteManyArgs
+ */
 /* eslint-enable max-len */
 
 /**
@@ -38,6 +41,15 @@ function findMany(params, tx = prisma) {
  */
 function findUnique(params, tx = prisma) {
   return tx.harvest.findUnique(params);
+}
+
+/**
+ * @param {HarvestFindFirstArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<Harvest | null>}
+ */
+function findFirst(params, tx = prisma) {
+  return tx.harvest.findFirst(params);
 }
 
 /**
@@ -80,6 +92,7 @@ async function removeMany(params, tx = prisma) {
 module.exports = {
   create,
   findMany,
+  findFirst,
   findUnique,
   count,
   update,

--- a/front/app/components/SimpleMetric.vue
+++ b/front/app/components/SimpleMetric.vue
@@ -1,23 +1,35 @@
 <template>
-  <v-sheet
-    class="d-flex flex-column justify-start align-center"
-    style="gap: 10px"
+  <v-card
+    :title="value"
+    :subtitle="title"
+    variant="flat"
+    density="compact"
   >
-    <v-icon :icon="icon" :color="color" size="x-large" />
+    <template #prepend>
+      <slot name="icon">
+        <v-avatar
+          :icon="icon"
+          :class="[`bg-${color}`, 'mr-2']"
+          style="border-radius: 10%;"
+        />
+      </slot>
+    </template>
 
-    <div class="text-center">
-      {{ text }}
-    </div>
-
-    <div>
-      <slot name="actions" />
-    </div>
-  </v-sheet>
+    <template v-if="$slots.actions" #text>
+      <div class="text-end">
+        <slot name="actions" />
+      </div>
+    </template>
+  </v-card>
 </template>
 
 <script setup>
 defineProps({
-  text: {
+  title: {
+    type: String,
+    default: '',
+  },
+  value: {
     type: String,
     default: '',
   },

--- a/front/app/components/SimpleMetric.vue
+++ b/front/app/components/SimpleMetric.vue
@@ -1,6 +1,5 @@
 <template>
   <v-card
-    :title="value"
     :subtitle="title"
     variant="flat"
     density="compact"
@@ -12,6 +11,12 @@
           :class="[`bg-${color}`, 'mr-2']"
           style="border-radius: 10%;"
         />
+      </slot>
+    </template>
+
+    <template #title>
+      <slot name="value">
+        {{ value }}
       </slot>
     </template>
 

--- a/front/app/components/institution/RepositoriesDialog.vue
+++ b/front/app/components/institution/RepositoriesDialog.vue
@@ -4,7 +4,33 @@
     width="600"
     @update:model-value="close()"
   >
+    <LoaderCard v-if="loading" />
+
+    <v-card v-else-if="errorMessage">
+      <v-empty-state
+        :icon="errorIcon"
+        :title="errorMessage"
+      >
+        <template #actions>
+          <v-btn
+            :text="$t('close')"
+            variant="text"
+            @click="isOpen = false"
+          />
+
+          <v-btn
+            :text="$t('retry')"
+            :loading="loading"
+            variant="elevated"
+            color="secondary"
+            @click="refreshForm"
+          />
+        </template>
+      </v-empty-state>
+    </v-card>
+
     <InstitutionRepositories
+      v-else
       :institution="institution"
       show-institution
       @update:model-value="hasChanged = true"
@@ -21,6 +47,8 @@
 </template>
 
 <script setup>
+import { getErrorMessage } from '@/lib/errors';
+
 const emit = defineEmits({
   'update:modelValue': () => true,
 });
@@ -29,11 +57,28 @@ const isOpen = shallowRef(false);
 const hasChanged = shallowRef(false);
 /** @type {Ref<object|null>} */
 const institution = ref(null);
+const loading = shallowRef(false);
+const errorMessage = shallowRef('');
+const errorIcon = shallowRef('');
 
-function open(i) {
+async function open(i) {
   institution.value = i;
   hasChanged.value = false;
   isOpen.value = true;
+
+  if (!i.repositories) {
+    loading.value = true;
+    errorMessage.value = '';
+    errorIcon.value = '';
+
+    try {
+      institution.value.repositories = await $fetch(`/api/institutions/${i.id}/repositories`);
+    } catch (err) {
+      errorMessage.value = getErrorMessage(err, t('anErrorOccurred'));
+      errorIcon.value = err?.statusCode === 404 ? 'mdi-file-hidden' : 'mdi-alert-circle';
+    }
+    loading.value = false;
+  }
 }
 
 function close() {

--- a/front/app/components/institution/RepositoriesDialog.vue
+++ b/front/app/components/institution/RepositoriesDialog.vue
@@ -17,14 +17,6 @@
             variant="text"
             @click="isOpen = false"
           />
-
-          <v-btn
-            :text="$t('retry')"
-            :loading="loading"
-            variant="elevated"
-            color="secondary"
-            @click="refreshForm"
-          />
         </template>
       </v-empty-state>
     </v-card>

--- a/front/app/components/institution/SpacesDialog.vue
+++ b/front/app/components/institution/SpacesDialog.vue
@@ -4,7 +4,33 @@
     width="600"
     @update:model-value="close()"
   >
+    <LoaderCard v-if="loading" />
+
+    <v-card v-else-if="errorMessage">
+      <v-empty-state
+        :icon="errorIcon"
+        :title="errorMessage"
+      >
+        <template #actions>
+          <v-btn
+            :text="$t('close')"
+            variant="text"
+            @click="isOpen = false"
+          />
+
+          <v-btn
+            :text="$t('retry')"
+            :loading="loading"
+            variant="elevated"
+            color="secondary"
+            @click="refreshForm"
+          />
+        </template>
+      </v-empty-state>
+    </v-card>
+
     <InstitutionSpaces
+      v-else
       :institution="institution"
       show-institution
       @update:model-value="hasChanged = true"
@@ -21,6 +47,8 @@
 </template>
 
 <script setup>
+import { getErrorMessage } from '@/lib/errors';
+
 const emit = defineEmits({
   'update:modelValue': () => true,
 });
@@ -29,11 +57,28 @@ const isOpen = shallowRef(false);
 const hasChanged = shallowRef(false);
 /** @type {Ref<object|null>} */
 const institution = ref(null);
+const loading = shallowRef(false);
+const errorMessage = shallowRef('');
+const errorIcon = shallowRef('');
 
-function open(i) {
+async function open(i) {
   institution.value = i;
   hasChanged.value = false;
   isOpen.value = true;
+
+  if (!i.spaces) {
+    loading.value = true;
+    errorMessage.value = '';
+    errorIcon.value = '';
+
+    try {
+      institution.value.spaces = await $fetch(`/api/institutions/${i.id}/spaces`);
+    } catch (err) {
+      errorMessage.value = getErrorMessage(err, t('anErrorOccurred'));
+      errorIcon.value = err?.statusCode === 404 ? 'mdi-file-hidden' : 'mdi-alert-circle';
+    }
+    loading.value = false;
+  }
 }
 
 function close() {

--- a/front/app/components/institution/SpacesDialog.vue
+++ b/front/app/components/institution/SpacesDialog.vue
@@ -17,14 +17,6 @@
             variant="text"
             @click="isOpen = false"
           />
-
-          <v-btn
-            :text="$t('retry')"
-            :loading="loading"
-            variant="elevated"
-            color="secondary"
-            @click="refreshForm"
-          />
         </template>
       </v-empty-state>
     </v-card>

--- a/front/app/components/skeleton/AdminMenu.vue
+++ b/front/app/components/skeleton/AdminMenu.vue
@@ -81,6 +81,13 @@
         </template>
 
         <v-list-item
+          :title="$t('menu.harvest.institutions')"
+          to="/admin/harvests/institutions"
+          prepend-icon="mdi-domain"
+          exact
+        />
+
+        <v-list-item
           :title="$t('menu.harvest.sessions')"
           to="/admin/harvests"
           prepend-icon="mdi-file-tree"

--- a/front/app/components/sushi/Metric.vue
+++ b/front/app/components/sushi/Metric.vue
@@ -1,13 +1,14 @@
 <template>
   <SimpleMetric
-    :text="$t(titleKey, modelValue)"
+    :title="title"
+    :value="`${value}`"
     :icon="icon"
     :color="color"
   >
     <template v-if="actionText" #actions>
       <v-btn
         :text="actionText"
-        :disabled="modelValue <= 0"
+        :disabled="value <= 0"
         :loading="loading"
         size="small"
         variant="outlined"
@@ -19,11 +20,11 @@
 
 <script setup>
 defineProps({
-  modelValue: {
+  value: {
     type: Number,
     required: true,
   },
-  titleKey: {
+  title: {
     type: String,
     required: true,
   },

--- a/front/app/components/sushi/Metric.vue
+++ b/front/app/components/sushi/Metric.vue
@@ -1,14 +1,21 @@
 <template>
   <SimpleMetric
     :title="title"
-    :value="`${value}`"
     :icon="icon"
     :color="color"
   >
+    <template #value>
+      {{ modelValue.total }}
+
+      <span v-if="shouldShowEnabled" style="font-size: 0.65em">
+        {{ $t('sushi.nEnabled', modelValue.enabled) }}
+      </span>
+    </template>
+
     <template v-if="actionText" #actions>
       <v-btn
         :text="actionText"
-        :disabled="value <= 0"
+        :disabled="modelValue.total <= 0"
         :loading="loading"
         size="small"
         variant="outlined"
@@ -19,9 +26,9 @@
 </template>
 
 <script setup>
-defineProps({
-  value: {
-    type: Number,
+const props = defineProps({
+  modelValue: {
+    type: Object,
     required: true,
   },
   title: {
@@ -49,4 +56,10 @@ defineProps({
 defineEmits({
   click: () => true,
 });
+
+const shouldShowEnabled = computed(
+  () => props.modelValue.total > 0
+      && props.modelValue.enabled != null
+      && props.modelValue.total !== props.modelValue.enabled,
+);
 </script>

--- a/front/app/components/sushiEndpoint/SupportedData.vue
+++ b/front/app/components/sushiEndpoint/SupportedData.vue
@@ -237,7 +237,6 @@ const tabs = computed(
 );
 
 const rows = computed(() => {
-  console.log(props.modelValue);
   const entries = Object.entries(innerSupportedData.value[currentVersion.value] ?? {});
   return entries.filter(([, data]) => !!data).sort(([a], [b]) => a.localeCompare(b));
 });

--- a/front/app/components/sushiHarvest/Logs.vue
+++ b/front/app/components/sushiHarvest/Logs.vue
@@ -66,7 +66,7 @@ const entries = computed(
         text,
         color: logColors.get(value) || 'white',
         // Ensure the help URL is a full URL
-        helpUrl: item.Help_URL ? new URL(item.Help_URL, props.endpointUrl) : undefined,
+        helpUrl: item.Help_URL ? new URL(item.Help_URL, props.endpointUrl).href : undefined,
       };
     })
     .sort((a, b) => (a.date < b.date ? -1 : 1)),

--- a/front/app/components/sushiHarvest/session/Credentials.vue
+++ b/front/app/components/sushiHarvest/session/Credentials.vue
@@ -26,7 +26,11 @@
               append-icon="mdi-open-in-new"
               target="_blank"
               rel="noopener noreferrer"
-            />
+            >
+              <template #prepend>
+                <InstitutionAvatar :institution="item" />
+              </template>
+            </v-list-item>
           </v-list>
         </v-col>
 

--- a/front/app/components/sushiHarvest/session/Form.vue
+++ b/front/app/components/sushiHarvest/session/Form.vue
@@ -1,0 +1,538 @@
+<template>
+  <LoaderCard v-if="initialLoading" />
+
+  <v-card v-else-if="institutionsError || endpointsError">
+    <v-empty-state
+      :title="getErrorMessage(institutionsError || endpointsError, t('anErrorOccurred'))"
+      icon="mdi-alert-circle"
+    >
+      <template #actions>
+        <v-btn
+          :text="$t('retry')"
+          :loading="initialLoading"
+          variant="elevated"
+          color="secondary"
+          @click="initialLoading = true; Promise.all([institutionsRefresh, endpointsRefresh])"
+        />
+
+        <v-spacer />
+
+        <slot name="actions" :loading="saving" />
+      </template>
+    </v-empty-state>
+  </v-card>
+
+  <v-card
+    v-else
+    :title="isEditing ? $t('harvest.sessions.update') : $t('harvest.sessions.add')"
+    :subtitle="props.modelValue?.id"
+    prepend-icon="mdi-tractor"
+  >
+    <template #text>
+      <v-row>
+        <v-col>
+          <v-form
+            id="sessionForm"
+            ref="formRef"
+            v-model="valid"
+            @submit.prevent="save()"
+          >
+            <v-card
+              :title="$t('harvest.sessions.credentials')"
+              prepend-icon="mdi-key"
+              variant="outlined"
+            >
+              <template #text>
+                <v-row>
+                  <v-col cols="6">
+                    <v-list
+                      v-model:selected="institutionIds"
+                      lines="two"
+                      density="compact"
+                      height="450"
+                      select-strategy="leaf"
+                      class="credentials-list pa-0"
+                    >
+                      <v-list-subheader sticky>
+                        <v-icon icon="mdi-domain" />
+                        {{ $t('institutions.toolbarTitle', { count: institutionsCount }) }}
+
+                        <v-spacer />
+
+                        <div style="width: 150px">
+                          <v-text-field
+                            v-model="institutionsSearch"
+                            :placeholder="$t('search')"
+                            append-inner-icon="mdi-magnify"
+                            variant="outlined"
+                            density="compact"
+                            hide-details
+                          />
+                        </div>
+                      </v-list-subheader>
+
+                      <v-list-item
+                        v-for="item in institutions"
+                        :key="item.id"
+                        :value="item.id"
+                        :title="item.name"
+                        :subtitle="item.acronym"
+                      >
+                        <template #prepend="{ isSelected, select }">
+                          <v-list-item-action start>
+                            <v-checkbox-btn
+                              :model-value="isSelected"
+                              color="primary"
+                              @update:model-value="select"
+                            />
+                          </v-list-item-action>
+
+                          <InstitutionAvatar :institution="item" />
+                        </template>
+                      </v-list-item>
+                    </v-list>
+                  </v-col>
+
+                  <v-divider vertical />
+
+                  <v-col cols="6">
+                    <v-list
+                      v-model:selected="endpointIds"
+                      lines="two"
+                      density="compact"
+                      height="450"
+                      select-strategy="leaf"
+                      class="credentials-list pa-0"
+                    >
+                      <v-list-subheader sticky>
+                        <v-icon icon="mdi-api" />
+                        {{ $t('endpoints.toolbarTitle', { count: endpointsCount }) }}
+
+                        <v-spacer />
+
+                        <div style="width: 150px">
+                          <v-text-field
+                            v-model="endpointsSearch"
+                            :placeholder="$t('search')"
+                            append-inner-icon="mdi-magnify"
+                            variant="outlined"
+                            density="compact"
+                            hide-details
+                          />
+                        </div>
+                      </v-list-subheader>
+
+                      <v-list-item
+                        v-for="item in endpoints"
+                        :key="item.id"
+                        :value="item.id"
+                        :title="item.vendor"
+                      >
+                        <template #prepend="{ isSelected, select }">
+                          <v-list-item-action start>
+                            <v-checkbox-btn
+                              :model-value="isSelected"
+                              color="primary"
+                              @update:model-value="select"
+                            />
+                          </v-list-item-action>
+                        </template>
+
+                        <template #subtitle>
+                          <SushiEndpointVersionsChip
+                            :model-value="item"
+                            size="small"
+                            density="compact"
+                          />
+                        </template>
+                      </v-list-item>
+                    </v-list>
+                  </v-col>
+                </v-row>
+              </template>
+            </v-card>
+
+            <v-card
+              :title="$t('harvest.sessions.reports')"
+              prepend-icon="mdi-download"
+              variant="outlined"
+              class="mt-4"
+            >
+              <template #text>
+                <v-row>
+                  <v-col cols="6">
+                    <MonthPickerField
+                      v-model="beginDate"
+                      :label="`${$t('harvest.jobs.beginDate')} *`"
+                      :rules="[v => !!v || $t('fieldIsRequired')]"
+                      :max="endDate"
+                      variant="underlined"
+                      prepend-icon="mdi-calendar-start"
+                    />
+                  </v-col>
+
+                  <v-col cols="6">
+                    <MonthPickerField
+                      v-model="endDate"
+                      :label="`${$t('harvest.jobs.endDate')} *`"
+                      :rules="[v => !!v || $t('fieldIsRequired')]"
+                      :min="beginDate"
+                      variant="underlined"
+                      prepend-icon="mdi-calendar-end"
+                    />
+                  </v-col>
+
+                  <v-col cols="6">
+                    <v-list
+                      v-model:selected="counterVersions"
+                      lines="one"
+                      density="compact"
+                      height="250"
+                      select-strategy="leaf"
+                      class="pa-0"
+                    >
+                      <v-list-subheader sticky>
+                        <v-icon icon="mdi-numeric" size="small" />
+                        {{ $t('harvest.sessions.counts.counterVersions', counterVersions.length) }}
+                      </v-list-subheader>
+
+                      <v-list-item
+                        v-for="item in versionsList"
+                        :key="item"
+                        :value="item"
+                      >
+                        <template #prepend="{ isSelected, select }">
+                          <v-list-item-action start>
+                            <v-checkbox-btn
+                              :model-value="isSelected"
+                              color="primary"
+                              @update:model-value="select"
+                            />
+                          </v-list-item-action>
+                        </template>
+
+                        <template #title>
+                          <v-chip
+                            :text="item"
+                            :color="counterVersionsColors.get(item) || 'secondary'"
+                            variant="flat"
+                            density="compact"
+                            label
+                          />
+                        </template>
+                      </v-list-item>
+                    </v-list>
+                  </v-col>
+
+                  <v-divider vertical />
+
+                  <v-col cols="6">
+                    <v-list
+                      v-model:selected="reportTypes"
+                      lines="one"
+                      density="compact"
+                      height="250"
+                      select-strategy="leaf"
+                      class="pa-0"
+                    >
+                      <v-list-subheader sticky>
+                        <v-icon icon="mdi-file" size="small" />
+                        {{ $t('harvest.sessions.counts.reportTypes', reportTypes.length) }}
+                      </v-list-subheader>
+
+                      <v-list-item
+                        v-for="item in reportsList"
+                        :key="item"
+                        :value="item"
+                        :title="item"
+                      >
+                        <template #prepend="{ isSelected, select }">
+                          <v-list-item-action start>
+                            <v-checkbox-btn
+                              :model-value="isSelected"
+                              color="primary"
+                              @update:model-value="select"
+                            />
+                          </v-list-item-action>
+                        </template>
+                      </v-list-item>
+                    </v-list>
+                  </v-col>
+                </v-row>
+              </template>
+            </v-card>
+
+            <v-card
+              :title="$t('harvest.sessions.settings')"
+              prepend-icon="mdi-cog"
+              variant="outlined"
+              class="mt-4"
+            >
+              <template #text>
+                <v-row>
+                  <v-col cols="12">
+                    <v-text-field
+                      v-model="id"
+                      :label="`${$t('name')} *`"
+                      :rules="[v => !!v || $t('fieldIsRequired')]"
+                      :disabled="isEditing"
+                      prepend-icon="mdi-rename"
+                      variant="underlined"
+                      hide-details="auto"
+                    />
+                  </v-col>
+
+                  <v-col cols="6">
+                    <v-checkbox
+                      v-model="sendEndMail"
+                      :label="$t('harvest.sessions.sendEndMail')"
+                      density="compact"
+                      color="primary"
+                      hide-details
+                    />
+                  </v-col>
+
+                  <v-col cols="6">
+                    <v-checkbox
+                      v-model="downloadUnsupported"
+                      :label="$t('harvest.sessions.downloadUnsupported')"
+                      density="compact"
+                      color="primary"
+                      hide-details
+                    />
+                  </v-col>
+
+                  <v-col cols="3">
+                    <v-checkbox
+                      v-model="allowFaulty"
+                      :label="$t('harvest.sessions.allowFaulty')"
+                      density="compact"
+                      color="primary"
+                      hide-details
+                    />
+                  </v-col>
+
+                  <v-col cols="3">
+                    <v-checkbox
+                      v-model="useCache"
+                      :label="$t('harvest.sessions.useCache')"
+                      density="compact"
+                      color="primary"
+                      hide-details
+                    />
+                  </v-col>
+
+                  <v-col cols="3">
+                    <v-checkbox
+                      v-model="useValidation"
+                      :label="$t('harvest.sessions.useValidation')"
+                      density="compact"
+                      color="primary"
+                      hide-details
+                    />
+                  </v-col>
+
+                  <v-col cols="3">
+                    <v-text-field
+                      :model-value="`${timeout}`"
+                      :label="$t('harvest.sessions.timeout')"
+                      :min="0"
+                      :rules="[(v) => !Number.isNaN(Number.parseInt(v, 10)) || $t('invalidFormat')]"
+                      type="number"
+                      prepend-icon="mdi-timer"
+                      variant="underlined"
+                      hide-details="auto"
+                      @update:model-value="timeout = Number.parseInt($event, 10)"
+                    />
+                  </v-col>
+                </v-row>
+              </template>
+            </v-card>
+          </v-form>
+        </v-col>
+      </v-row>
+    </template>
+
+    <template #actions>
+      <v-spacer />
+
+      <slot name="actions" :loading="saving" />
+
+      <v-btn
+        :text="!isEditing ? $t('add') : $t('save')"
+        :prepend-icon="!isEditing ? 'mdi-plus' : 'mdi-content-save'"
+        :disabled="!isValid"
+        :loading="saving"
+        type="submit"
+        form="sessionForm"
+        variant="elevated"
+        color="primary"
+      />
+    </template>
+  </v-card>
+</template>
+
+<script setup>
+import { getErrorMessage } from '@/lib/errors';
+import { DEFAULT_REPORTS_IDS, SUPPORTED_COUNTER_VERSIONS } from '@/lib/sushi';
+
+const props = defineProps({
+  modelValue: {
+    type: Object,
+    default: () => undefined,
+  },
+});
+
+const emit = defineEmits({
+  submit: (item) => !!item,
+});
+
+const snacks = useSnacksStore();
+const { t } = useI18n();
+
+const institutionsSearch = shallowRef('');
+const endpointsSearch = shallowRef('');
+const initialLoading = shallowRef(true);
+const saving = shallowRef(false);
+const valid = shallowRef(false);
+
+const id = shallowRef(props.modelValue?.id ?? '');
+const timeout = shallowRef(props.modelValue?.timeout ?? 600);
+const beginDate = shallowRef(props.modelValue?.beginDate ?? '');
+const endDate = shallowRef(props.modelValue?.endDate ?? '');
+const reportTypes = ref(
+  props.modelValue?.reportTypes?.map((report) => report.toUpperCase())
+  ?? DEFAULT_REPORTS_IDS,
+);
+const counterVersions = ref(props.modelValue?.allowedCounterVersions ?? SUPPORTED_COUNTER_VERSIONS);
+const downloadUnsupported = shallowRef(props.modelValue?.downloadUnsupported ?? false);
+const allowFaulty = shallowRef(props.modelValue?.allowFaulty ?? false);
+const sendEndMail = shallowRef(props.modelValue?.sendEndMail ?? true);
+const useCache = shallowRef(!props.modelValue?.forceDownload);
+const useValidation = shallowRef(!props.modelValue?.ignoreValidation);
+// TODO: credentials to institutions/endpoints (packages ?)
+const institutionIds = ref([...(props.modelValue?.credentialsQuery?.institutionIds ?? [])]);
+const endpointIds = ref([...(props.modelValue?.credentialsQuery?.endpointIds ?? [])]);
+
+/** @type {Ref<Object | null>} */
+const formRef = useTemplateRef('formRef');
+
+const {
+  data: institutions,
+  status: institutionsStatus,
+  error: institutionsError,
+  refresh: institutionsRefresh,
+} = await useFetch('/api/institutions', {
+  lazy: true,
+  query: {
+    size: 0,
+    sort: 'name',
+    q: debouncedRef(institutionsSearch),
+  },
+});
+
+const {
+  data: endpoints,
+  status: endpointsStatus,
+  error: endpointsError,
+  refresh: endpointsRefresh,
+} = await useFetch('/api/sushi-endpoints', {
+  lazy: true,
+  query: {
+    size: 0,
+    sort: 'vendor',
+    q: debouncedRef(endpointsSearch),
+  },
+});
+
+const isEditing = computed(() => !!props.modelValue?.id);
+const institutionsCount = computed(() => {
+  // institutionIds.length || $t('all')
+  if (institutionIds.value.length > 0) {
+    return institutionIds.value.length;
+  }
+  if (endpointIds.value.length > 0) {
+    return t('all');
+  }
+  return 0;
+});
+const endpointsCount = computed(() => {
+  // endpointIds.length || $t('all')
+  if (endpointIds.value.length > 0) {
+    return endpointIds.value.length;
+  }
+  if (institutionIds.value.length > 0) {
+    return t('all');
+  }
+  return 0;
+});
+const reportsList = computed(() => Array.from(new Set([
+  ...DEFAULT_REPORTS_IDS,
+  ...reportTypes.value,
+])));
+const versionsList = computed(() => Array.from(new Set([
+  ...SUPPORTED_COUNTER_VERSIONS,
+  ...counterVersions.value,
+])));
+
+const isValid = computed(() => {
+  if (!valid.value) {
+    return false;
+  }
+
+  return (institutionIds.value.length > 0 || endpointIds.value.length > 0)
+    && reportTypes.value.length > 0
+    && counterVersions.value.length > 0;
+});
+
+async function save() {
+  saving.value = true;
+
+  try {
+    const newSession = await $fetch(`/api/harvests-sessions/${id.value}`, {
+      method: 'PUT',
+      body: {
+        id: id.value,
+        timeout: timeout.value,
+        beginDate: beginDate.value,
+        endDate: endDate.value,
+        downloadUnsupported: downloadUnsupported.value,
+        allowFaulty: allowFaulty.value,
+        sendEndMail: sendEndMail.value,
+        forceDownload: !useCache.value,
+        ignoreValidation: !useValidation.value,
+        reportTypes: reportTypes.value.map((report) => report.toLowerCase()),
+        allowedCounterVersions: counterVersions.value,
+        credentialsQuery: {
+          institutionIds: institutionIds.value,
+          endpointIds: endpointIds.value,
+        },
+      },
+    });
+    emit('submit', newSession);
+  } catch (err) {
+    snacks.error(t('anErrorOccurred'), err);
+  }
+
+  saving.value = false;
+}
+
+watch(() => institutionsStatus.value === 'pending' && endpointsStatus.value === 'pending', (isLoading) => {
+  if (!isLoading) {
+    initialLoading.value = false;
+  }
+});
+</script>
+
+<style scoped>
+.credentials-list :deep(.v-list-subheader__text) {
+  width: 100%;
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+</style>

--- a/front/app/components/sushiHarvest/session/FormDialog.vue
+++ b/front/app/components/sushiHarvest/session/FormDialog.vue
@@ -1,0 +1,46 @@
+<template>
+  <v-dialog
+    v-model="isOpen"
+    width="1200"
+    scrollable
+    persistent
+  >
+    <SushiHarvestSessionForm
+      :model-value="session"
+      @submit="onSave($event)"
+    >
+      <template #actions="{ loading }">
+        <v-btn
+          :text="$t('cancel')"
+          :disabled="loading"
+          variant="text"
+          @click="isOpen = false"
+        />
+      </template>
+    </SushiHarvestSessionForm>
+  </v-dialog>
+</template>
+
+<script setup>
+const emit = defineEmits({
+  submit: (item) => !!item,
+});
+
+const isOpen = shallowRef(false);
+/** @type {Ref<object | undefined>} */
+const session = ref(undefined);
+
+async function open(s) {
+  session.value = s;
+  isOpen.value = true;
+}
+
+function onSave(s) {
+  emit('submit', s);
+  isOpen.value = false;
+}
+
+defineExpose({
+  open,
+});
+</script>

--- a/front/app/components/sushiHarvest/session/Header.vue
+++ b/front/app/components/sushiHarvest/session/Header.vue
@@ -110,10 +110,39 @@
 
         <v-list>
           <v-list-item
+            :title="$t('modify')"
+            :disabled="modelValue.status !== 'prepared'"
+            prepend-icon="mdi-pencil"
+            @click="emit('click:update', modelValue)"
+          />
+
+          <v-list-item
+            :title="$t('delete')"
+            prepend-icon="mdi-delete"
+            @click="deleteSession()"
+          />
+
+          <v-divider />
+
+          <v-list-item
+            :title="$t('harvest.sessions.start')"
+            :disabled="modelValue.status !== 'prepared'"
+            prepend-icon="mdi-play"
+            @click="startSession()"
+          />
+
+          <v-list-item
+            :title="$t('harvest.sessions.stop')"
+            :disabled="modelValue.status !== 'running'"
+            prepend-icon="mdi-stop"
+            @click="stopSession()"
+          />
+
+          <v-list-item
             v-if="clipboard"
             :title="$t('copyId')"
             prepend-icon="mdi-identifier"
-            @click="copyId(item)"
+            @click="copyId()"
           />
         </v-list>
       </v-menu>
@@ -129,9 +158,15 @@ const props = defineProps({
   },
 });
 
+const emit = defineEmits({
+  'update:model-value': (value) => value === null || !!value,
+  'click:update': (value) => !!value,
+});
+
 const { t, locale } = useI18n();
 const snacks = useSnacksStore();
 const { isSupported: clipboard, copy } = useClipboard();
+const { openConfirm } = useDialogStore();
 
 const isCredentialsMenuOpen = shallowRef(false);
 const isReportsMenuOpen = shallowRef(false);
@@ -151,5 +186,49 @@ async function copyId() {
     return;
   }
   snacks.info(t('clipboard.textCopied'));
+}
+
+async function startSession() {
+  try {
+    await $fetch(`/api/harvests-sessions/${props.modelValue.id}/_start`, {
+      method: 'POST',
+    });
+
+    emit('update:model-value', props.modelValue);
+  } catch (err) {
+    snacks.error(t('anErrorOccurred'), err);
+  }
+}
+
+function stopSession() {
+  openConfirm({
+    onAgree: async () => {
+      try {
+        await $fetch(`/api/harvests-sessions/${props.modelValue.id}/_stop`, {
+          method: 'POST',
+        });
+
+        emit('update:model-value', props.modelValue);
+      } catch (err) {
+        snacks.error(t('anErrorOccurred'), err);
+      }
+    },
+  });
+}
+
+function deleteSession() {
+  openConfirm({
+    onAgree: async () => {
+      try {
+        await $fetch(`/api/harvests-sessions/${props.modelValue.id}`, {
+          method: 'DELETE',
+        });
+
+        emit('update:model-value', null);
+      } catch (err) {
+        snacks.error(t('anErrorOccurred'), err);
+      }
+    },
+  });
 }
 </script>

--- a/front/app/pages/admin/endpoints/[id].vue
+++ b/front/app/pages/admin/endpoints/[id].vue
@@ -98,7 +98,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.success || 0"
+              :model-value="sushiMetrics.success || { total: 0 }"
               :title="$t('sushi.operationalCredentials')"
               icon="mdi-check"
               color="success"
@@ -107,7 +107,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.untested || 0"
+              :model-value="sushiMetrics.untested || { total: 0 }"
               :title="$t('sushi.untestedCredentials')"
               :action-text="$t('show')"
               icon="mdi-bell-alert"
@@ -118,7 +118,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.unauthorized || 0"
+              :model-value="sushiMetrics.unauthorized || { total: 0 }"
               :title="$t('sushi.invalidCredentials')"
               :action-text="$t('show')"
               icon="mdi-key-alert-outline"

--- a/front/app/pages/admin/endpoints/[id].vue
+++ b/front/app/pages/admin/endpoints/[id].vue
@@ -98,7 +98,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :value="sushiMetrics.success || 0"
+              :model-value="sushiMetrics.success || 0"
               :title="$t('sushi.operationalCredentials')"
               icon="mdi-check"
               color="success"
@@ -107,7 +107,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :value="sushiMetrics.untested || 0"
+              :model-value="sushiMetrics.untested || 0"
               :title="$t('sushi.untestedCredentials')"
               :action-text="$t('show')"
               icon="mdi-bell-alert"
@@ -118,7 +118,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :value="sushiMetrics.unauthorized || 0"
+              :model-value="sushiMetrics.unauthorized || 0"
               :title="$t('sushi.invalidCredentials')"
               :action-text="$t('show')"
               icon="mdi-key-alert-outline"
@@ -486,7 +486,7 @@ function calcSushiMetrics() {
   const value = Object.fromEntries(
     Object.entries(
       Object.groupBy(sushis.value, (s) => s.connection?.status ?? 'untested') || {},
-    ).map(([k, s]) => [k, s.length]),
+    ).map(([k, s]) => [k, { total: s.length }]),
   );
   value.institutions = institutionsMap.value.size;
 

--- a/front/app/pages/admin/endpoints/[id].vue
+++ b/front/app/pages/admin/endpoints/[id].vue
@@ -44,16 +44,20 @@
     </SkeletonPageBar>
 
     <v-container fluid>
-      <v-row>
-        <v-col cols="6">
-          <template v-if="!sushiMetrics">
-            <v-skeleton-loader
-              height="100"
-              type="avatar, paragraph"
+      <v-row v-if="endpoint">
+        <v-slide-x-transition>
+          <v-col v-if="!endpoint.active" cols="6">
+            <v-alert
+              :title="$t('endpoints.inactive')"
+              :text="$t('endpoints.inactiveDescription')"
+              type="warning"
+              prominent
             />
-          </template>
+          </v-col>
+        </v-slide-x-transition>
 
-          <template v-else-if="sushiMetrics.failed > 0">
+        <v-slide-x-reverse-transition>
+          <v-col v-if="(sushiMetrics?.failed ?? 0) > 0" cols="6">
             <v-alert
               :title="$t('sushi.problematicEndpoint')"
               :text="$t('sushi.nErrsCredentials', sushiMetrics.failed)"
@@ -69,69 +73,61 @@
                 />
               </template>
             </v-alert>
-          </template>
-        </v-col>
+          </v-col>
+        </v-slide-x-reverse-transition>
+      </v-row>
 
-        <v-col v-if="!endpoint.active" cols="6">
-          <v-alert
-            :title="$t('endpoints.inactive')"
-            :text="$t('endpoints.inactiveDescription')"
-            type="warning"
-            prominent
+      <v-row v-if="!sushiMetrics">
+        <v-col v-for="i in 4" :key="i" cols="3">
+          <v-skeleton-loader
+            height="64"
+            type="list-item-avatar"
           />
         </v-col>
       </v-row>
 
-      <v-row class="justify-space-evenly">
-        <template v-if="!sushiMetrics">
-          <v-col v-for="n in 4" :key="n" cols="2">
-            <v-skeleton-loader
-              height="100"
-              type="paragraph"
-            />
-          </v-col>
-        </template>
-
-        <template v-else>
-          <v-col cols="2">
+      <v-slide-y-transition>
+        <v-row v-if="sushiMetrics">
+          <v-col cols="3">
             <SimpleMetric
-              :text="$t('sushi.nInstitutions', sushiMetrics.institutions)"
+              :title="$t('sushi.institutions', sushiMetrics.institutions)"
+              :value="`${sushiMetrics.institutions}`"
               icon="mdi-domain"
             />
           </v-col>
 
-          <v-col cols="2">
+          <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.success || 0"
-              title-key="sushi.nOperationalCredentials"
+              :value="sushiMetrics.success || 0"
+              :title="$t('sushi.operationalCredentials')"
               icon="mdi-check"
               color="success"
             />
           </v-col>
 
-          <v-col cols="2">
+          <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.untested || 0"
+              :value="sushiMetrics.untested || 0"
+              :title="$t('sushi.untestedCredentials')"
               :action-text="$t('show')"
-              title-key="sushi.nUntestedCredentials"
               icon="mdi-bell-alert"
               color="info"
               @click="filters.connection = 'untested'"
             />
           </v-col>
 
-          <v-col cols="2">
+          <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.unauthorized || 0"
+              :value="sushiMetrics.unauthorized || 0"
+              :title="$t('sushi.invalidCredentials')"
               :action-text="$t('show')"
-              title-key="sushi.nInvalidCredentials"
               icon="mdi-key-alert-outline"
               color="warning"
               @click="filters.connection = 'unauthorized'"
             />
           </v-col>
-        </template>
-      </v-row>
+        </v-row>
+      </v-slide-y-transition>
     </v-container>
 
     <v-data-table

--- a/front/app/pages/admin/harvests/index.vue
+++ b/front/app/pages/admin/harvests/index.vue
@@ -7,7 +7,18 @@
       search
       icons
       @update:model-value="debouncedRefresh()"
-    />
+    >
+      <v-btn
+        v-if="harvestSessionFormDialogRef"
+        v-tooltip="$t('harvest.sessions.add')"
+        icon="mdi-plus"
+        variant="tonal"
+        density="comfortable"
+        color="green"
+        class="mr-2"
+        @click="harvestSessionFormDialogRef.open()"
+      />
+    </SkeletonPageBar>
 
     <v-data-iterator :items="sessionsWithStatus" items-per-page="0">
       <template #default="{ items }">
@@ -19,7 +30,11 @@
             :expand-icon="!item.startedAt ? '' : undefined"
           >
             <template #title>
-              <SushiHarvestSessionHeader :model-value="item" />
+              <SushiHarvestSessionHeader
+                :model-value="item"
+                @click:update="harvestSessionFormDialogRef?.open(item)"
+                @update:model-value="refresh()"
+              />
             </template>
 
             <template #text>
@@ -49,6 +64,11 @@
         </div>
       </template>
     </v-data-iterator>
+
+    <SushiHarvestSessionFormDialog
+      ref="harvestSessionFormDialogRef"
+      @submit="refresh()"
+    />
   </div>
 </template>
 
@@ -60,6 +80,8 @@ definePageMeta({
 
 const { t } = useI18n();
 const snacks = useSnacksStore();
+
+const harvestSessionFormDialogRef = useTemplateRef('harvestSessionFormDialogRef');
 
 const {
   data: sessions,

--- a/front/app/pages/admin/harvests/institutions.vue
+++ b/front/app/pages/admin/harvests/institutions.vue
@@ -275,7 +275,14 @@
       :text="$t('institutions.manageN', selected.length)"
     >
       <template #actions>
-        <!--  -->
+        <v-list-item
+          v-if="harvestSessionFormDialogRef"
+          :title="$t('harvest.sessions.add')"
+          prepend-icon="mdi-tractor"
+          @click="harvestSessionFormDialogRef.open({
+            credentialsQuery: { institutionIds: selected },
+          })"
+        />
       </template>
     </SelectionMenu>
 
@@ -287,6 +294,11 @@
     <InstitutionSpacesDialog
       ref="institutionSpacesDialogRef"
       @update:model-value="refresh()"
+    />
+
+    <SushiHarvestSessionFormDialog
+      ref="harvestSessionFormDialogRef"
+      @submit="navigateTo('/admin/harvests')"
     />
   </div>
 </template>
@@ -313,6 +325,7 @@ const harvestedMonth = shallowRef(undefined);
 
 const institutionRepositoriesDialogRef = useTemplateRef('institutionRepositoriesDialogRef');
 const institutionSpacesDialogRef = useTemplateRef('institutionSpacesDialogRef');
+const harvestSessionFormDialogRef = useTemplateRef('harvestSessionFormDialogRef');
 
 const headers = computed(() => [
   {

--- a/front/app/pages/admin/harvests/institutions.vue
+++ b/front/app/pages/admin/harvests/institutions.vue
@@ -184,21 +184,23 @@
         />
       </template>
 
-      <template #[`item.institution._count.repositories`]="{ value }">
+      <template #[`item.institution._count.repositories`]="{ value, item }">
         <v-chip
           :text="`${value}`"
           :color="!value ? 'red' : undefined"
           prepend-icon="mdi-database-outline"
           size="small"
+          @click="institutionRepositoriesDialogRef?.open(item.institution)"
         />
       </template>
 
-      <template #[`item.institution._count.spaces`]="{ value }">
+      <template #[`item.institution._count.spaces`]="{ value, item }">
         <v-chip
           :text="`${value}`"
           :color="!value ? 'orange' : undefined"
           prepend-icon="mdi-tab"
           size="small"
+          @click="institutionSpacesDialogRef?.open(item.institution)"
         />
       </template>
 
@@ -276,6 +278,16 @@
         <!--  -->
       </template>
     </SelectionMenu>
+
+    <InstitutionRepositoriesDialog
+      ref="institutionRepositoriesDialogRef"
+      @update:model-value="refresh()"
+    />
+
+    <InstitutionSpacesDialog
+      ref="institutionSpacesDialogRef"
+      @update:model-value="refresh()"
+    />
   </div>
 </template>
 
@@ -298,6 +310,9 @@ const allowFaulty = shallowRef(false);
 const allowHarvested = shallowRef(false);
 const allEndpointsMustBeUnharvested = shallowRef(false);
 const harvestedMonth = shallowRef(undefined);
+
+const institutionRepositoriesDialogRef = useTemplateRef('institutionRepositoriesDialogRef');
+const institutionSpacesDialogRef = useTemplateRef('institutionSpacesDialogRef');
 
 const headers = computed(() => [
   {

--- a/front/app/pages/admin/harvests/institutions.vue
+++ b/front/app/pages/admin/harvests/institutions.vue
@@ -1,0 +1,447 @@
+<template>
+  <div>
+    <SkeletonPageBar
+      v-model:search="search"
+      :title="$t('institutions.harvestable.title')"
+      :loading="status === 'pending'"
+      :refresh="refresh"
+      icons
+    >
+      <v-menu :close-on-content-click="false" width="600">
+        <template #activator="{ props }">
+          <v-btn
+            v-tooltip="$t('institutions.harvestable.settings')"
+            icon="mdi-cog"
+            variant="tonal"
+            density="comfortable"
+            color="primary"
+            class="mr-2"
+            v-bind="props"
+          />
+        </template>
+
+        <v-card
+          :title="$t('institutions.harvestable.settings')"
+          prepend-icon="mdi-cog"
+        >
+          <template #text>
+            <v-row>
+              <v-col cols="6">
+                <v-switch
+                  v-model="allowNotReady"
+                  :label="$t('institutions.harvestable.allowNotReady')"
+                />
+              </v-col>
+              <v-col cols="6">
+                <v-switch
+                  v-model="allowFaulty"
+                  :label="$t('institutions.harvestable.allowFaulty')"
+                />
+              </v-col>
+              <v-col cols="6">
+                <v-switch
+                  v-model="allowHarvested"
+                  :label="$t('institutions.harvestable.allowHarvested')"
+                />
+              </v-col>
+              <v-col cols="6">
+                <MonthPickerField
+                  v-model="harvestedMonth"
+                  :label="$t('institutions.harvestable.harvestedMonth')"
+                  :max="'2025-10'"
+                  variant="underlined"
+                  density="compact"
+                  hide-details
+                  clearable
+                />
+              </v-col>
+            </v-row>
+          </template>
+        </v-card>
+      </v-menu>
+    </SkeletonPageBar>
+
+    <v-container fluid>
+      <v-row v-if="!data">
+        <v-col v-for="i in 2" :key="i" cols="3">
+          <v-skeleton-loader
+            height="64"
+            type="list-item-avatar"
+          />
+        </v-col>
+      </v-row>
+
+      <v-slide-y-transition>
+        <v-row v-if="data">
+          <v-col cols="3">
+            <SimpleMetric
+              :title="$t('institutions.harvestable.harvestableInstitutions')"
+              icon="mdi-check"
+              color="success"
+            >
+              <template #value>
+                {{ harvestableInstitutions.length }}
+
+                <span
+                  v-if="harvestableInstitutions.length !== selectableInstitutions.length"
+                  style="font-size: 0.65em"
+                >
+                  {{ $t('institutions.harvestable.nSelectable', selectableInstitutions.length) }}
+                </span>
+              </template>
+
+              <template #actions>
+                <v-btn
+                  :text="$t('select')"
+                  :disabled="harvestableInstitutions.length <= 0"
+                  :loading="status === 'pending'"
+                  size="small"
+                  variant="outlined"
+                  @click="selected = selectableInstitutions.map(({ id }) => id)"
+                />
+              </template>
+            </SimpleMetric>
+          </v-col>
+
+          <v-col cols="3">
+            <SimpleMetric
+              :value="`${data.length}`"
+              :title="$t('institutions.harvestable.institutions', data.length)"
+            >
+              <template #icon>
+                <v-menu
+                  location="start center"
+                  offset="5"
+                  open-delay="50"
+                  open-on-hover
+                >
+                  <template #activator="{ props: menu }">
+                    <ProgressCircularStack
+                      :model-value="loaders"
+                      size="40"
+                      class="mr-2"
+                      v-bind="menu"
+                    />
+                  </template>
+
+                  <v-sheet min-width="300">
+                    <v-table density="comfortable">
+                      <tbody>
+                        <tr>
+                          <th colspan="2">
+                            {{ $t('institutions.harvestable.institutions', data.length) }}
+                          </th>
+                        </tr>
+
+                        <template v-for="row in table">
+                          <tr v-if="row.value > 0" :key="row.key">
+                            <td>
+                              <v-icon
+                                v-if="row.icon"
+                                :icon="row.icon"
+                                :color="row.color"
+                                start
+                              />
+
+                              {{ row.label }}
+                            </td>
+
+                            <td class="text-right">
+                              {{ row.value }} ({{ row.percent }})
+                            </td>
+                          </tr>
+                        </template>
+                      </tbody>
+                    </v-table>
+                  </v-sheet>
+                </v-menu>
+              </template>
+            </SimpleMetric>
+          </v-col>
+        </v-row>
+      </v-slide-y-transition>
+    </v-container>
+
+    <v-data-table
+      v-model="selected"
+      v-model:items-per-page="itemsPerPageStored"
+      :items="data"
+      :loading="status === 'pending' && 'primary'"
+      :headers="headers"
+      :search="search"
+      :sort-by="[{ key: 'harvestable.value', order: 'desc' }, { key: 'institution.name', order: 'asc' }]"
+      :items-per-page-options="[10, 25, 50, 100]"
+      item-value="institution.id"
+      show-select
+    >
+      <template #[`item.institution._count.memberships`]="{ item, value }">
+        <v-chip
+          :text="`${value}`"
+          :to="`/admin/institutions/${item.institution.id}/members`"
+          :color="!value ? 'orange' : undefined"
+          prepend-icon="mdi-account-multiple"
+          size="small"
+        />
+      </template>
+
+      <template #[`item.institution._count.repositories`]="{ value }">
+        <v-chip
+          :text="`${value}`"
+          :color="!value ? 'red' : undefined"
+          prepend-icon="mdi-database-outline"
+          size="small"
+        />
+      </template>
+
+      <template #[`item.institution._count.spaces`]="{ value }">
+        <v-chip
+          :text="`${value}`"
+          :color="!value ? 'orange' : undefined"
+          prepend-icon="mdi-tab"
+          size="small"
+        />
+      </template>
+
+      <template #[`item.institution._count.sushiCredentials`]="{ value, item }">
+        <v-chip
+          :text="`${value}`"
+          :to="`/admin/institutions/${item.institution.id}/sushi`"
+          :color="!value ? 'red' : undefined"
+          prepend-icon="mdi-key"
+          size="small"
+        />
+      </template>
+
+      <template #[`item.harvestable.value`]="{ value, item }">
+        <v-menu
+          :disabled="item.harvestable.reasons.length <= 0"
+          :close-on-content-click="false"
+          open-on-hover
+        >
+          <template #activator="{ props }">
+            <v-chip
+              :text="value ? $t('institutions.harvestable.status.harvestable') : $t('institutions.harvestable.status.non-harvestable')"
+              :prepend-icon="value ? 'mdi-check' : 'mdi-close'"
+              :color="value ? 'green' : 'red'"
+              variant="text"
+              v-bind="props"
+            />
+          </template>
+
+          <v-card>
+            <template #text>
+              <v-list>
+                <v-list-item
+                  v-for="reason of item.harvestable.reasons"
+                  :key="reason"
+                  :title="$t(`sushi.isNotHarvestable.reasons.${reason}`)"
+                  prepend-icon="mdi-alert"
+                />
+              </v-list>
+            </template>
+          </v-card>
+        </v-menu>
+      </template>
+
+      <template #[`item.actions`]="{ item }">
+        <v-menu>
+          <template #activator="{ props: menu }">
+            <v-btn
+              icon="mdi-cog"
+              variant="plain"
+              density="compact"
+              v-bind="menu"
+            />
+          </template>
+
+          <v-list>
+            <v-divider />
+
+            <v-list-item
+              v-if="clipboard"
+              :title="$t('copyId')"
+              prepend-icon="mdi-identifier"
+              @click="copyInstitutionId(item)"
+            />
+          </v-list>
+        </v-menu>
+      </template>
+    </v-data-table>
+
+    <SelectionMenu
+      v-model="selected"
+      :text="$t('institutions.manageN', selected.length)"
+    >
+      <template #actions>
+        <!--  -->
+      </template>
+    </SelectionMenu>
+  </div>
+</template>
+
+<script setup>
+definePageMeta({
+  layout: 'admin',
+  middleware: ['sidebase-auth', 'terms', 'admin'],
+});
+
+const { t, locale } = useI18n();
+const { isSupported: clipboard, copy } = useClipboard();
+const snacks = useSnacksStore();
+
+const itemsPerPageStored = useLocalStorage('ezm.itemsPerPage', 10);
+
+const selected = ref([]);
+const search = shallowRef('');
+const allowNotReady = shallowRef(false);
+const allowFaulty = shallowRef(false);
+const allowHarvested = shallowRef(false);
+const allEndpointsMustBeUnharvested = shallowRef(false);
+const harvestedMonth = shallowRef(undefined);
+
+const headers = computed(() => [
+  {
+    title: t('institutions.title'),
+    value: 'institution.name',
+    sortable: true,
+  },
+  {
+    title: t('institutions.institution.members'),
+    value: 'institution._count.memberships',
+    sortable: true,
+    align: 'center',
+  },
+  {
+    title: t('repositories.repositories'),
+    value: 'institution._count.repositories',
+    sortable: true,
+    align: 'center',
+  },
+  {
+    title: t('spaces.spaces'),
+    value: 'institution._count.spaces',
+    sortable: true,
+    align: 'center',
+  },
+  {
+    title: t('sushi.credentials'),
+    value: 'institution._count.sushiCredentials',
+    sortable: true,
+    align: 'center',
+  },
+  {
+    title: t('institutions.institution.status'),
+    value: 'harvestable.value',
+    sortable: true,
+    align: 'center',
+  },
+  {
+    title: t('actions'),
+    value: 'actions',
+    align: 'center',
+  },
+]);
+
+const {
+  data,
+  status,
+  refresh,
+} = await useFetch('/api/institutions/_harvestable', {
+  lazy: true,
+  query: {
+    allowNotReady,
+    allowFaulty,
+    allowHarvested,
+    allEndpointsMustBeUnharvested,
+    harvestedMonth,
+  },
+});
+
+const harvestableInstitutions = computed(
+  () => (data.value ?? [])
+    .filter(({ harvestable }) => harvestable.value)
+    .map(({ institution }) => institution),
+);
+
+const selectableInstitutions = computed(
+  () => harvestableInstitutions.value.filter(
+    /* eslint-disable no-underscore-dangle */
+    (institution) => institution._count.sushiCredentials > 0
+                  && institution._count.repositories > 0,
+    /* eslint-enable no-underscore-dangle */
+  ),
+);
+
+const harvestedInstitutions = computed(
+  () => (data.value ?? [])
+    .filter(({ harvestable }) => harvestable.reasons.length === 1 && harvestable.reasons[0] === 'institutionIsHarvested')
+    .map(({ institution }) => institution),
+);
+
+const loaders = computed(() => [
+  {
+    key: 'selectable',
+    originalValue: selectableInstitutions.value.length,
+    color: 'green',
+    icon: 'mdi-check',
+  },
+  {
+    key: 'harvested',
+    originalValue: harvestedInstitutions.value.length,
+    color: 'blue',
+    icon: 'mdi-cloud',
+  },
+  {
+    key: 'harvestable',
+    originalValue: harvestableInstitutions.value.length - selectableInstitutions.value.length,
+    color: 'orange',
+    icon: 'mdi-alert',
+  },
+  {
+    key: 'non-harvestable',
+    originalValue:
+        (data.value?.length ?? 0)
+        - harvestableInstitutions.value.length
+        - harvestedInstitutions.value.length,
+    color: 'red',
+    icon: 'mdi-close',
+  },
+].map((loader) => ({
+  ...loader,
+  value: loader.originalValue / (data.value?.length ?? 1),
+})));
+
+const table = computed(() => {
+  const formatter = new Intl.NumberFormat(locale.value, { style: 'percent' });
+
+  return loaders.value.map(
+    (loader) => ({
+      key: loader.key,
+      icon: loader.icon,
+      value: loader.originalValue,
+      color: loader.color,
+      label: t(`institutions.harvestable.status.${loader.key}`),
+      percent: formatter.format(loader.value),
+    }),
+  );
+});
+
+/**
+ * Put institution ID into clipboard
+ *
+ * @param {object} param0 Item
+ */
+async function copyInstitutionId({ institution }) {
+  if (!id) {
+    return;
+  }
+
+  try {
+    await copy(institution.id);
+  } catch (err) {
+    snacks.error(t('clipboard.unableToCopy'), err);
+    return;
+  }
+  snacks.info(t('clipboard.textCopied'));
+}
+</script>

--- a/front/app/pages/myspace/institutions/[id]/sushi.vue
+++ b/front/app/pages/myspace/institutions/[id]/sushi.vue
@@ -74,7 +74,7 @@
         <v-row v-if="sushiMetrics?.statuses">
           <v-col cols="3">
             <SushiMetric
-              :value="sushiMetrics.statuses.success"
+              :model-value="sushiMetrics.statuses.success"
               :title="$t('sushi.operationalCredentials')"
               icon="mdi-check"
               color="success"
@@ -83,7 +83,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :value="sushiMetrics.statuses.untested"
+              :model-value="sushiMetrics.statuses.untested"
               :title="$t('sushi.untestedCredentials')"
               :action-text="$t('show')"
               icon="mdi-bell-alert"
@@ -94,7 +94,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :value="sushiMetrics.statuses.unauthorized"
+              :model-value="sushiMetrics.statuses.unauthorized"
               :title="$t('sushi.invalidCredentials')"
               :action-text="$t('show')"
               icon="mdi-key-alert-outline"
@@ -105,7 +105,7 @@
 
           <v-col cols="3">
             <SushiMetric
-              :value="sushiMetrics.statuses.failed"
+              :model-value="sushiMetrics.statuses.failed"
               :title="$t('sushi.problematicEndpoints', sushiMetrics.statuses.failed)"
               :action-text="$t('show')"
               icon="mdi-alert-circle"

--- a/front/app/pages/myspace/institutions/[id]/sushi.vue
+++ b/front/app/pages/myspace/institutions/[id]/sushi.vue
@@ -29,9 +29,27 @@
         variant="tonal"
         color="green"
         class="mr-2"
-        @click="sushiFormRef.open(undefined, { institution })"
+        @click="openForm()"
       />
     </SkeletonPageBar>
+
+    <v-slide-y-transition>
+      <v-banner
+        v-if="isLocked"
+        color="info"
+        icon="mdi-lock"
+        :lines="lockStatus?.reason ? 'two' : 'one'"
+      >
+        <template #text>
+          <div class="font-weight-bold">
+            {{ $t('sushi.managementIsLocked') }}
+          </div>
+          <div v-if="lockStatus?.reason">
+            {{ $t('reason', { reason: lockStatus?.reason }) }}
+          </div>
+        </template>
+      </v-banner>
+    </v-slide-y-transition>
 
     <v-container fluid>
       <v-row>
@@ -43,111 +61,127 @@
         </v-col>
       </v-row>
 
-      <v-row v-if="isLocked">
-        <v-col>
-          <v-alert
-            :title="$t('sushi.managementIsLocked')"
-            :text="lockStatus?.reason ? $t('reason', { reason: lockStatus?.reason }) : undefined"
-            type="info"
-            icon="mdi-lock"
-            variant="outlined"
-            prominent
+      <v-row v-if="!sushiMetrics">
+        <v-col v-for="i in 4" :key="i" cols="3">
+          <v-skeleton-loader
+            height="64"
+            type="list-item-avatar"
           />
         </v-col>
       </v-row>
 
-      <v-row class="justify-space-evenly">
-        <template v-if="!sushiMetrics?.statuses">
-          <v-col v-for="n in 4" :key="n" cols="2">
-            <v-skeleton-loader
-              height="100"
-              type="paragraph"
-            />
-          </v-col>
-        </template>
-
-        <template v-else>
-          <v-col cols="2">
+      <v-slide-y-transition>
+        <v-row v-if="sushiMetrics?.statuses">
+          <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.statuses.success"
-              title-key="sushi.nOperationalCredentials"
+              :value="sushiMetrics.statuses.success"
+              :title="$t('sushi.operationalCredentials')"
               icon="mdi-check"
               color="success"
             />
           </v-col>
 
-          <v-col cols="2">
+          <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.statuses.untested"
+              :value="sushiMetrics.statuses.untested"
+              :title="$t('sushi.untestedCredentials')"
               :action-text="$t('show')"
-              title-key="sushi.nUntestedCredentials"
               icon="mdi-bell-alert"
               color="info"
               @click="query.connection = 'untested'; refresh()"
             />
           </v-col>
 
-          <v-col cols="2">
+          <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.statuses.unauthorized"
+              :value="sushiMetrics.statuses.unauthorized"
+              :title="$t('sushi.invalidCredentials')"
               :action-text="$t('show')"
-              title-key="sushi.nInvalidCredentials"
               icon="mdi-key-alert-outline"
               color="warning"
               @click="query.connection = 'unauthorized'; refresh()"
             />
           </v-col>
 
-          <v-col cols="2">
+          <v-col cols="3">
             <SushiMetric
-              :model-value="sushiMetrics.statuses.failed"
+              :value="sushiMetrics.statuses.failed"
+              :title="$t('sushi.problematicEndpoints', sushiMetrics.statuses.failed)"
               :action-text="$t('show')"
-              title-key="sushi.nProblematicEndpoints"
               icon="mdi-alert-circle"
               color="error"
               @click="query.connection = 'failed'; refresh()"
             />
           </v-col>
-        </template>
-      </v-row>
+        </v-row>
+      </v-slide-y-transition>
 
-      <v-row class="mt-4">
-        <v-col>
-          <v-chip
-            :text="sushiReadyLabels.status.text"
-            :color="sushiReadyLabels.status.color"
-            size="small"
-            variant="outlined"
+      <v-row>
+        <v-col cols="6">
+          <v-card
+            :title="sushiReadyLabels.card.title"
+            :text="sushiReadyLabels.card.text"
+            variant="flat"
+            :class="['border', 'border-opacity-100', `border-${sushiReadyLabels.button.color}`]"
           >
-            <template v-if="!!sushiReadyLabels.status.icon" #prepend>
-              <v-icon :icon="sushiReadyLabels.status.icon" start />
-            </template>
-          </v-chip>
-        </v-col>
+            <template #actions>
+              <v-chip
+                :text="sushiReadyLabels.status.text"
+                :color="sushiReadyLabels.status.color"
+                size="small"
+                variant="outlined"
+              >
+                <template v-if="!!sushiReadyLabels.status.icon" #prepend>
+                  <v-icon :icon="sushiReadyLabels.status.icon" start />
+                </template>
+              </v-chip>
 
-        <v-col class="text-end">
-          <ConfirmPopover
-            v-if="canEdit"
-            :title="sushiReadyLabels.confirm.title"
-            :text="sushiReadyLabels.confirm.text"
-            :agree-icon="sushiReadyLabels.confirm.ok.icon"
-            :agree-text="sushiReadyLabels.confirm.ok.text"
-            :agree="() => toggleSushiReady()"
-            :disagree-text="$t('close')"
-            width="500"
-          >
-            <template #activator="{ props: confirm }">
+              <v-spacer />
+
               <v-btn
                 :text="sushiReadyLabels.button.text"
+                :prepend-icon="sushiReadyLabels.button.icon"
                 :color="sushiReadyLabels.button.color"
-                append-icon="mdi-chevron-down"
+                :loading="sushiReadyLoading"
                 size="small"
                 variant="flat"
-                v-bind="confirm"
+                @click="toggleSushiReady()"
               />
             </template>
-          </ConfirmPopover>
+          </v-card>
         </v-col>
+
+        <v-col v-if="!harvestableLabels">
+          <v-skeleton-loader
+            height="100"
+            type="avatar, paragraph"
+          />
+        </v-col>
+
+        <v-slide-x-reverse-transition>
+          <v-col v-if="harvestableLabels">
+            <v-alert
+              :title="harvestableLabels.title"
+              :type="harvestableLabels.type"
+              :icon="harvestableLabels.icon"
+              variant="tonal"
+            >
+              <template #text>
+                {{ harvestableLabels.text }}
+
+                <ul v-if="(sushiMetrics?.harvestable.reasons.length ?? 0) > 0" class="mt-2">
+                  <li
+                    v-for="reason in sushiMetrics.harvestable.reasons"
+                    :key="reason"
+                    class="font-weight-bold"
+                  >
+                    - {{ $t(`sushi.isNotHarvestable.reasons.${reason}`) }}
+                  </li>
+                </ul>
+              </template>
+            </v-alert>
+          </v-col>
+        </v-slide-x-reverse-transition>
       </v-row>
     </v-container>
 
@@ -179,7 +213,9 @@
               :institution="institution"
               :is-locked="lockStatus?.locked"
               :can-edit="canEdit"
-              :define-tab="(tab) => { tabsData.set(item.value, tab); }"
+              @mounted="tabsData.set(item.value, $event)"
+              @refresh="sushiMetricsRefresh()"
+              @[`update:institution.sushiReadySince`]="toggleSushiReady()"
             />
           </v-tabs-window-item>
         </template>
@@ -213,10 +249,12 @@ const { params } = useRoute();
 const { t } = useI18n();
 const { data: user } = useAuthState();
 const { hasPermission } = useCurrentUserStore();
+const { openConfirm } = useDialogStore();
 const snacks = useSnacksStore();
 
 const tabsData = ref(new Map());
 const currentTabId = shallowRef('');
+const sushiReadyLoading = shallowRef(false);
 
 const sushiFormRef = useTemplateRef('sushiFormRef');
 
@@ -303,14 +341,22 @@ const toolbarTitle = computed(() => {
 /**
  * Sushi ready formatted date
  */
+const isSushiReady = computed(() => institution.value?.sushiReadySince || false);
+/**
+ * Sushi ready formatted date
+ */
 const sushiReadySince = useDateFormat(() => institution.value?.sushiReadySince, 'P');
 /**
  * Sushi ready labels
  */
 const sushiReadyLabels = computed(() => {
-  if (institution.value?.sushiReadySince) {
+  if (isSushiReady.value) {
     // Is ready
     return {
+      card: {
+        title: t('institutions.sushi.resumeMyEntry'),
+        text: t('institutions.sushi.readyPopup.completed', { date: sushiReadySince.value }),
+      },
       status: {
         icon: 'mdi-checkbox-marked-circle-outline',
         color: 'success',
@@ -318,35 +364,51 @@ const sushiReadyLabels = computed(() => {
       },
       button: {
         color: 'secondary',
+        icon: 'mdi-text-box-edit-outline',
         text: t('institutions.sushi.resumeMyEntry'),
-      },
-      confirm: {
-        title: t('institutions.sushi.resumeMyEntry'),
-        text: t('institutions.sushi.readyPopup.completed', { date: sushiReadySince.value }),
-        ok: {
-          icon: 'mdi-text-box-edit-outline',
-          text: t('institutions.sushi.resumeMyEntry'),
-        },
       },
     };
   }
   // Is not ready
   return {
+    card: {
+      title: t('institutions.sushi.validateMyCredentials'),
+      text: t('institutions.sushi.readyPopup.inProgress'),
+    },
     status: {
+      icon: undefined,
+      color: undefined,
       text: t('institutions.sushi.entryInProgress'),
     },
     button: {
       color: 'primary',
+      icon: 'mdi-text-box-check-outline',
       text: t('institutions.sushi.validateMyCredentials'),
     },
-    confirm: {
-      title: t('institutions.sushi.validateMyCredentials'),
-      text: t('institutions.sushi.readyPopup.inProgress'),
-      ok: {
-        icon: 'mdi-text-box-check-outline',
-        text: t('institutions.sushi.validateMyCredentials'),
-      },
-    },
+  };
+});
+/**
+ * Harvestable labels
+ */
+const harvestableLabels = computed(() => {
+  if (!sushiMetrics.value) {
+    return undefined;
+  }
+
+  if (sushiMetrics.value.harvestable.value) {
+    return {
+      title: t('sushi.isHarvestable.title'),
+      text: t('sushi.isHarvestable.text'),
+      type: 'success',
+      icon: 'mdi-check',
+    };
+  }
+
+  return {
+    title: t('sushi.isNotHarvestable.title'),
+    text: t('sushi.isNotHarvestable.text'),
+    type: 'warning',
+    icon: 'mdi-alert',
   };
 });
 
@@ -365,19 +427,43 @@ const debouncedRefresh = useDebounceFn(refresh, 250);
  */
 async function toggleSushiReady() {
   if (!institution.value) {
-    return Promise.reject();
+    return;
   }
 
+  sushiReadyLoading.value = true;
   const value = institution.value.sushiReadySince ? null : new Date();
   try {
     await $fetch(`/api/institutions/${institution.value.id}/sushiReadySince`, {
       method: 'PUT',
       body: { value },
     });
-    return institutionRefresh();
+
+    await institutionRefresh();
+    // fix issue where institution is shown as not ready
+    setTimeout(async () => {
+      await sushiMetricsRefresh();
+    }, 500);
   } catch (err) {
     snacks.error(t('errors.generic'), err);
   }
-  return Promise.resolve();
+  sushiReadyLoading.value = false;
+}
+
+async function openForm() {
+  // Show confirm if already ready
+  if (!user.value.isAdmin && isSushiReady.value) {
+    const shouldUnready = await openConfirm({
+      title: t('institutions.sushi.resumeEntryQuestion'),
+      text: t('institutions.sushi.resumeEntryDesc'),
+    });
+
+    if (!shouldUnready) {
+      return;
+    }
+
+    toggleSushiReady();
+  }
+
+  sushiFormRef.value.open(undefined, { institution: institution.value });
 }
 </script>

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -635,6 +635,7 @@ sushi:
   deletingWaiting: Waiting for deletion
   deletingError: "Unable to delete credentials: {error}"
   deletionTask: Deletion state
+  nEnabled: ({n} enabled)
   institutions: Institution|Institutions
   untestedCredentials: Untested credentials
   invalidCredentials: Invalid credentials

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -36,6 +36,7 @@ menu:
   spaces: Spaces
   harvest:
     group: Harvest
+    institutions: Établissements
     sessions: Sessions
     alerts: Alertes
   sync: Synchronisation

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -635,15 +635,11 @@ sushi:
   deletingWaiting: Waiting for deletion
   deletingError: "Unable to delete credentials: {error}"
   deletionTask: Deletion state
-  nInstitutions: >
-    1 institution use this endpoint
-    |{count} institutions use this endpoint
-  nUntestedCredentials: "{count} untested credentials"
-  nInvalidCredentials: "{count} invalid credentials"
-  nOperationalCredentials: "{count} valid credentials"
-  nProblematicEndpoints: >
-    1 problematic endpoint
-    |{count} problematic endpoints
+  institutions: Institution|Institutions
+  untestedCredentials: Untested credentials
+  invalidCredentials: Invalid credentials
+  operationalCredentials: Valid credentials
+  problematicEndpoints: Problematic endpoint
   nErrsCredentials: >
     1 credential show that endpoint is problematic
     |{count} credentials show that endpoint is problematic
@@ -705,6 +701,16 @@ sushi:
     mistake: I entered the identifiers by mistake
     neverWorked: The access point has never worked for our institution
     duplicate: This identifier is a duplicate of another one
+  isHarvestable:
+    title: Your institution is eligible for harvesting
+    text: Your institution will be included in next harvest session, no action is need from your end.
+  isNotHarvestable:
+    title: Your institution is currently not eligible for harvesting
+    text: 'You need to address the following issues in order to be harvested :'
+    reasons:
+      institutionIsNotReady: Your entry is not complete
+      institutionHasNoCredentials: No COUNTER credentials has been declared
+      institutionHasFaultyCredentials: Some of your credentials have not been tested or are invalid
 reports:
   sushiReturnedErrors: The COUNTER endpoint responded with errors.
   checkCredentials: Check credentials

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -993,6 +993,18 @@ harvest:
     sendEndMail: A mail will be sent on harvest end
     notStarted: Not started
     unableToRetrive: Unable to retrieve harvests
+    add: Create an harvest session
+    update: Update an harvest session
+    start: Start the session
+    stop: Stop the session
+    credentials: COUNTER credentials to harvest
+    reports: COUNTER reports to harvest
+    settings: Harvest settings
+    downloadUnsupported: Download reports even if unsupported by endpoint
+    allowFaulty: Include invalid credentials
+    useCache: Use report cache
+    useValidation: Respect report validation
+    timeout: Délai de complétion des tâches
   jobs:
     title: Harvesting Tasks
     filtersTitle: Filter Tasks
@@ -1199,3 +1211,4 @@ cantCancel: This operation cannot be undone.
 version: Version
 back: Back
 select: Select
+all: All

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -512,6 +512,21 @@ institutions:
     readyPopup:
       inProgress: Your credentials are still being entered. When they are ready to be harvested, declare the completion of your entry by clicking on the button below.
       completed: You have declared the completion of your credentials on {date}. These will be eligible to be included in future harvesting rounds. If adjustments are still needed, please declare it by clicking on the button below.
+    harvestable:
+      title: Harvestable institutions
+      harvestableInstitutions: Harvestables
+      status:
+        harvestable: Harvestable
+        non-harvestable: Non harvestable
+        selectable: Selectable
+        harvested: Already harvested
+      settings: Search settings
+      allowNotReady: Include non ready institutions
+      allowFaulty: Include invalid credentials
+      allowHarvested: Include harvested institutions
+      harvestedMonth: Target period
+      nSelectable: ({n} selectable)
+      institutions: Institutions
   unableToRetriveInformations: Unable to retrieve institution information
   unableToRetrivePlatforms: Unable to retrieve plateform information
   notAttachedToAnyInstitution: You are not attached to any institution, where you have not declared any information about your institution.
@@ -1182,3 +1197,4 @@ deletedSince: Deleted since {date}
 cantCancel: This operation cannot be undone.
 version: Version
 back: Back
+select: Select

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -36,6 +36,7 @@ menu:
   spaces: Espaces
   harvest:
     group: Moissonnage
+    institutions: Établissements
     sessions: Sessions
     alerts: Alertes
   sync: Synchronisation

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -1007,6 +1007,18 @@ harvest:
     sendEndMail: Un mail sera envoyé lors de la fin du moissonnage
     notStarted: Pas encore lancé
     unableToRetrive: Impossible de récupérer les moissonnages
+    add: Créer une session de moissonnage
+    update: Éditer une session de moissonnage
+    start: Démarrer la session
+    stop: Arrêter la session
+    credentials: Identifiants COUNTER à moissonner
+    reports: Rapports COUNTER à moissonner
+    settings: Paramètres de moissonnage
+    downloadUnsupported: Télécharger les rapports même si non supportés par le point d'accès
+    allowFaulty: Inclure les identifiants invalides
+    useCache: Utiliser le cache des rapports
+    useValidation: Respecter la validation des rapports
+    timeout: Délai de complétion des tâches
   jobs:
     title: Tâches de moissonnage
     filtersTitle: Filtrer les tâches
@@ -1212,3 +1224,4 @@ cantCancel: Cette action est irreversible
 version: Version
 back: Retour
 select: Sélectionner
+all: Tous

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -641,21 +641,11 @@ sushi:
   deletingWaiting: En attente de suppression
   deletingError: "Impossible de supprimer l'identifiant: {error}"
   deletionTask: État de suppression
-  nInstitutions: >
-    1 établissement utilise cet endpoint
-    |{count} établissements utilisent cet endpoint
-  nUntestedCredentials: >
-    1 identifiant non testé
-    |{count} identifiants non testés
-  nInvalidCredentials: >
-    1 identifiant invalide
-    |{count} identifiants invalides
-  nOperationalCredentials: >
-    1 identifiant valide
-    |{count} identifiants valides
-  nProblematicEndpoints: >
-    1 point d'accès problématique
-    |{count} points d'accès problématiques
+  institutions: Établissement|Établissements
+  untestedCredentials: Identifiants non testés
+  invalidCredentials: Identifiants invalides
+  operationalCredentials: Identifiants valides
+  problematicEndpoints: Point d'accès problématique|Points d'accès problématiques
   nErrsCredentials: >
     1 identifiant indique que le point d'accès est problématique
     |{count} identifiants indiquent que le point d'accès est problématique
@@ -721,6 +711,16 @@ sushi:
     mistake: J'ai entré(e) ces identifiants par erreur
     neverWorked: Le point d'accès n'a jamais fonctionné pour notre établissement
     duplicate: Cet identifiant est en doublon avec un autre
+  isHarvestable:
+    title: Votre établissement est éligible au moissonnage
+    text: Votre établissement sera inclus dans la prochaine vague de moissonnage, aucune action n'est nécéssaire de votre part.
+  isNotHarvestable:
+    title: Votre établissement n'est actuellement pas éligible au moissonnage
+    text: "Vous devez corriger les problèmes suivants afin d'être moissonné :"
+    reasons:
+      institutionIsNotReady: Votre saisie n'est pas terminée
+      institutionHasNoCredentials: Aucun identifiant COUNTER n'a été déclaré
+      institutionHasFaultyCredentials: Certains de vos identifiants n'ont pas été testés ou sont invalides
 reports:
   sushiReturnedErrors: Le point d'accès COUNTER a retourné des erreurs.
   checkCredentials: Vérifier les identifiants

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -516,6 +516,21 @@ institutions:
     readyPopup:
       inProgress: Vos identifiants sont encore en cours de saisie. Lorsque ces derniers seront prêts à être moissonnés, déclarez la fin de votre saisie en cliquant sur le bouton ci-dessous.
       completed: Vous avez déclaré la fin de saisie de vos identifiants le {date}. Ces derniers pourront faire partie des prochaines vagues de moissonnage. Si des ajustements sont encore nécessaires, déclarez-le en cliquant sur le bouton ci-dessous.
+  harvestable:
+    title: Établissements moissonnables
+    harvestableInstitutions: Moissonnables
+    status:
+      harvestable: Moissonnable
+      non-harvestable: Non moissonable
+      selectable: Sélectionnable
+      harvested: Déjà moissonné
+    settings: Paramètres de recherche
+    allowNotReady: Inclure les établissements non prêts
+    allowFaulty: Inclure les identifiants invalides
+    allowHarvested: Inclure les établissements déjà moissonnés
+    harvestedMonth: Période cible
+    nSelectable: (1 sélectionnable)|({n} sélectionnables)
+    institutions: Établissement|Établissements
   unableToRetriveInformations: Impossible de récupérer les informations d'établissement
   unableToRetrivePlatforms: Impossible de récupérer les informations d'établissement
   notAttachedToAnyInstitution: Vous n'êtes rattachés à aucun établissement, où vous n'avez déclaré aucunes informations sur votre établissement.
@@ -1195,3 +1210,4 @@ deletedSince: Supprimé depuis le {date}
 cantCancel: Cette action est irreversible
 version: Version
 back: Retour
+select: Sélectionner

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -641,6 +641,7 @@ sushi:
   deletingWaiting: En attente de suppression
   deletingError: "Impossible de supprimer l'identifiant: {error}"
   deletionTask: État de suppression
+  nEnabled: (1 actif)|({n} actifs)
   institutions: Établissement|Établissements
   untestedCredentials: Identifiants non testés
   invalidCredentials: Identifiants invalides


### PR DESCRIPTION
# API

- [x] Added route to get if institution is harvestable
- [x] Added route to get harvestable institutions
- [x] Added "enabled" metrics to COUNTER credentials
- [ ] Added doc

# Front

- [x] Revamped COUNTER credentials metrics
<img width="1323" height="199" alt="image" src="https://github.com/user-attachments/assets/677264be-274b-4bb9-868c-23d6ec94c63b" />

- [x] Shows if institution is harvestable
<img width="1341" height="293" alt="image" src="https://github.com/user-attachments/assets/600ecbae-a9d5-4299-bbbc-44bab840cbee" />
<img width="1340" height="199" alt="image" src="https://github.com/user-attachments/assets/c64a9ed9-3175-463b-88e7-7514debe96eb" />


- [x] Added page to get harvestable institutions
<img width="301" height="94" alt="image" src="https://github.com/user-attachments/assets/64892eb8-cd2c-41bc-8a1b-2f9a52c830fe" />
<img width="1343" height="836" alt="image" src="https://github.com/user-attachments/assets/8687c822-cb9a-415a-a5fe-25c656b1b390" />

- [x] Can now create/edit/start/stop/delete harvest session from the interface 
<img width="1207" height="916" alt="image" src="https://github.com/user-attachments/assets/0bc28483-ffd5-433f-988b-b1f100e2b4a0" />
<img width="531" height="361" alt="image" src="https://github.com/user-attachments/assets/94c6aaa6-cc4d-4467-9177-4352870052c0" />
