### PR TITLE
Feature/emails summary

### DIFF
--- a/api/config/custom-environment-variables.json
+++ b/api/config/custom-environment-variables.json
@@ -48,6 +48,18 @@
       }
     }
   },
+  "emails": {
+    "summary": {
+      "schedule": "EZMESURE_EMAILS_SUMMARY_SCHEDULE"
+    },
+    "cleanup": {
+      "schedule": "EZMESURE_EMAILS_CLEANUP_SCHEDULE",
+      "maxDayAge": {
+        "__name": "EZMESURE_EMAILS_CLEANUP_MAX_DAY_AGE",
+        "__format": "number"
+      }
+    }
+  },
   "notifications": {
     "cron": "EZMESURE_NOTIFICATIONS_CRON",
     "sender": "EZMESURE_NOTIFICATIONS_SENDER",

--- a/api/config/default.js
+++ b/api/config/default.js
@@ -34,6 +34,15 @@ module.exports = {
     secure: false,
     ignoreTLS: false,
   },
+  emails: {
+    summary: {
+      schedule: '0 0 * * * *',
+    },
+    cleanup: {
+      schedule: '0 0 * * * *',
+      maxDayAge: 7,
+    },
+  },
   ezreeport: {
     host: 'reporting',
     port: 8080,

--- a/api/lib/controllers/auth/actions.js
+++ b/api/lib/controllers/auth/actions.js
@@ -1,10 +1,8 @@
 const config = require('config');
-const { add, format } = require('date-fns');
-const { fr } = require('date-fns/locale');
+const { add } = require('date-fns');
 
 const { getPermissionsFromPreset, mergePresets } = require('../../utils/roles');
-const { getNotificationRecipients } = require('../../utils/notifications');
-const { EVENT_TYPES, ADMIN_NOTIFICATION_TYPES } = require('../../utils/notifications/constants');
+const { EVENT_TYPES } = require('../../utils/notifications/constants');
 const { signJWT } = require('../../utils/jwt');
 
 const UsersService = require('../../entities/users.service');
@@ -23,6 +21,7 @@ const { schema: membershipSchema, includableFields: includableMembershipFields }
 const { schema: elasticRoleSchema, includableFields: includableElasticRoleFields } = require('../../entities/elastic-roles.dto');
 
 const { deleteDurationDays } = config.get('users');
+const publicUrl = config.get('publicUrl');
 
 // Query params for sub routes
 
@@ -92,7 +91,7 @@ exports.getCurrentUserElasticRoles = async (ctx) => {
 };
 
 exports.deleteCurrentUser = async (ctx) => {
-  const { username, email } = ctx.state.user;
+  const { username, email, language } = ctx.state.user;
 
   const deletedAt = add(new Date(), { days: deleteDurationDays });
 
@@ -106,19 +105,21 @@ exports.deleteCurrentUser = async (ctx) => {
   appLogger.verbose(`User [${username}] will be deleted at [${deletedAt.toISOString()}]`);
 
   try {
-    const admins = await getNotificationRecipients(
-      ADMIN_NOTIFICATION_TYPES.userRequestDeletion,
-      [email],
-    );
-
     await sendMail({
       to: email,
-      bcc: admins,
       subject: 'Votre demande de suppression à bien été prise en compte',
-      ...generateMail('user-deletion-requested', {
-        deletedAt: format(deletedAt, 'PPPp', { locale: fr }),
-        isFromUser: true,
-      }),
+      ...generateMail(
+        'user-deletion-requested',
+        {
+          loginURL: new URL('/authenticate', publicUrl).href,
+          deletedAt,
+          isFromUser: true,
+        },
+        {
+          locale: language,
+          subjectKey: 'subject.fromUser',
+        },
+      ),
     });
   } catch (err) {
     appLogger.error(`Failed to send mail to ${email}: ${err}`);

--- a/api/lib/controllers/auth/actions.js
+++ b/api/lib/controllers/auth/actions.js
@@ -107,7 +107,6 @@ exports.deleteCurrentUser = async (ctx) => {
   try {
     await sendMail({
       to: email,
-      subject: 'Votre demande de suppression à bien été prise en compte',
       ...generateMail(
         'user-deletion-requested',
         {

--- a/api/lib/controllers/auth/activate/mail.js
+++ b/api/lib/controllers/auth/activate/mail.js
@@ -1,8 +1,5 @@
 const { sendMail, generateMail } = require('../../../services/mail');
 
-const { getNotificationRecipients } = require('../../../utils/notifications');
-const { ADMIN_NOTIFICATION_TYPES } = require('../../../utils/notifications/constants');
-
 /**
  * @typedef {import('../../entities/users.service').User} User
  */
@@ -35,15 +32,7 @@ exports.sendActivateUserMail = (user, activateLink) => sendMail({
  *
  * @returns {Promise<void>}
  */
-exports.sendNewUserToContact = async (user, data) => {
-  const admins = await getNotificationRecipients(
-    ADMIN_NOTIFICATION_TYPES.newUserMatchingInstitution,
-    [user.email],
-  );
-
-  return sendMail({
-    to: user.email,
-    bcc: admins,
-    ...generateMail('new-account', { user, ...data }, { locale: user.language }),
-  });
-};
+exports.sendNewUserToContact = (user, data) => sendMail({
+  to: user.email,
+  ...generateMail('new-account', { user, ...data }, { locale: user.language }),
+});

--- a/api/lib/controllers/index.js
+++ b/api/lib/controllers/index.js
@@ -39,6 +39,7 @@ const activity = require('./activity');
 const actions = require('./actions');
 const sync = require('./sync');
 const kibanaBridge = require('./kibana-bridge');
+const outgoingEmails = require('./outgoing-emails');
 
 const openapi = require('./openapi.json');
 
@@ -97,6 +98,7 @@ app.use(kibana.prefix('/kibana').middleware());
 app.use(actions.prefix('/actions').middleware());
 app.use(activity.prefix('/activity').middleware());
 app.use(sync.prefix('/sync').middleware());
+app.use(outgoingEmails.prefix('/outgoing-emails').middleware());
 
 app.use(kibanaBridge.prefix('/_kbb').middleware());
 

--- a/api/lib/controllers/institutions/actions.js
+++ b/api/lib/controllers/institutions/actions.js
@@ -49,17 +49,11 @@ const { PERMISSIONS } = require('../../entities/memberships.dto');
 
 async function sendValidateInstitutionMail(receivers, data) {
   try {
-    const admins = await getNotificationRecipients(
-      ADMIN_NOTIFICATION_TYPES.institutionValidated,
-      receivers.map((receiver) => receiver.email),
-    );
-
     return await Promise.allSettled(
       receivers.map(async (receiver) => {
         try {
           await sendMail({
             to: receiver.email,
-            bcc: admins,
             ...generateMail('validate-institution', data, { locale: receiver.language }),
           });
 

--- a/api/lib/controllers/institutions/admin.js
+++ b/api/lib/controllers/institutions/admin.js
@@ -6,24 +6,18 @@ const { appLogger } = require('../../services/logger');
 const InstitutionsService = require('../../entities/institutions.service');
 const UsersService = require('../../entities/users.service');
 
-const { getNotificationRecipients, getNotificationMembershipWhere } = require('../../utils/notifications');
-const { NOTIFICATION_TYPES, ADMIN_NOTIFICATION_TYPES } = require('../../utils/notifications/constants');
+const { getNotificationMembershipWhere } = require('../../utils/notifications');
+const { NOTIFICATION_TYPES } = require('../../utils/notifications/constants');
 
 const publicUrl = config.get('publicUrl');
 
 async function sendValidateInstitutionMail(receivers, data) {
   try {
-    const admins = await getNotificationRecipients(
-      ADMIN_NOTIFICATION_TYPES.institutionValidated,
-      receivers.map((receiver) => receiver.email),
-    );
-
     return await Promise.allSettled(
       receivers.map(async (receiver) => {
         try {
           await sendMail({
             to: receiver.email,
-            bcc: admins,
             ...generateMail('validate-institution', data, { locale: receiver.language }),
           });
 

--- a/api/lib/controllers/institutions/memberships/actions.js
+++ b/api/lib/controllers/institutions/memberships/actions.js
@@ -41,11 +41,8 @@ async function sendNewAssignedRole(receiver, institutionName, role) {
     role,
   };
 
-  const admins = await getNotificationRecipients(ADMIN_NOTIFICATION_TYPES.roleAssigned, [email]);
-
   return sendMail({
     to: email,
-    bcc: admins,
     ...generateMail('assigned-role', { data }, { locale: language }),
   });
 }

--- a/api/lib/controllers/outgoing-emails/actions.js
+++ b/api/lib/controllers/outgoing-emails/actions.js
@@ -1,0 +1,48 @@
+const OutgoingEmailsService = require('../../entities/outgoing-emails.service');
+
+const { schema, includableFields } = require('../../entities/outgoing-emails.dto');
+const { prepareStandardQueryParams } = require('../../services/std-query');
+
+const standardQueryParams = prepareStandardQueryParams({
+  schema,
+  includableFields,
+  queryFields: ['id', 'subject'],
+});
+exports.standardQueryParams = standardQueryParams;
+
+exports.getAll = async (ctx) => {
+  const prismaQuery = standardQueryParams.getPrismaManyQuery(ctx);
+
+  const emailsService = new OutgoingEmailsService();
+
+  ctx.type = 'json';
+  ctx.status = 200;
+  ctx.set('X-Total-Count', await emailsService.count({ where: prismaQuery.where }));
+  ctx.body = await emailsService.findMany(prismaQuery);
+};
+
+exports.getOne = async (ctx) => {
+  const { id } = ctx.params;
+
+  const prismaQuery = standardQueryParams.getPrismaOneQuery(ctx, { id });
+
+  const emailsService = new OutgoingEmailsService();
+  const email = await emailsService.findUnique(prismaQuery);
+
+  if (!email) {
+    ctx.throw(404, ctx.$t('errors.email.notFound'));
+    return;
+  }
+
+  ctx.status = 200;
+  ctx.body = email;
+};
+
+exports.deleteOne = async (ctx) => {
+  const { id } = ctx.params;
+
+  const emailsService = new OutgoingEmailsService();
+  await emailsService.delete({ where: { id } });
+
+  ctx.status = 204;
+};

--- a/api/lib/controllers/outgoing-emails/index.js
+++ b/api/lib/controllers/outgoing-emails/index.js
@@ -1,0 +1,52 @@
+const router = require('koa-joi-router')();
+const { Joi } = require('koa-joi-router');
+
+const {
+  requireActiveJwt,
+  requireUser,
+  requireAdmin,
+} = require('../../services/auth');
+
+const {
+  standardQueryParams,
+
+  getAll,
+  getOne,
+  deleteOne,
+} = require('./actions');
+
+router.use(requireActiveJwt, requireUser, requireAdmin);
+
+router.route({
+  method: 'GET',
+  path: '/',
+  handler: getAll,
+  validate: {
+    query: standardQueryParams.manyValidation,
+  },
+});
+
+router.route({
+  method: 'GET',
+  path: '/:id',
+  handler: getOne,
+  validate: {
+    params: {
+      id: Joi.string().trim().required(),
+    },
+    query: standardQueryParams.oneValidation,
+  },
+});
+
+router.route({
+  method: 'DELETE',
+  path: '/:id',
+  handler: deleteOne,
+  validate: {
+    params: {
+      id: Joi.string().trim().required(),
+    },
+  },
+});
+
+module.exports = router;

--- a/api/lib/controllers/users/actions.js
+++ b/api/lib/controllers/users/actions.js
@@ -1,8 +1,6 @@
 const config = require('config');
 const { add } = require('date-fns');
 
-const { getNotificationRecipients } = require('../../utils/notifications');
-const { ADMIN_NOTIFICATION_TYPES } = require('../../utils/notifications/constants');
 const { signJWE } = require('../../utils/jwt');
 
 const { appLogger } = require('../../services/logger');
@@ -311,14 +309,8 @@ exports.deleteUser = async (ctx) => {
   appLogger.verbose(`User [${username}] will be deleted at [${deletedAt.toISOString()}]`);
 
   try {
-    const admins = await getNotificationRecipients(
-      ADMIN_NOTIFICATION_TYPES.userRequestDeletion,
-      [user.email],
-    );
-
     await sendMail({
       to: user.email,
-      bcc: admins,
       ...generateMail(
         'user-deletion-requested',
         {

--- a/api/lib/entities/outgoing-emails.dto.js
+++ b/api/lib/entities/outgoing-emails.dto.js
@@ -1,0 +1,37 @@
+const { Joi } = require('koa-joi-router');
+
+/**
+ * Base schema
+ * @type {Record<string, import('joi').AnySchema>}
+ */
+const schema = {
+  id: Joi.string().trim(),
+  sentAt: Joi.date(),
+
+  recipients: Joi.array().items(Joi.string().trim().email()),
+
+  status: Joi.string().trim(),
+  subject: Joi.string().allow(''),
+  locale: Joi.string().trim(),
+  template: Joi.string().trim(),
+  errors: Joi.array().items(Joi.string().trim()),
+};
+
+/**
+ * Fields that cannot be changed but could be found in a request body
+ */
+const immutableFields = [
+  'id',
+];
+
+/**
+ * Fields that can be populated with related items
+ */
+const includableFields = [];
+
+module.exports = {
+  schema,
+  allFields: Object.keys(schema),
+  immutableFields,
+  includableFields,
+};

--- a/api/lib/entities/outgoing-emails.service.js
+++ b/api/lib/entities/outgoing-emails.service.js
@@ -1,0 +1,76 @@
+// @ts-check
+const BasePrismaService = require('./base-prisma.service');
+const outgoingEmailsPrisma = require('../services/prisma/outgoing-emails');
+
+/* eslint-disable max-len */
+/** @typedef {import('../.prisma/client.mts').Prisma.BatchPayload} BatchPayload */
+/** @typedef {import('../.prisma/client.mts').OutgoingEmail} OutgoingEmail */
+/** @typedef {import('../.prisma/client.mts').Prisma.OutgoingEmailUpdateArgs} OutgoingEmailUpdateArgs */
+/** @typedef {import('../.prisma/client.mts').Prisma.OutgoingEmailUpsertArgs} OutgoingEmailUpsertArgs */
+/** @typedef {import('../.prisma/client.mts').Prisma.OutgoingEmailFindUniqueArgs} OutgoingEmailFindUniqueArgs */
+/** @typedef {import('../.prisma/client.mts').Prisma.OutgoingEmailFindManyArgs} OutgoingEmailFindManyArgs */
+/** @typedef {import('../.prisma/client.mts').Prisma.OutgoingEmailCreateArgs} OutgoingEmailCreateArgs */
+/** @typedef {import('../.prisma/client.mts').Prisma.OutgoingEmailCountArgs} OutgoingEmailCountArgs */
+/** @typedef {import('../.prisma/client.mts').Prisma.OutgoingEmailDeleteManyArgs} OutgoingEmailDeleteManyArgs */
+/* eslint-enable max-len */
+
+module.exports = class OutgoingEmailsService extends BasePrismaService {
+  /** @type {BasePrismaService.TransactionFnc<OutgoingEmailsService>} */
+  static $transaction = super.$transaction;
+
+  /**
+   * @param {OutgoingEmailCreateArgs} params
+   * @returns {Promise<OutgoingEmail>}
+   */
+  create(params) {
+    return outgoingEmailsPrisma.create(params, this.prisma);
+  }
+
+  /**
+   * @param {OutgoingEmailFindManyArgs} params
+   * @returns {Promise<OutgoingEmail[]>}
+   */
+  findMany(params) {
+    return outgoingEmailsPrisma.findMany(params, this.prisma);
+  }
+
+  /**
+   * @param {OutgoingEmailFindUniqueArgs} params
+   * @returns {Promise<OutgoingEmail | null>}
+   */
+  findUnique(params) {
+    return outgoingEmailsPrisma.findUnique(params, this.prisma);
+  }
+
+  /**
+   * @param {OutgoingEmailUpdateArgs} params
+   * @returns {Promise<OutgoingEmail>}
+   */
+  update(params) {
+    return outgoingEmailsPrisma.update(params, this.prisma);
+  }
+
+  /**
+   * @param {OutgoingEmailUpsertArgs} params
+   * @returns {Promise<OutgoingEmail>}
+   */
+  upsert(params) {
+    return outgoingEmailsPrisma.upsert(params, this.prisma);
+  }
+
+  /**
+   * @param {OutgoingEmailCountArgs} params
+   * @returns {Promise<number>}
+   */
+  count(params) {
+    return outgoingEmailsPrisma.count(params, this.prisma);
+  }
+
+  /**
+   * @param {OutgoingEmailCountArgs} params
+   * @returns {Promise<BatchPayload>}
+   */
+  deleteMany(params) {
+    return outgoingEmailsPrisma.deleteMany(params, this.prisma);
+  }
+};

--- a/api/lib/hooks/emails/index.js
+++ b/api/lib/hooks/emails/index.js
@@ -1,0 +1,2 @@
+// @ts-check
+require('./outgoing-emails');

--- a/api/lib/hooks/emails/outgoing-emails.js
+++ b/api/lib/hooks/emails/outgoing-emails.js
@@ -1,0 +1,72 @@
+// @ts-check
+const { registerHook } = require('../hookEmitter');
+const { appLogger } = require('../../services/logger');
+
+const OutgoingEmailsService = require('../../entities/outgoing-emails.service');
+
+/**
+ * @typedef {import('nodemailer').SendMailOptions} SendMailOptions
+ * @typedef {import('nodemailer/lib/smtp-pool').SentMessageInfo} SentMessageInfo
+ *
+ * @typedef {object} EmailSentHookPayload
+ * @prop {SendMailOptions} options - The options of the mail
+ * @prop {SentMessageInfo} [result] - The result, if the sendMail() function succeeded
+ * @prop {Error | null} [error] - The error, if the sendMail() function failed
+ * @prop {import('../../services/mail').SendMailMeta} [meta] - Email metadata
+ */
+
+/**
+ * @param {EmailSentHookPayload} payload
+ */
+const onEmailSent = async (payload) => {
+  appLogger.verbose('[emails][hooks] Saving outgoing email');
+
+  const {
+    options,
+    result,
+    error,
+    meta,
+  } = payload ?? {};
+
+  // If everything went fine, the normalized recipient list is in the envelope
+  let recipients = result?.envelope?.to;
+
+  if (!Array.isArray(recipients) && options?.to) {
+    // If the envelope is not available, get the recipients from the mail options
+    const to = Array.isArray(options.to) ? options.to : [options.to];
+
+    recipients = to.map((recipient) => {
+      if (typeof recipient === 'string') {
+        return recipient;
+      }
+      return recipient?.address;
+    });
+  }
+
+  const errors = [];
+
+  if (error) {
+    errors.push(error.message);
+  }
+
+  if (Array.isArray(result?.rejectedErrors) && result.rejectedErrors.length > 0) {
+    errors.push(...result.rejectedErrors.map((e) => e.message));
+  }
+
+  try {
+    await (new OutgoingEmailsService()).create({
+      data: {
+        recipients,
+        subject: options?.subject,
+        status: error ? 'failed' : 'sent',
+        template: meta?.templateName,
+        locale: meta?.locale,
+        errors,
+      },
+    });
+  } catch (err) {
+    appLogger.error(`[emails][hooks] Failed to save outgoing email: ${err}`);
+  }
+};
+
+registerHook('email:sent', onEmailSent, { queue: 'outgoing-emails' });

--- a/api/lib/hooks/index.js
+++ b/api/lib/hooks/index.js
@@ -7,5 +7,6 @@ require('./kibana');
 require('./harvest');
 require('./users');
 require('./onboarding');
+require('./emails');
 
 module.exports = hookEmitter;

--- a/api/lib/services/crons/outgoing-emails.js
+++ b/api/lib/services/crons/outgoing-emails.js
@@ -1,0 +1,150 @@
+// @ts-check
+const { CronJob } = require('cron');
+const config = require('config');
+
+const { subDays } = require('date-fns');
+
+const { getNotificationRecipients } = require('../../utils/notifications');
+const { ADMIN_NOTIFICATION_TYPES } = require('../../utils/notifications/constants');
+
+const OutgoingEmailsService = require('../../entities/outgoing-emails.service');
+
+const { appLogger } = require('../logger');
+const { sendMail, generateMail } = require('../mail');
+
+/**
+ * @typedef {import('../../.prisma/client.mts').User} User
+ */
+
+const summaryCron = config.get('emails.summary.schedule');
+const cleanupCron = config.get('emails.cleanup.schedule');
+const maxDayAge = config.get('emails.cleanup.maxDayAge');
+
+// Email types that should not be included in the summary, since they are directly sent to admins
+const emailTypesToIgnore = [
+  'outgoing-emails-summary',
+  'contact',
+  'recent-activity',
+  'sushi-ready-change',
+];
+
+let lastSummaryDate = new Date();
+
+async function sendEmailsSummaryToAdmins() {
+  appLogger.verbose('[emails-summary] Sending a summary of sent emails...');
+
+  const outgoingEmails = await (new OutgoingEmailsService()).findMany({
+    where: {
+      sentAt: {
+        gte: lastSummaryDate,
+      },
+      OR: [
+        { template: null },
+        { template: { notIn: emailTypesToIgnore } },
+      ],
+    },
+  });
+
+  if (outgoingEmails.length === 0) {
+    appLogger.verbose('[emails-summary] No email to summerize');
+    lastSummaryDate = new Date();
+    return;
+  }
+
+  const admins = await getNotificationRecipients(ADMIN_NOTIFICATION_TYPES.emailsSummary);
+
+  /**
+   * @type {{
+   *   totalFailed: number,
+   *   totalByType: Record<string, number>,
+   * }}
+   */
+  const summary = {
+    totalFailed: 0,
+    totalByType: {},
+  };
+
+  outgoingEmails.forEach((email) => {
+    if (email.status === 'failed') {
+      summary.totalFailed += 1;
+    }
+
+    const template = email.template ?? 'unknown';
+
+    if (summary.totalByType[template]) {
+      summary.totalByType[template] += 1;
+    } else {
+      summary.totalByType[template] = 1;
+    }
+  }, { totalFailed: 0, totalByType: {} });
+
+  await Promise.all(
+    admins.map(async (user) => {
+      try {
+        await sendMail({
+          to: user.email,
+          ...generateMail(
+            'outgoing-emails-summary',
+            {
+              emails: outgoingEmails,
+              summary,
+            },
+            {
+              locale: user.language ?? undefined,
+            },
+          ),
+        });
+      } catch (err) {
+        appLogger.error(`[emails-summary] Failed to send mail to [${user.email}]`, err);
+      }
+    }),
+  );
+
+  appLogger.verbose(`[emails-summary] Sent a summary of ${outgoingEmails.length} emails to ${admins.length} admins`);
+
+  lastSummaryDate = new Date();
+}
+
+async function cleanupEmails() {
+  const limit = subDays(new Date(), maxDayAge);
+  appLogger.verbose(`[emails-cleanup] Cleaning up outgoing emails older than ${limit.toISOString()}...`);
+
+  const { count } = await (new OutgoingEmailsService()).deleteMany({
+    where: {
+      sentAt: {
+        lte: limit,
+      },
+    },
+  });
+
+  appLogger.verbose(`[emails-cleanup] Cleaned up ${count} emails`);
+}
+
+async function startEmailsSummaryCron() {
+  const job = CronJob.from({
+    cronTime: summaryCron,
+    runOnInit: true,
+    onTick: async () => {
+      await sendEmailsSummaryToAdmins();
+    },
+  });
+
+  job.start();
+}
+
+async function startEmailsCleanupCron() {
+  const job = CronJob.from({
+    cronTime: cleanupCron,
+    runOnInit: true,
+    onTick: async () => {
+      await cleanupEmails();
+    },
+  });
+
+  job.start();
+}
+
+module.exports = {
+  startEmailsSummaryCron,
+  startEmailsCleanupCron,
+};

--- a/api/lib/services/crons/outgoing-emails.js
+++ b/api/lib/services/crons/outgoing-emails.js
@@ -76,7 +76,7 @@ async function sendEmailsSummaryToAdmins() {
     } else {
       summary.totalByType[template] = 1;
     }
-  }, { totalFailed: 0, totalByType: {} });
+  });
 
   await Promise.all(
     admins.map(async (user) => {

--- a/api/lib/services/crons/users.js
+++ b/api/lib/services/crons/users.js
@@ -3,9 +3,6 @@ const { CronJob } = require('cron');
 const config = require('config');
 const { isValid, startOfDay } = require('date-fns');
 
-const { getNotificationRecipients } = require('../../utils/notifications');
-const { ADMIN_NOTIFICATION_TYPES } = require('../../utils/notifications/constants');
-
 const UsersService = require('../../entities/users.service');
 
 const { appLogger } = require('../logger');
@@ -55,17 +52,11 @@ async function deleteMarkedUsers() {
 
   appLogger.verbose(`[user-deletion] Deleted ${deletedUsers.length} users`);
 
-  const admins = await getNotificationRecipients(
-    ADMIN_NOTIFICATION_TYPES.userDeleted,
-    // No need to exclude as users are deleted
-  );
-
   await Promise.all(
     deletedUsers.map(async (user) => {
       try {
         await sendMail({
           to: user.email,
-          bcc: admins.map((admin) => admin.email),
           ...generateMail('user-deleted', {}, { locale: user.language }),
         });
       } catch (err) {

--- a/api/lib/services/mail.js
+++ b/api/lib/services/mail.js
@@ -8,8 +8,12 @@ const { camelCase } = require('lodash');
 const { smtp, publicUrl, notifications } = require('config');
 
 const i18n = require('./i18n');
+const { triggerHooks } = require('../hooks/hookEmitter');
+
+const metaKey = Symbol('meta');
 
 /** @typedef {import('mjml-core').MJMLParseError} MJMLParseError */
+/** @typedef {nodemailer.SendMailOptions} SendMailOptions */
 
 const templatesDir = path.resolve(__dirname, '../../templates');
 const imagesDir = path.resolve(templatesDir, 'images');
@@ -20,13 +24,39 @@ nunjucks.configure(templatesDir);
 const images = fs.readdirSync(imagesDir);
 
 /**
+ * @typedef {object} SendMailMeta
+ * @property {string} templateName - The name of the template used
+ * @property {string} locale - The locale used
+ */
+
+/**
+ * @typedef {object} GenerateMailOptions
+ * @property {string | null} [locale] - The locale to use for translations
+ * @property {string | null} [subjectKey] - The key to use for the subject. Defaults to "subject".
+ */
+
+/**
+ * @typedef {object} GenerateMailReturn
+ * @property {string} subject - The mail subject
+ * @property {string} html - The mail body in HTML
+ * @property {string} text - The mail body in text
+ * @property {MJMLParseError[]} errors - The errors found while parsing the MJML template
+ * @property {SendMailMeta} meta - Email metadata
+ */
+
+/**
  * Send mail with given options
  *
- * @param {nodemailer.SendMailOptions} mailOptions - The options of mail
+ * @param {SendMailOptions & { [metaKey]?: string }} sendMailOptions - The options of mail
  *
  * @returns {Promise<nodemailer.SentMessageInfo>}
  */
-module.exports.sendMail = (mailOptions) => {
+module.exports.sendMail = async (sendMailOptions) => {
+  const {
+    [metaKey]: meta = {},
+    ...mailOptions
+  } = sendMailOptions;
+
   const options = {
     from: notifications.sender,
     replyTo: notifications.replyTo || undefined,
@@ -42,14 +72,19 @@ module.exports.sendMail = (mailOptions) => {
     });
   });
 
-  return transporter.sendMail(options);
-};
+  let result;
 
-/**
- * @typedef {object} GenerateMailOptions
- * @property {string} [locale] - The locale to use for translations
- * @property {string} [subjectKey] - The key to use for the subject. Defaults to "subject".
- */
+  try {
+    result = await transporter.sendMail(options);
+  } catch (error) {
+    triggerHooks('email:sent', { options, error, meta });
+    throw error;
+  }
+
+  triggerHooks('email:sent', { options, result, meta });
+
+  return result;
+};
 
 /**
  * Generate a mail with a registered template
@@ -58,7 +93,7 @@ module.exports.sendMail = (mailOptions) => {
  * @param {Record<string, unknown>} [locals] local variables to be used in the template
  * @param {GenerateMailOptions} [opts] options
  *
- * @returns {{ html: string, text: string, errors: MJMLParseError[] }}
+ * @returns {GenerateMailReturn}
  */
 module.exports.generateMail = (templateName, locals = {}, opts = {}) => {
   if (!templateName) { throw new Error('No template name provided'); }
@@ -81,6 +116,10 @@ module.exports.generateMail = (templateName, locals = {}, opts = {}) => {
   const { html, errors } = mjml2html(mjmlTemplate);
 
   return {
+    [metaKey]: {
+      templateName,
+      locale: opts.locale,
+    },
     subject,
     html,
     text,

--- a/api/lib/services/prisma/outgoing-emails.js
+++ b/api/lib/services/prisma/outgoing-emails.js
@@ -1,0 +1,90 @@
+// @ts-check
+const { client: prisma } = require('./index');
+
+/* eslint-disable max-len */
+/**
+ * @typedef {import('../../.prisma/client.mjs').Prisma.TransactionClient} TransactionClient
+ * @typedef {import('../../.prisma/client.mjs').Prisma.BatchPayload} BatchPayload
+ * @typedef {import('../../.prisma/client.mjs').OutgoingEmail} OutgoingEmail
+ * @typedef {import('../../.prisma/client.mjs').Prisma.OutgoingEmailUpdateArgs} OutgoingEmailUpdateArgs
+ * @typedef {import('../../.prisma/client.mjs').Prisma.OutgoingEmailUpsertArgs} OutgoingEmailUpsertArgs
+ * @typedef {import('../../.prisma/client.mjs').Prisma.OutgoingEmailFindUniqueArgs} OutgoingEmailFindUniqueArgs
+ * @typedef {import('../../.prisma/client.mjs').Prisma.OutgoingEmailFindManyArgs} OutgoingEmailFindManyArgs
+ * @typedef {import('../../.prisma/client.mjs').Prisma.OutgoingEmailCreateArgs} OutgoingEmailCreateArgs
+ * @typedef {import('../../.prisma/client.mjs').Prisma.OutgoingEmailCountArgs} OutgoingEmailCountArgs
+ * @typedef {import('../../.prisma/client.mjs').Prisma.OutgoingEmailDeleteManyArgs} OutgoingEmailDeleteManyArgs
+ */
+/* eslint-enable max-len */
+
+/**
+ * @param {OutgoingEmailCreateArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<OutgoingEmail>}
+ */
+function create(params, tx = prisma) {
+  return tx.outgoingEmail.create(params);
+}
+
+/**
+ * @param {OutgoingEmailFindManyArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<OutgoingEmail[]>}
+ */
+function findMany(params, tx = prisma) {
+  return tx.outgoingEmail.findMany(params);
+}
+
+/**
+ * @param {OutgoingEmailFindUniqueArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<OutgoingEmail | null>}
+ */
+function findUnique(params, tx = prisma) {
+  return tx.outgoingEmail.findUnique(params);
+}
+
+/**
+ * @param {OutgoingEmailUpdateArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<OutgoingEmail>}
+ */
+function update(params, tx = prisma) {
+  return tx.outgoingEmail.update(params);
+}
+
+/**
+ * @param {OutgoingEmailUpsertArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<OutgoingEmail>}
+ */
+function upsert(params, tx = prisma) {
+  return tx.outgoingEmail.upsert(params);
+}
+
+/**
+ * @param {OutgoingEmailCountArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<number>}
+ */
+function count(params, tx = prisma) {
+  return tx.outgoingEmail.count(params);
+}
+
+/**
+ * @param {OutgoingEmailDeleteManyArgs} params
+ * @param {TransactionClient} [tx]
+ * @returns {Promise<BatchPayload>}
+ */
+function deleteMany(params, tx = prisma) {
+  return tx.outgoingEmail.deleteMany(params);
+}
+
+module.exports = {
+  create,
+  findMany,
+  findUnique,
+  update,
+  upsert,
+  count,
+  deleteMany,
+};

--- a/api/lib/utils/notifications/constants.js
+++ b/api/lib/utils/notifications/constants.js
@@ -23,16 +23,12 @@ const NOTIFICATION_TYPES = {
 };
 
 const ADMIN_NOTIFICATION_TYPES = applyModifier({
-  ...NOTIFICATION_TYPES,
+  membershipRequest: NOTIFICATION_TYPES.membershipRequest,
 
   counterReadyChange: 'institution:counter_ready_change',
-
-  userRequestDeletion: 'user:request_deletion',
-  userDeleted: 'user:auto_deleted',
-
   contactForm: 'contact:form',
-
   appRecentActivity: 'app:recent_activity',
+  emailsSummary: 'app:outgoing_emails_summary',
 }, 'admin');
 
 const NOTIFICATION_KEYS = [

--- a/api/locales/en.yml
+++ b/api/locales/en.yml
@@ -192,6 +192,7 @@ emails:
     file: File
     index: Index
     package: Package
+    total: Total
 
   layout:
     body:
@@ -326,3 +327,28 @@ emails:
     title: An error has happened
     body:
       headline: An error has happened in ezMESURE.
+
+  outgoingEmailsSummary:
+    subject: "[Admin] Outgoing emails summary"
+    body:
+      title: Outgoing emails summary
+      headline: Outgoing emails summary
+      p1: "{{ count }} emails has recently been sent. Please find the summary below."
+      hasFailedEmails: "{{ count }} emails has encountered errors during their delivery."
+      detailedList: Detailed list
+      recipients: Recipients
+      subject: Subject
+      template: Template
+      emailsCount: "Number of emails"
+      status:
+        sent: Sent
+        failed: Failed
+      types:
+        assigned-role: New role assigned
+        harvest-end: Harvest end
+        new-account: Collaborator registration
+        request-membership: Institution join request
+        user-deleted: Account deletion confirmation
+        user-deletion-requested: Account deletion request
+        validate-institution: Institution validated
+        welcome: Welcome to ezMESURE

--- a/api/locales/fr.yml
+++ b/api/locales/fr.yml
@@ -186,6 +186,7 @@ emails:
     file: Fichier
     index: Index
     package: Package
+    total: Total
 
   layout:
     body:
@@ -320,3 +321,28 @@ emails:
     title: Une erreur est survenue
     body:
       headline: Une erreur est survenue sur ezMESURE.
+
+  outgoingEmailsSummary:
+    subject: "[Admin] Rapport des envois de mails"
+    body:
+      title: Rapport des envois de mails
+      headline: Rapport des envois de mails
+      p1: "{{ count }} emails ont récemment été envoyés. Voici un résumé de ces envois :"
+      hasFailedEmails: "{{ count }} emails ont rencontré des problèmes lors de leur envoi."
+      detailedList: Liste détaillée
+      recipients: Destinataires
+      subject: Objet
+      template: Modèle
+      emailsCount: Nombre d'emails
+      status:
+        sent: Envoyé
+        failed: Échec
+      types:
+        assigned-role: Nouveau rôle assigné
+        harvest-end: Fin de moissonnage
+        new-account: Inscription d'un collaborateur
+        request-membership: Demande d'intégration à un établissement
+        user-deleted: Confirmation de suppression de compte
+        user-deletion-requested: Demande de suppression de compte
+        validate-institution: Établissement validé
+        welcome: Bienvenue sur ezMESURE

--- a/api/prisma/models/outgoing-email.prisma
+++ b/api/prisma/models/outgoing-email.prisma
@@ -1,0 +1,29 @@
+/// Possible statuses of an outgoing email
+enum OutgoingEmailStatus {
+  /// The mail has been sent
+  sent
+  /// The mail has been sent and delivered
+  delivered
+  /// The mail failed to be sent
+  failed
+}
+
+/// Represent outgoing emails
+model OutgoingEmail {
+  /// Message ID
+  id         String              @id @default(cuid())
+  /// Email recipients
+  recipients String[]
+  /// Date when the email has been sent
+  sentAt     DateTime            @default(now())
+  /// Email subject
+  status     OutgoingEmailStatus
+  /// Email subject
+  subject    String?
+  /// Email locale
+  locale     String?              @db.VarChar(5)
+  /// Name of the email template
+  template   String?
+  /// The error messages, if any
+  errors     String[]
+}

--- a/api/prisma/models/outgoing-email.prisma
+++ b/api/prisma/models/outgoing-email.prisma
@@ -2,8 +2,6 @@
 enum OutgoingEmailStatus {
   /// The mail has been sent
   sent
-  /// The mail has been sent and delivered
-  delivered
   /// The mail failed to be sent
   failed
 }

--- a/api/server.js
+++ b/api/server.js
@@ -4,7 +4,6 @@ const Koa = require('koa');
 const mount = require('koa-mount');
 const cors = require('@koa/cors');
 const config = require('config');
-const path = require('path');
 const { setTimeout } = require('timers/promises');
 const { STATUS_CODES } = require('http');
 
@@ -26,6 +25,7 @@ const harvest = require('./lib/services/crons/harvest');
 const cronMetrics = require('./lib/services/crons/metrics');
 const users = require('./lib/services/crons/users');
 const testUsers = require('./lib/services/crons/test-users');
+const outgoingEmails = require('./lib/services/crons/outgoing-emails');
 
 /**
  * Register hooks. Must not be called elsewhere. Some services can both
@@ -156,6 +156,8 @@ function start() {
   cronMetrics.start();
   users.startDeletionCron();
   testUsers.startExpiredCron();
+  outgoingEmails.startEmailsSummaryCron();
+  outgoingEmails.startEmailsCleanupCron();
 
   const server = app.listen(config.port);
   server.setTimeout(1000 * 60 * 30);

--- a/api/templates/outgoing-emails-summary.mjml
+++ b/api/templates/outgoing-emails-summary.mjml
@@ -1,0 +1,85 @@
+{% extends "layout.mjml" %}
+
+{% macro statusColor(status) %}
+{% if status == 'sent' %}
+#008000
+{% elif status == 'failed' %}
+#ff0000
+{% else %}
+#005eff
+{% endif %}
+{% endmacro %}
+
+{% block title %}
+<mj-title>{{ t('emails.outgoingEmailsSummary.body.title') }}</mj-title>
+{% endblock %}
+
+{% block content %}
+
+<mj-section>
+  <mj-column>
+    <mj-text mj-class="headline">{{ t('emails.outgoingEmailsSummary.body.headline') }}</mj-text>
+
+    {% if summary.totalFailed > 0 %}
+    <mj-text>
+      <div style="color: #ff0000">⚠️ {{ t('emails.outgoingEmailsSummary.body.hasFailedEmails', { count: summary.totalFailed }) }}</div>
+    </mj-text>
+    {% endif %}
+
+    <mj-text>
+      {{ t('emails.outgoingEmailsSummary.body.p1', { count: emails.length }) }}
+    </mj-text>
+  <mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-table cellpadding="5px">
+      <thead>
+        <tr style="text-align: left; border-bottom: 1px solid #d0d0d0">
+          <th>{{ t('emails.outgoingEmailsSummary.body.template') }}</th>
+          <th style="text-align: right">{{ t('emails.outgoingEmailsSummary.body.emailsCount') }}</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        {% for type, count in summary.totalByType %}
+        <tr style="border-bottom: 1px solid #d0d0d0">
+          <td>{{ t('emails.outgoingEmailsSummary.body.types.' + type) }}</td>
+          <td style="text-align: right">{{ count }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </mj-table>
+  </mj-column>
+</mj-section>
+
+<mj-section>
+  <mj-column>
+    <mj-text mj-class="subheading">{{ t('emails.outgoingEmailsSummary.body.detailedList') }}</mj-text>
+
+    <mj-table cellpadding="5px">
+      <thead>
+        <tr style="text-align: left; border-bottom: 1px solid #d0d0d0">
+          <th>{{ t('emails.outgoingEmailsSummary.body.subject') }}</th>
+          <th style="width: 200px">{{ t('emails.outgoingEmailsSummary.body.recipients') }}</th>
+          <th style="width: 130px">{{ t('emails.global.date') }}</th>
+          <th style="width: 50px">{{ t('emails.global.status') }}</th>
+        </tr>
+      </thead>
+
+      <tbody>
+        {% for email in emails %}
+        <tr style="border-bottom: 1px solid #d0d0d0">
+          <td>{{ email.subject }}</td>
+          <td>{{ email.recipients | join(", ") }}</td>
+          <td>{{ d(email.sentAt, 'Pp') }}</td>
+          <td style="color: {{ statusColor(email.status) | trim }}">{{ t('emails.outgoingEmailsSummary.body.status.' + email.status) }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </mj-table>
+  </mj-column>
+</mj-section>
+
+{% endblock %}

--- a/api/templates/outgoing-emails-summary.txt
+++ b/api/templates/outgoing-emails-summary.txt
@@ -1,0 +1,20 @@
+{{ t('emails.outgoingEmailsSummary.body.headline') }}
+
+{% if summary.totalFailed > 0 %}
+⚠️ {{ t('emails.outgoingEmailsSummary.body.hasFailedEmails', { count: summary.totalFailed }) }}
+{% endif %}
+
+{{- t('emails.outgoingEmailsSummary.body.p1', { count: emails.length }) }}
+
+{% for type, count in summary.totalByType %}
+  - {{ t('emails.outgoingEmailsSummary.body.types.' + type) }}: {{ count }}
+{%- endfor %}
+
+{{ t('emails.outgoingEmailsSummary.body.detailedList') }}
+
+{%- for email in emails %}
+  - {{ email.subject }}
+    {{ email.recipients | join(", ") }}
+    {{ d(email.sentAt, 'Pp') }}
+    {{ t('emails.outgoingEmailsSummary.body.status.' + email.status) }}
+{% endfor %}

--- a/front/app/components/currentUser/settings/NotificationsForm.vue
+++ b/front/app/components/currentUser/settings/NotificationsForm.vue
@@ -112,18 +112,16 @@ const NOTIFICATION_TYPES = [
   'institution:role_assigned',
 
   'counter:new_data_available',
-
 ];
 
 const ADMIN_NOTIFICATION_TYPES = [
+  'institution:membership_request',
   'institution:counter_ready_change',
-
-  'user:request_deletion',
-  'user:auto_deleted',
 
   'contact:form',
 
   'app:recent_activity',
+  'app:outgoing_emails_summary',
 ];
 
 const authStore = useAuthStore();
@@ -140,10 +138,7 @@ const error = ref(undefined);
 const availableOptions = computed(() => {
   const isAdmin = currentTab.value === 'admin';
 
-  const types = [
-    ...NOTIFICATION_TYPES,
-    ...(isAdmin ? ADMIN_NOTIFICATION_TYPES : []),
-  ];
+  const types = isAdmin ? ADMIN_NOTIFICATION_TYPES : NOTIFICATION_TYPES;
 
   const scopesMap = new Map();
 

--- a/front/i18n/locales/en.yaml
+++ b/front/i18n/locales/en.yaml
@@ -126,6 +126,8 @@ myspace:
           admin: An institution has been harvested
         app:recent_activity:
           admin: Recent activity on application
+        app:outgoing_emails_summary:
+          admin: Summary of sent emails
       alerts:
         updated:
           title: Your notification settings has been applied

--- a/front/i18n/locales/fr.yaml
+++ b/front/i18n/locales/fr.yaml
@@ -126,6 +126,8 @@ myspace:
           admin: Un établissement a été moissonné
         app:recent_activity:
           admin: Activité récente de l'application
+        app:outgoing_emails_summary:
+          admin: Résumé des emails envoyés
       alerts:
         updated:
           title: Vos paramètres de notifications ont été appliqués


### PR DESCRIPTION
# Changes

Regularly send a summary of outgoing emails to the admins, instead of setting them in the BCC of all emails.

## API
- [x] Added an OutgoingEmail entity to temporarly save emails
- [x] Added an `email:sent` hook that save ougoing emails to the database
- [x] Added two crons to send regular digest of outgoing emails to admins and cleanup emails after a given period of time
- [x] Add some routes under `/api/outgoing-emails` to get or delete saved emails (no update needed here)

## Front
- [x] Removed notification types that are not used anymore from the account settings

<img width="717" height="858" alt="image" src="https://github.com/user-attachments/assets/9d9982ef-ea42-401d-a293-45b0d22037b1" />
