### PR TITLE
Fix/tests

### DIFF
--- a/api/test/features/custom-fields/create.test.mjs
+++ b/api/test/features/custom-fields/create.test.mjs
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeEach, beforeAll, afterAll,
+  describe, it, expect, beforeEach, beforeAll,
 } from 'vitest';
 import config from 'config';
 
@@ -7,10 +7,10 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import customFieldsPrisma from '../../../lib/services/prisma/custom-fields';
 
 const adminUsername = config.get('admin.username');
@@ -43,7 +43,7 @@ describe('[custom-fields]: Test create features', () => {
     let adminToken;
 
     beforeAll(async () => {
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe('Create new custom field', () => {
@@ -81,7 +81,7 @@ describe('[custom-fields]: Test create features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Create new custom field', () => {

--- a/api/test/features/custom-fields/delete.test.mjs
+++ b/api/test/features/custom-fields/delete.test.mjs
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeEach, beforeAll, afterAll,
+  describe, it, expect, beforeEach, beforeAll,
 } from 'vitest';
 import config from 'config';
 
@@ -7,10 +7,10 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import customFieldsPrisma from '../../../lib/services/prisma/custom-fields';
 
 const adminUsername = config.get('admin.username');
@@ -44,7 +44,7 @@ describe('[repositories]: Test delete features', () => {
     let adminToken;
 
     beforeAll(async () => {
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe('Delete custom field', () => {
@@ -72,7 +72,7 @@ describe('[repositories]: Test delete features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Delete custom field', () => {

--- a/api/test/features/custom-fields/read.test.mjs
+++ b/api/test/features/custom-fields/read.test.mjs
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeAll, afterAll,
+  describe, it, expect, beforeAll,
 } from 'vitest';
 import config from 'config';
 
@@ -7,10 +7,10 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import customFieldsPrisma from '../../../lib/services/prisma/custom-fields';
 
 const adminUsername = config.get('admin.username');
@@ -44,7 +44,7 @@ describe('[custom-fields]: Test read features', () => {
     let adminToken;
 
     beforeAll(async () => {
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe('Get custom field', () => {
@@ -76,7 +76,7 @@ describe('[custom-fields]: Test read features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Get custom field', () => {

--- a/api/test/features/dashboards/templates/create.test.mjs
+++ b/api/test/features/dashboards/templates/create.test.mjs
@@ -12,8 +12,8 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
-import { createSpace, deleteSpace, importObjects } from '../../../../lib/services/kibana';
 import { signJWT } from '../../../../lib/utils/jwt';
+import { createSpace, deleteSpace, importObjects } from '../../../../lib/services/kibana';
 
 import usersPrisma from '../../../../lib/services/prisma/users';
 import dashboardsPrisma from '../../../../lib/services/prisma/dashboards';

--- a/api/test/features/dashboards/templates/refresh.test.mjs
+++ b/api/test/features/dashboards/templates/refresh.test.mjs
@@ -12,8 +12,8 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
-import { createSpace, deleteSpace, importObjects } from '../../../../lib/services/kibana';
 import { signJWT } from '../../../../lib/utils/jwt';
+import { createSpace, deleteSpace, importObjects } from '../../../../lib/services/kibana';
 
 import usersPrisma from '../../../../lib/services/prisma/users';
 import dashboardsPrisma from '../../../../lib/services/prisma/dashboards';

--- a/api/test/features/indices/create.test.mjs
+++ b/api/test/features/indices/create.test.mjs
@@ -7,11 +7,11 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import indicesPrisma from '../../../lib/services/elastic/indices';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
 
@@ -30,7 +30,7 @@ describe('[indices]: Test create features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername);
+    adminToken = await signJWT({ username: adminUsername });
   });
 
   describe('As admin', () => {
@@ -58,7 +58,7 @@ describe('[indices]: Test create features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     it(`#02 Should not create index [${indexName}]`, async () => {

--- a/api/test/features/indices/delete.test.mjs
+++ b/api/test/features/indices/delete.test.mjs
@@ -7,15 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import indicesPrisma from '../../../lib/services/elastic/indices';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
 
-import UsersService from '../../../lib/entities/users.service';
-
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[indices]: Test delete features', () => {
   const userTest = {
@@ -31,7 +29,7 @@ describe('[indices]: Test delete features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     beforeEach(async () => {
@@ -60,7 +58,7 @@ describe('[indices]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     beforeEach(async () => {
       await indicesPrisma.create(indexName, null, { ignore: [404] });

--- a/api/test/features/institutions/create.test.mjs
+++ b/api/test/features/institutions/create.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions]: Test create features', () => {
   const userTest = {
@@ -33,7 +32,7 @@ describe('[institutions]: Test create features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
 
   describe('As admin', () => {
@@ -103,7 +102,7 @@ describe('[institutions]: Test create features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     it(`#02 Should create new institution [${institutionTest.name}]`, async () => {
       const httpAppResponse = await ezmesure.raw('/institutions', {

--- a/api/test/features/institutions/custom-props/add.test.mjs
+++ b/api/test/features/institutions/custom-props/add.test.mjs
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeEach, afterAll,
+  describe, it, expect, beforeEach,
 } from 'vitest';
 import config from 'config';
 
@@ -9,10 +9,10 @@ import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import customFieldsPrisma from '../../../../lib/services/prisma/custom-fields';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 const adminUsername = config.get('admin.username');
 
@@ -58,7 +58,7 @@ describe('[institutions - custom-props] Add', () => {
     let adminToken;
 
     beforeEach(async () => {
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     it('#01 Should be able to add a custom prop', async () => {
@@ -101,7 +101,7 @@ describe('[institutions - custom-props] Add', () => {
         },
       });
 
-      memberToken = await (new UsersService()).generateToken(userTest.username);
+      memberToken = await signJWT({ username: userTest.username });
     });
 
     it('#02 Should not be able to add a custom prop', async () => {

--- a/api/test/features/institutions/custom-props/read.test.mjs
+++ b/api/test/features/institutions/custom-props/read.test.mjs
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeEach, afterAll,
+  describe, it, expect, beforeEach,
 } from 'vitest';
 import config from 'config';
 
@@ -9,10 +9,10 @@ import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import customFieldsPrisma from '../../../../lib/services/prisma/custom-fields';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 const adminUsername = config.get('admin.username');
 
@@ -81,7 +81,7 @@ describe('[institutions - custom-props] Read', () => {
     let adminToken;
 
     beforeEach(async () => {
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     it('#01 Should be able view all custom props', async () => {
@@ -121,7 +121,7 @@ describe('[institutions - custom-props] Read', () => {
         },
       });
 
-      memberToken = await (new UsersService()).generateToken(userTest.username);
+      memberToken = await signJWT({ username: userTest.username });
     });
 
     it('#02 Should be able to view visible custom props', async () => {

--- a/api/test/features/institutions/custom-props/remove.test.mjs
+++ b/api/test/features/institutions/custom-props/remove.test.mjs
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeEach, afterAll,
+  describe, it, expect, beforeEach,
 } from 'vitest';
 import config from 'config';
 
@@ -9,10 +9,10 @@ import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import customFieldsPrisma from '../../../../lib/services/prisma/custom-fields';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 const adminUsername = config.get('admin.username');
 
@@ -61,7 +61,7 @@ describe('[institutions - custom-props] Remove', () => {
     let adminToken;
 
     beforeEach(async () => {
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     it('#01 Should be able to remove a custom prop', async () => {
@@ -104,7 +104,7 @@ describe('[institutions - custom-props] Remove', () => {
         },
       });
 
-      memberToken = await (new UsersService()).generateToken(userTest.username);
+      memberToken = await signJWT({ username: userTest.username });
     });
 
     it('#02 Should not be able to remove a custom prop', async () => {

--- a/api/test/features/institutions/custom-props/update.test.mjs
+++ b/api/test/features/institutions/custom-props/update.test.mjs
@@ -1,5 +1,5 @@
 import {
-  describe, it, expect, beforeEach, afterAll,
+  describe, it, expect, beforeEach,
 } from 'vitest';
 import config from 'config';
 
@@ -9,10 +9,10 @@ import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import customFieldsPrisma from '../../../../lib/services/prisma/custom-fields';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 const adminUsername = config.get('admin.username');
 
@@ -78,7 +78,7 @@ describe('[institutions - custom-props] Update', () => {
     let adminToken;
 
     beforeEach(async () => {
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     it('#01 Should be able to update a readonly custom prop', async () => {
@@ -160,7 +160,7 @@ describe('[institutions - custom-props] Update', () => {
         },
       });
 
-      privilegedMemberToken = await (new UsersService()).generateToken(userTest.username);
+      privilegedMemberToken = await signJWT({ username: userTest.username });
     });
 
     it('#03 Should not be able to update readonly custom prop', async () => {

--- a/api/test/features/institutions/delete.test.mjs
+++ b/api/test/features/institutions/delete.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions]: Test delete features', () => {
   const userTest = {
@@ -33,7 +32,7 @@ describe('[institutions]: Test delete features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     let institutionId;
@@ -68,7 +67,7 @@ describe('[institutions]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
       const institution = await institutionsPrisma.create({ data: institutionTest });
       institutionId = institution.id;
     });

--- a/api/test/features/institutions/memberships/create.test.mjs
+++ b/api/test/features/institutions/memberships/create.test.mjs
@@ -13,9 +13,9 @@ import UsersService from '../../../../lib/entities/users.service';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions - memberships]: Test create memberships features', () => {
   const allPermission = ['memberships:write', 'memberships:read'];
@@ -54,7 +54,7 @@ describe('[institutions - memberships]: Test create memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -147,8 +147,7 @@ describe('[institutions - memberships]: Test create memberships features', () =>
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await (new UsersService())
-        .generateToken(userManagerTest.username, userManagerPassword);
+      userManagerToken = await signJWT({ username: userManagerTest.username });
     });
     describe(`With permission [${allPermission}]`, () => {
       beforeEach(async () => {

--- a/api/test/features/institutions/memberships/delete.test.mjs
+++ b/api/test/features/institutions/memberships/delete.test.mjs
@@ -7,6 +7,7 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import membershipsPrisma from '../../../../lib/services/prisma/memberships';
@@ -15,7 +16,6 @@ import usersElastic from '../../../../lib/services/elastic/users';
 import UsersService from '../../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions - memberships]: Test delete memberships features', () => {
   const allPermission = ['memberships:write', 'memberships:read'];
@@ -58,7 +58,7 @@ describe('[institutions - memberships]: Test delete memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -131,8 +131,7 @@ describe('[institutions - memberships]: Test delete memberships features', () =>
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await (new UsersService())
-        .generateToken(userManagerTest.username, userManagerPassword);
+      userManagerToken = await signJWT({ username: userManagerTest.username });
     });
     describe(`With permission [${allPermission}]`, () => {
       beforeEach(async () => {

--- a/api/test/features/institutions/memberships/read.test.mjs
+++ b/api/test/features/institutions/memberships/read.test.mjs
@@ -7,6 +7,7 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import membershipsPrisma from '../../../../lib/services/prisma/memberships';
@@ -15,7 +16,6 @@ import usersElastic from '../../../../lib/services/elastic/users';
 import UsersService from '../../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions - memberships]: Test read memberships features', () => {
   const allPermission = ['memberships:write', 'memberships:read'];
@@ -58,7 +58,7 @@ describe('[institutions - memberships]: Test read memberships features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -138,8 +138,7 @@ describe('[institutions - memberships]: Test read memberships features', () => {
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await (new UsersService())
-        .generateToken(userManagerTest.username, userManagerPassword);
+      userManagerToken = await signJWT({ username: userManagerTest.username });
     });
     describe(`As user with permission [${allPermission}]`, () => {
       beforeEach(async () => {

--- a/api/test/features/institutions/memberships/update.test.mjs
+++ b/api/test/features/institutions/memberships/update.test.mjs
@@ -7,6 +7,7 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import membershipsPrisma from '../../../../lib/services/prisma/memberships';
@@ -15,7 +16,6 @@ import usersElastic from '../../../../lib/services/elastic/users';
 import UsersService from '../../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions - memberships]: Test update memberships features', () => {
   let adminToken;
@@ -58,7 +58,7 @@ describe('[institutions - memberships]: Test update memberships features', () =>
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
 
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
@@ -157,8 +157,7 @@ describe('[institutions - memberships]: Test update memberships features', () =>
       await usersPrisma.create({ data: userManagerTest });
       await usersElastic.createUser(userManagerTest);
 
-      userManagerToken = await (new UsersService())
-        .generateToken(userManagerTest.username, userManagerPassword);
+      userManagerToken = await signJWT({ username: userManagerTest.username });
     });
     describe(`With permission [${allPermission}]`, () => {
       beforeEach(async () => {

--- a/api/test/features/institutions/permissions/create.test.mjs
+++ b/api/test/features/institutions/permissions/create.test.mjs
@@ -7,24 +7,19 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import repositoriesPrisma from '../../../../lib/services/prisma/repositories';
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import membershipsPrisma from '../../../../lib/services/prisma/memberships';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 import repositoryPermissionsPrisma from '../../../../lib/services/prisma/repository-permissions';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[repository permission]: Test create features', () => {
-  const allPermission = ['memberships:write', 'memberships:read'];
-  const readPermission = ['memberships:read'];
-  const emptyPermission = [];
-
   const userTest = {
     username: 'user.test',
     email: 'user.test@test.fr',
@@ -40,19 +35,9 @@ describe('[repository permission]: Test create features', () => {
     name: 'Test',
   };
 
-  const ezpaarseRepositoryConfig = {
-    pattern: 'ezpaarse-*',
-    type: 'ezPAARSE',
-  };
-
   const ezcounterRepositoryConfig = {
     pattern: 'publisher-*',
     type: 'COUNTER 5',
-  };
-
-  const randomRepositoryConfig = {
-    pattern: 'random-*',
-    type: 'random',
   };
 
   const permissionTest = {
@@ -65,7 +50,7 @@ describe('[repository permission]: Test create features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/permissions/delete.test.mjs
+++ b/api/test/features/institutions/permissions/delete.test.mjs
@@ -7,24 +7,19 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import repositoriesPrisma from '../../../../lib/services/prisma/repositories';
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import membershipsPrisma from '../../../../lib/services/prisma/memberships';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 import repositoryPermissionsPrisma from '../../../../lib/services/prisma/repository-permissions';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[repository permission]: Test delete features', () => {
-  const allPermission = ['memberships:write', 'memberships:read'];
-  const readPermission = ['memberships:read'];
-  const emptyPermission = [];
-
   const userTest = {
     username: 'user.test',
     email: 'user.test@test.fr',
@@ -40,19 +35,9 @@ describe('[repository permission]: Test delete features', () => {
     name: 'Test',
   };
 
-  const ezpaarseRepositoryConfig = {
-    pattern: 'ezpaarse-*',
-    type: 'ezPAARSE',
-  };
-
   const ezcounterRepositoryConfig = {
     pattern: 'publisher-*',
     type: 'COUNTER 5',
-  };
-
-  const randomRepositoryConfig = {
-    pattern: 'random-*',
-    type: 'random',
   };
 
   const permissionTest = {
@@ -65,7 +50,7 @@ describe('[repository permission]: Test delete features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/permissions/update.test.mjs
+++ b/api/test/features/institutions/permissions/update.test.mjs
@@ -7,23 +7,18 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import repositoriesPrisma from '../../../../lib/services/prisma/repositories';
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import membershipsPrisma from '../../../../lib/services/prisma/memberships';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 import repositoryPermissionsPrisma from '../../../../lib/services/prisma/repository-permissions';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[repository permission]: Test update features', () => {
-  const allPermission = ['memberships:write', 'memberships:read'];
-  const readPermission = ['memberships:read'];
-  const emptyPermission = [];
-
   const userTest = {
     username: 'user.test',
     email: 'user.test@test.fr',
@@ -39,19 +34,9 @@ describe('[repository permission]: Test update features', () => {
     name: 'Test',
   };
 
-  const ezpaarseRepositoryConfig = {
-    pattern: 'ezpaarse-*',
-    type: 'ezPAARSE',
-  };
-
   const ezcounterRepositoryConfig = {
     pattern: 'publisher-*',
     type: 'COUNTER 5',
-  };
-
-  const randomRepositoryConfig = {
-    pattern: 'random-*',
-    type: 'random',
   };
 
   const permissionTest = {
@@ -69,7 +54,7 @@ describe('[repository permission]: Test update features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/institutions/read.test.mjs
+++ b/api/test/features/institutions/read.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions]: Test read features', () => {
   const userTest = {
@@ -33,7 +32,7 @@ describe('[institutions]: Test read features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
 
   describe('As admin', () => {
@@ -124,7 +123,7 @@ describe('[institutions]: Test read features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
 
       const institution = await institutionsPrisma.create({ data: institutionTest });
       institutionId = institution.id;

--- a/api/test/features/institutions/subinstitutions/create.test.mjs
+++ b/api/test/features/institutions/subinstitutions/create.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions - subinstitution]: Test create features', () => {
   const masterInstitutionTest = {
@@ -33,8 +32,6 @@ describe('[institutions - subinstitution]: Test create features', () => {
     isAdmin: false,
   };
 
-  const userPassword = 'changeme';
-
   const anotherUserTest = {
     username: 'another.user',
     email: 'another.user@test.fr',
@@ -50,11 +47,11 @@ describe('[institutions - subinstitution]: Test create features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
+    userToken = await signJWT({ username: userTest.username });
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/subinstitutions/delete.test.mjs
+++ b/api/test/features/institutions/subinstitutions/delete.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions - subinstitution]: Test delete features', () => {
   const masterInstitutionTest = {
@@ -48,11 +47,11 @@ describe('[institutions - subinstitution]: Test delete features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+    userToken = await signJWT({ username: userTest.username });
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/subinstitutions/read.test.mjs
+++ b/api/test/features/institutions/subinstitutions/read.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../../setup/ezmesure';
 
 import { resetDatabase } from '../../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../../lib/services/elastic/utils';
+import { signJWT } from '../../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../../lib/services/prisma/users';
 import usersElastic from '../../../../lib/services/elastic/users';
-import UsersService from '../../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions - subinstitution]: Test read features', () => {
   const masterInstitutionTest = {
@@ -33,8 +32,6 @@ describe('[institutions - subinstitution]: Test read features', () => {
     isAdmin: false,
   };
 
-  const userPassword = 'changeme';
-
   const anotherUserTest = {
     username: 'another.user',
     email: 'another.user@test.fr',
@@ -50,11 +47,11 @@ describe('[institutions - subinstitution]: Test read features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
 
     await usersPrisma.create({ data: userTest });
     await usersElastic.createUser(userTest);
-    userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
+    userToken = await signJWT({ username: userTest.username });
 
     await usersPrisma.create({ data: anotherUserTest });
     await usersElastic.createUser(anotherUserTest);

--- a/api/test/features/institutions/update.test.mjs
+++ b/api/test/features/institutions/update.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions]: Test update features', () => {
   const userTest = {
@@ -37,7 +36,7 @@ describe('[institutions]: Test update features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
 
   describe('As admin', () => {
@@ -111,7 +110,7 @@ describe('[institutions]: Test update features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     describe('Institution created by user', () => {
       beforeAll(async () => {

--- a/api/test/features/institutions/validate.test.mjs
+++ b/api/test/features/institutions/validate.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[institutions]: Test validate institution features', () => {
   const userTest = {
@@ -33,7 +32,7 @@ describe('[institutions]: Test validate institution features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
 
   describe('As admin', () => {
@@ -92,7 +91,7 @@ describe('[institutions]: Test validate institution features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     let institutionId;
     describe('Institution created by user', () => {

--- a/api/test/features/logs/logs.test.mjs
+++ b/api/test/features/logs/logs.test.mjs
@@ -9,16 +9,15 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import indicesPrisma from '../../../lib/services/elastic/indices';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const logDir = path.resolve(__dirname, '..', '..', 'sources', 'log');
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[logs]: Test insert features', () => {
   const userTest = {
@@ -34,7 +33,7 @@ describe('[logs]: Test insert features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
       await indicesPrisma.create(indexName, null, { ignore: [404] });
     });
     describe(`Add [wiley.csv] in [${indexName}] index`, () => {
@@ -73,7 +72,7 @@ describe('[logs]: Test insert features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     // TODO create roles
     describe(`Add [wiley.csv] in [${indexName}] index who has roles`, () => {

--- a/api/test/features/repositories/create.test.mjs
+++ b/api/test/features/repositories/create.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import repositoriesPrisma from '../../../lib/services/prisma/repositories';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[repositories]: Test create features', () => {
   const userTest = {
@@ -44,7 +43,7 @@ describe('[repositories]: Test create features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe(`Create new repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
@@ -157,7 +156,7 @@ describe('[repositories]: Test create features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe(`Create new repository of type [${ezcounterRepositoryConfig.type}]`, () => {

--- a/api/test/features/repositories/delete.test.mjs
+++ b/api/test/features/repositories/delete.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import repositoriesPrisma from '../../../lib/services/prisma/repositories';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[repositories]: Test delete features', () => {
   const userTest = {
@@ -22,10 +21,6 @@ describe('[repositories]: Test delete features', () => {
     email: 'user.test@test.fr',
     fullName: 'User test',
     isAdmin: false,
-  };
-
-  const institutionTest = {
-    name: 'Test',
   };
 
   const ezpaarseRepositoryConfig = {
@@ -39,7 +34,7 @@ describe('[repositories]: Test delete features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     describe(`Delete repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
@@ -75,7 +70,7 @@ describe('[repositories]: Test delete features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe(`Delete repository of type [${ezpaarseRepositoryConfig.type}]`, () => {

--- a/api/test/features/repositories/read.test.mjs
+++ b/api/test/features/repositories/read.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import repositoriesPrisma from '../../../lib/services/prisma/repositories';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[repositories]: Test read features', () => {
   const userTest = {
@@ -34,16 +33,12 @@ describe('[repositories]: Test read features', () => {
     type: 'COUNTER 5',
   };
 
-  const randomRepositoryConfig = {
-    pattern: 'random-*',
-    type: 'random',
-  };
   describe('As admin', () => {
     let adminToken;
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
     });
     describe(`Get repository of type [${ezcounterRepositoryConfig.type}]`, () => {
       let pattern;
@@ -83,7 +78,7 @@ describe('[repositories]: Test read features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     describe(`Get repository of type [${ezpaarseRepositoryConfig.type}]`, () => {
       let pattern;

--- a/api/test/features/repositories/update.test.mjs
+++ b/api/test/features/repositories/update.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import repositoriesPrisma from '../../../lib/services/prisma/repositories';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[repositories]: Test update features', () => {
   const userTest = {
@@ -29,16 +28,6 @@ describe('[repositories]: Test update features', () => {
     type: 'ezPAARSE',
   };
 
-  const ezcounterRepositoryConfig = {
-    pattern: 'publisher-*',
-    type: 'COUNTER 5',
-  };
-
-  const randomRepositoryConfig = {
-    pattern: 'random-*',
-    type: 'random',
-  };
-
   const updateRepositoryConfig = {
     pattern: 'update-pattern',
     type: 'update-type',
@@ -49,7 +38,7 @@ describe('[repositories]: Test update features', () => {
     beforeAll(async () => {
       await resetDatabase();
       await resetElastic();
-      adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+      adminToken = await signJWT({ username: adminUsername });
     });
     describe(`Update repository of type [${ezpaarseRepositoryConfig.type}] with [${updateRepositoryConfig.type}]`, () => {
       let pattern;
@@ -98,7 +87,7 @@ describe('[repositories]: Test update features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe(`Update repository of type [${ezpaarseRepositoryConfig.type}] with [${updateRepositoryConfig.type}]`, () => {

--- a/api/test/features/roles/assign.test.mjs
+++ b/api/test/features/roles/assign.test.mjs
@@ -10,9 +10,9 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
-import UsersService from '../../../lib/entities/users.service';
 import rolesPrisma from '../../../lib/services/prisma/roles';
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import membershipsRolesPrisma from '../../../lib/services/prisma/membership-roles';
@@ -90,7 +90,7 @@ describe('[roles] Assign features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: adminUser });
-      adminToken = await (new UsersService()).generateToken(adminUser.username);
+      adminToken = await signJWT({ username: adminUser.username });
     });
 
     it('#01 Should be able to assign a restricted role', async () => {
@@ -154,7 +154,7 @@ describe('[roles] Assign features', () => {
     let userToken;
 
     beforeAll(async () => {
-      userToken = await (new UsersService()).generateToken(privilegedMember.username);
+      userToken = await signJWT({ username: privilegedMember.username });
     });
 
     it('#03 Should be able to assign an unrestricted role', async () => {
@@ -206,7 +206,7 @@ describe('[roles] Assign features', () => {
     let userToken;
 
     beforeAll(async () => {
-      userToken = await (new UsersService()).generateToken(regularMember.username);
+      userToken = await signJWT({ username: regularMember.username });
     });
 
     it('#04 Should not be able to assign a restricted role', async () => {

--- a/api/test/features/roles/create.test.mjs
+++ b/api/test/features/roles/create.test.mjs
@@ -10,9 +10,9 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
-import UsersService from '../../../lib/entities/users.service';
 import rolesPrisma from '../../../lib/services/prisma/roles';
 
 const isoDatePattern = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/;
@@ -56,7 +56,7 @@ describe('[roles] Create features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: adminUser });
-      adminToken = await (new UsersService()).generateToken(adminUser.username);
+      adminToken = await signJWT({ username: adminUser.username });
     });
 
     it('#01 Should be able to create a role', async () => {
@@ -91,7 +91,7 @@ describe('[roles] Create features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: testUser });
-      userToken = await (new UsersService()).generateToken(testUser.username);
+      userToken = await signJWT({ username: testUser.username });
     });
 
     it('#02 Should not be able to create a role', async () => {

--- a/api/test/features/roles/delete.test.mjs
+++ b/api/test/features/roles/delete.test.mjs
@@ -12,9 +12,9 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
-import UsersService from '../../../lib/entities/users.service';
 import rolesPrisma from '../../../lib/services/prisma/roles';
 
 const adminUsername = config.get('admin.username');
@@ -59,7 +59,7 @@ describe('[roles] Delete features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: adminUser });
-      adminToken = await (new UsersService()).generateToken(adminUsername);
+      adminToken = await signJWT({ username: adminUsername });
     });
 
     it('#01 Should be able to delete a role', async () => {
@@ -84,7 +84,7 @@ describe('[roles] Delete features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: testUser });
-      userToken = await (new UsersService()).generateToken(testUser.username);
+      userToken = await signJWT({ username: testUser.username });
     });
 
     it('#02 Should not be able to delete a role', async () => {

--- a/api/test/features/roles/read.test.mjs
+++ b/api/test/features/roles/read.test.mjs
@@ -10,9 +10,9 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
-import UsersService from '../../../lib/entities/users.service';
 import rolesPrisma from '../../../lib/services/prisma/roles';
 
 describe('[roles] Read features', () => {
@@ -66,7 +66,7 @@ describe('[roles] Read features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: adminUser });
-      adminToken = await (new UsersService()).generateToken(adminUser.username);
+      adminToken = await signJWT({ username: adminUser.username });
     });
 
     it('#01 Should be able to list roles', async () => {
@@ -104,7 +104,7 @@ describe('[roles] Read features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: testUser });
-      userToken = await (new UsersService()).generateToken(testUser.username);
+      userToken = await signJWT({ username: testUser.username });
     });
 
     it('#03 Should be able to list roles', async () => {

--- a/api/test/features/roles/unassign.test.mjs
+++ b/api/test/features/roles/unassign.test.mjs
@@ -10,9 +10,9 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
-import UsersService from '../../../lib/entities/users.service';
 import rolesPrisma from '../../../lib/services/prisma/roles';
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import membershipsRolesPrisma from '../../../lib/services/prisma/membership-roles';
@@ -106,7 +106,7 @@ describe('[roles] Assign features', () => {
 
     beforeAll(async () => {
       await usersPrisma.create({ data: adminUser });
-      adminToken = await (new UsersService()).generateToken(adminUser.username);
+      adminToken = await signJWT({ username: adminUser.username });
     });
 
     it('#01 Should be able to unassign a restricted role', async () => {
@@ -154,7 +154,7 @@ describe('[roles] Assign features', () => {
     let userToken;
 
     beforeAll(async () => {
-      userToken = await (new UsersService()).generateToken(privilegedMember.username);
+      userToken = await signJWT({ username: privilegedMember.username });
     });
 
     it('#03 Should be able to unassign an unrestricted role', async () => {
@@ -198,7 +198,7 @@ describe('[roles] Assign features', () => {
     let userToken;
 
     beforeAll(async () => {
-      userToken = await (new UsersService()).generateToken(regularMember.username);
+      userToken = await signJWT({ username: regularMember.username });
     });
 
     it('#05 Should not be able to unassign a restricted role', async () => {

--- a/api/test/features/spaces/create.test.mjs
+++ b/api/test/features/spaces/create.test.mjs
@@ -1,19 +1,20 @@
-import { describe, it, expect, beforeAll, afterAll, afterAll } from 'vitest';
+import {
+  describe, it, expect, beforeAll, afterAll,
+} from 'vitest';
 import config from 'config';
 
 import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import spacesPrisma from '../../../lib/services/prisma/spaces';
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[space]: Test create spaces features', () => {
   const userTest = {
@@ -43,7 +44,7 @@ describe('[space]: Test create spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
     spaceConfig.institutionId = institutionId;
@@ -51,7 +52,6 @@ describe('[space]: Test create spaces features', () => {
 
   describe('As admin', () => {
     describe(`Create new space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {
-      let spaceId;
       it('#01 Should create space', async () => {
         const httpAppResponse = await ezmesure.raw('/kibana-spaces/', {
           method: 'POST',
@@ -92,7 +92,7 @@ describe('[space]: Test create spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     describe(`Create new space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {
       it('#02 Should not create space', async () => {

--- a/api/test/features/spaces/delete.test.mjs
+++ b/api/test/features/spaces/delete.test.mjs
@@ -1,19 +1,20 @@
-import { describe, it, expect, beforeAll, afterAll, afterAll } from 'vitest';
+import {
+  describe, it, expect, beforeAll, afterAll,
+} from 'vitest';
 import config from 'config';
 
 import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import spacesPrisma from '../../../lib/services/prisma/spaces';
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[space]: Test delete spaces features', () => {
   const userTest = {
@@ -42,7 +43,7 @@ describe('[space]: Test delete spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
   });
@@ -79,7 +80,7 @@ describe('[space]: Test delete spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe(`Delete space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {

--- a/api/test/features/spaces/read.test.mjs
+++ b/api/test/features/spaces/read.test.mjs
@@ -1,19 +1,20 @@
-import { describe, it, expect, beforeAll, afterAll, afterAll } from 'vitest';
+import {
+  describe, it, expect, beforeAll, afterAll,
+} from 'vitest';
 import config from 'config';
 
 import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import spacesPrisma from '../../../lib/services/prisma/spaces';
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[space]: Test read spaces features', () => {
   const userTest = {
@@ -42,7 +43,7 @@ describe('[space]: Test read spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
     spaceConfig.institutionId = institutionId;
@@ -89,7 +90,7 @@ describe('[space]: Test read spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe(`Get space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {

--- a/api/test/features/spaces/sync.test.mjs
+++ b/api/test/features/spaces/sync.test.mjs
@@ -9,6 +9,7 @@ import fs from 'node:fs';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+
 import {
   deleteSpace,
   getSpace,

--- a/api/test/features/spaces/update.test.mjs
+++ b/api/test/features/spaces/update.test.mjs
@@ -1,19 +1,20 @@
-import { describe, it, expect, beforeAll, afterAll, afterAll } from 'vitest';
+import {
+  describe, it, expect, beforeAll, afterAll,
+} from 'vitest';
 import config from 'config';
 
 import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import spacesPrisma from '../../../lib/services/prisma/spaces';
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[space]: Test update spaces features', () => {
   const userTest = {
@@ -47,7 +48,7 @@ describe('[space]: Test update spaces features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const institution = await institutionsPrisma.create({ data: institutionTest });
     institutionId = institution.id;
   });
@@ -112,7 +113,7 @@ describe('[space]: Test update spaces features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
     describe(`Update space [${spaceConfig.type}] for institution [${institutionTest.name}]`, () => {
       let spaceId;

--- a/api/test/features/sushi-endpoints/create.test.mjs
+++ b/api/test/features/sushi-endpoints/create.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi-endpoint]: Test create sushi-endpoints features', () => {
   const userTest = {
@@ -45,7 +44,7 @@ describe('[sushi-endpoint]: Test create sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     describe('Create new sushi-endpoint', () => {
@@ -111,7 +110,7 @@ describe('[sushi-endpoint]: Test create sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Create new sushi-endpoint', () => {

--- a/api/test/features/sushi-endpoints/delete.test.mjs
+++ b/api/test/features/sushi-endpoints/delete.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi-endpoint]: Test update sushi-endpoints features', () => {
   const userTest = {
@@ -45,7 +44,7 @@ describe('[sushi-endpoint]: Test update sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     describe('Delete sushi-endpoint', () => {
@@ -83,7 +82,7 @@ describe('[sushi-endpoint]: Test update sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Delete sushi-endpoint', () => {

--- a/api/test/features/sushi-endpoints/read.test.mjs
+++ b/api/test/features/sushi-endpoints/read.test.mjs
@@ -7,13 +7,12 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi-endpoint]: Test read sushi-endpoints features', () => {
   const userTest = {
@@ -46,7 +45,7 @@ describe('[sushi-endpoint]: Test read sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     beforeEach(async () => {
@@ -107,7 +106,7 @@ describe('[sushi-endpoint]: Test read sushi-endpoints features', () => {
       await usersPrisma.create({ data: userTest });
       await usersPrisma.acceptTerms(userTest.username);
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     beforeEach(async () => {

--- a/api/test/features/sushi-endpoints/update.test.mjs
+++ b/api/test/features/sushi-endpoints/update.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi-endpoint]: Test delete sushi-endpoints features', () => {
   const userTest = {
@@ -62,7 +61,7 @@ describe('[sushi-endpoint]: Test delete sushi-endpoints features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     describe('Update sushi-endpoint', () => {
@@ -133,7 +132,7 @@ describe('[sushi-endpoint]: Test delete sushi-endpoints features', () => {
     beforeAll(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Update sushi-endpoint', () => {

--- a/api/test/features/sushi/create.test.mjs
+++ b/api/test/features/sushi/create.test.mjs
@@ -7,17 +7,16 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 import sushiCredentialsPrisma from '../../../lib/services/prisma/sushi-credentials';
 import membershipsPrisma from '../../../lib/services/prisma/memberships';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi]: Test create sushi credential features', () => {
   const allPermission = ['sushi:write', 'sushi:read'];
@@ -41,8 +40,6 @@ describe('[sushi]: Test create sushi credential features', () => {
     fullName: 'User test',
     isAdmin: false,
   };
-
-  const userPassword = 'changeme';
 
   const membershipUserTest = {
     username: userTest.username,
@@ -90,7 +87,7 @@ describe('[sushi]: Test create sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -245,7 +242,7 @@ describe('[sushi]: Test create sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/delete.test.mjs
+++ b/api/test/features/sushi/delete.test.mjs
@@ -7,17 +7,16 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 import sushiCredentialsPrisma from '../../../lib/services/prisma/sushi-credentials';
 import membershipsPrisma from '../../../lib/services/prisma/memberships';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi]: Test delete sushi credential features', () => {
   const allPermission = ['sushi:write', 'sushi:read'];
@@ -39,8 +38,6 @@ describe('[sushi]: Test delete sushi credential features', () => {
     fullName: 'User test',
     isAdmin: false,
   };
-
-  const userPassword = 'changeme';
 
   const membershipUserTest = {
     username: userTest.username,
@@ -88,7 +85,7 @@ describe('[sushi]: Test delete sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -189,7 +186,7 @@ describe('[sushi]: Test delete sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/read.test.mjs
+++ b/api/test/features/sushi/read.test.mjs
@@ -7,17 +7,16 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 import sushiCredentialsPrisma from '../../../lib/services/prisma/sushi-credentials';
 import membershipsPrisma from '../../../lib/services/prisma/memberships';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi]: Test read sushi credential features', () => {
   const allPermission = ['sushi:write', 'sushi:read'];
@@ -39,8 +38,6 @@ describe('[sushi]: Test read sushi credential features', () => {
     isAdmin: false,
   };
 
-  const userPassword = 'changeme';
-
   const membershipUserTest = {
     username: userTest.username,
   };
@@ -51,8 +48,6 @@ describe('[sushi]: Test read sushi credential features', () => {
     fullName: 'Another user',
     isAdmin: false,
   };
-
-  const anotherUserTestPermissions = allPermission;
 
   const sushiEndpointTest = {
     sushiUrl: 'http://localhost',
@@ -89,7 +84,7 @@ describe('[sushi]: Test read sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -209,7 +204,7 @@ describe('[sushi]: Test read sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/sushi/update.test.mjs
+++ b/api/test/features/sushi/update.test.mjs
@@ -7,17 +7,16 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import institutionsPrisma from '../../../lib/services/prisma/institutions';
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 import sushiEndpointsPrisma from '../../../lib/services/prisma/sushi-endpoints';
 import sushiCredentialsPrisma from '../../../lib/services/prisma/sushi-credentials';
 import membershipsPrisma from '../../../lib/services/prisma/memberships';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[sushi]: Test update sushi credential features', () => {
   const allPermission = ['sushi:write', 'sushi:read'];
@@ -42,8 +41,6 @@ describe('[sushi]: Test update sushi credential features', () => {
     isAdmin: false,
   };
 
-  const userPassword = 'changeme';
-
   const membershipUserTest = {
     username: userTest.username,
   };
@@ -54,8 +51,6 @@ describe('[sushi]: Test update sushi credential features', () => {
     fullName: 'Another user',
     isAdmin: false,
   };
-
-  const anotherUserTestPermissions = allPermission;
 
   const sushiEndpointTest = {
     sushiUrl: 'http://localhost',
@@ -103,7 +98,7 @@ describe('[sushi]: Test update sushi credential features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
     const sushiEndpoint = await sushiEndpointsPrisma.create({ data: sushiEndpointTest });
     sushiEndpointId = sushiEndpoint.id;
   });
@@ -263,7 +258,7 @@ describe('[sushi]: Test update sushi credential features', () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
       await usersPrisma.acceptTerms(userTest.username);
-      userToken = await (new UsersService()).generateToken(userTest.username, userPassword);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Institution created by admin', () => {

--- a/api/test/features/users/activate.test.mjs
+++ b/api/test/features/users/activate.test.mjs
@@ -52,13 +52,17 @@ describe('[users]: Test activate users features', () => {
         // Test user service
         const userFromService = await usersPrisma.findByUsername('user.test');
 
-        expect(userFromService).toHaveProperty('username', userTest.username);
-        expect(userFromService).toHaveProperty('fullName', userTest.fullName);
-        expect(userFromService).toHaveProperty('email', userTest.email);
-        expect(userFromService).toHaveProperty('isAdmin', false);
-        expect(userFromService?.createdAt).not.toBeNull();
-        expect(userFromService?.updatedAt).not.toBeNull();
-        expect(userFromService?.metadata).toBe(true);
+        expect(userFromService).toMatchObject({
+          id: expect.any(String),
+          username: userTest.username,
+          fullName: userTest.fullName,
+          email: userTest.email,
+          isAdmin: false,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          lastActivity: expect.any(Date),
+          metadata: {},
+        });
       });
 
       afterAll(async () => {

--- a/api/test/features/users/activate.test.mjs
+++ b/api/test/features/users/activate.test.mjs
@@ -1,15 +1,15 @@
 import {
-  describe, it, expect, beforeAll, afterAll,
+  describe, it, expect, beforeAll,
 } from 'vitest';
 
 import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 describe('[users]: Test activate users features', () => {
   const userTest = {
@@ -34,7 +34,7 @@ describe('[users]: Test activate users features', () => {
       beforeAll(async () => {
         await usersPrisma.create({ data: userTest });
         await usersElastic.createUser(userTest);
-        userToken = await UsersService.generateTokenForActivate(userTest.username);
+        userToken = await signJWT({ username: userTest.username });
       });
 
       it(`#01 Should activate user [${userTest.username}]`, async () => {

--- a/api/test/features/users/create.test.mjs
+++ b/api/test/features/users/create.test.mjs
@@ -7,12 +7,11 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[users]: Test create users features', () => {
   const userTest = {
@@ -31,7 +30,7 @@ describe('[users]: Test create users features', () => {
       let adminToken;
 
       beforeAll(async () => {
-        adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+        adminToken = await signJWT({ username: adminUsername });
       });
 
       it(`#01 Should create new user [${userTest.username}]`, async () => {

--- a/api/test/features/users/delete.test.mjs
+++ b/api/test/features/users/delete.test.mjs
@@ -7,13 +7,12 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
-import UsersService from '../../../lib/entities/users.service';
 import usersElastic from '../../../lib/services/elastic/users';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[users]: Test delete users features', () => {
   const userTest = {
@@ -28,7 +27,7 @@ describe('[users]: Test delete users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     describe(`Delete user [${userTest.username}]`, () => {

--- a/api/test/features/users/impersonate.test.mjs
+++ b/api/test/features/users/impersonate.test.mjs
@@ -7,10 +7,10 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
 const authCookie = config.get('auth.cookie');
@@ -49,9 +49,8 @@ describe('[users]: Test impersonation features', () => {
     await usersPrisma.create({ data: regularUser });
     await usersElastic.createUser(regularUser);
 
-    const usersService = new UsersService();
-    adminToken = await (usersService).generateToken(adminUsername);
-    regularUserToken = await (usersService).generateToken(regularUser.username);
+    adminToken = await signJWT({ username: adminUsername });
+    regularUserToken = await signJWT({ username: regularUser.username });
   });
 
   describe('An admin', () => {

--- a/api/test/features/users/impersonate.test.mjs
+++ b/api/test/features/users/impersonate.test.mjs
@@ -1,6 +1,7 @@
 import {
   describe, it, expect, beforeAll, afterAll,
 } from 'vitest';
+import { parseSetCookie, stringifyCookie } from 'cookie';
 import config from 'config';
 
 import ezmesure from '../../setup/ezmesure';
@@ -62,20 +63,26 @@ describe('[users]: Test impersonation features', () => {
         },
       });
 
-      const tokenPattern = new RegExp(`^${authCookie}=([a-z0-9._-]+)`, 'i');
-
       expect(httpAppResponse).toHaveProperty('status', 200);
 
-      const cookieHeader = httpAppResponse.headers.get('set-cookie');
+      const cookies = httpAppResponse.headers.getSetCookie().map(parseSetCookie);
+      const jwePattern = /^[a-z0-9_-]+(\.[a-z0-9_-]*){4}$/i;
 
-      expect(cookieHeader).toMatch(tokenPattern);
+      expect(cookies).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: authCookie,
+            value: expect.stringMatching(jwePattern),
+          }),
+        ]),
+      );
 
-      const targetUserToken = tokenPattern.exec(cookieHeader)?.[1];
+      const userTokenCookie = cookies.find((cookie) => cookie.name === authCookie);
 
       const profileResponse = await ezmesure.raw('/auth', {
         method: 'GET',
         headers: {
-          Authorization: `Bearer ${targetUserToken}`,
+          Cookie: stringifyCookie({ [userTokenCookie.name]: userTokenCookie.value }),
         },
       });
 

--- a/api/test/features/users/read.test.mjs
+++ b/api/test/features/users/read.test.mjs
@@ -7,14 +7,13 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminFullName = config.get('admin.fullName');
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[users]: Test read users features', () => {
   const userTest = {
@@ -29,7 +28,7 @@ describe('[users]: Test read users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('As admin', () => {
     describe('Get all users', () => {
@@ -106,7 +105,7 @@ describe('[users]: Test read users features', () => {
     beforeEach(async () => {
       await usersPrisma.create({ data: userTest });
       await usersElastic.createUser(userTest);
-      userToken = await (new UsersService()).generateToken(userTest.username, userTest.password);
+      userToken = await signJWT({ username: userTest.username });
     });
 
     describe('Get all users', () => {

--- a/api/test/features/users/update.test.mjs
+++ b/api/test/features/users/update.test.mjs
@@ -7,13 +7,12 @@ import ezmesure from '../../setup/ezmesure';
 
 import { resetDatabase } from '../../../lib/services/prisma/utils';
 import { resetElastic } from '../../../lib/services/elastic/utils';
+import { signJWT } from '../../../lib/utils/jwt';
 
 import usersPrisma from '../../../lib/services/prisma/users';
 import usersElastic from '../../../lib/services/elastic/users';
-import UsersService from '../../../lib/entities/users.service';
 
 const adminUsername = config.get('admin.username');
-const adminPassword = config.get('admin.password');
 
 describe('[users]: Test update users features', () => {
   const userTest = {
@@ -35,7 +34,7 @@ describe('[users]: Test update users features', () => {
   beforeAll(async () => {
     await resetDatabase();
     await resetElastic();
-    adminToken = await (new UsersService()).generateToken(adminUsername, adminPassword);
+    adminToken = await signJWT({ username: adminUsername });
   });
   describe('Update', () => {
     describe('As admin', () => {


### PR DESCRIPTION
# Changes

This PR aims to fix ezMESURE tests, which have broke after the introduction of the new OIDC login flow.

## API

- [x] Replace `generateToken()` by `signJWT()`
- [x] Fix cookie handling in the impersonate test
- [x] Fix user schema validation in the activation test
